### PR TITLE
#5: Fixed EnvironmentCommandlet

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandlet.java
@@ -2,6 +2,7 @@ package com.devonfw.tools.ide.commandlet;
 
 import java.util.Collection;
 
+import com.devonfw.tools.ide.common.SystemPath;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.environment.VariableLine;
 import com.devonfw.tools.ide.os.WindowsPathSyntax;
@@ -49,6 +50,8 @@ public final class EnvironmentCommandlet extends Commandlet {
       }
       this.context.info(line.toString());
     }
+    SystemPath path = this.context.getPath();
+    this.context.info("export PATH={}", path.toString(this.bash.isTrue()));
   }
 
   VariableLine normalizeWindowsValue(VariableLine line) {

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandlet.java
@@ -56,7 +56,7 @@ public final class EnvironmentCommandlet extends Commandlet {
     String value = line.getValue();
     String normalized = normalizeWindowsValue(value);
     if (normalized != value) {
-      line = line.withValue(value);
+      line = line.withValue(normalized);
     }
     return line;
   }
@@ -64,15 +64,15 @@ public final class EnvironmentCommandlet extends Commandlet {
   String normalizeWindowsValue(String value) {
 
     WindowsPathSyntax pathSyntax;
-    WindowsPathSyntax driveSyntax;
     if (this.bash.isTrue()) {
       pathSyntax = WindowsPathSyntax.MSYS;
-      driveSyntax = WindowsPathSyntax.WINDOWS;
     } else {
       pathSyntax = WindowsPathSyntax.WINDOWS;
-      driveSyntax = WindowsPathSyntax.MSYS;
     }
-    String drive = driveSyntax.getDrive(value);
+    String drive = WindowsPathSyntax.WINDOWS.getDrive(value);
+    if (drive == null) {
+      drive = WindowsPathSyntax.MSYS.getDrive(value);
+    }
     if (drive != null) {
       value = pathSyntax.replaceDrive(value, drive);
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/environment/VariableLine.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/VariableLine.java
@@ -217,7 +217,15 @@ public abstract class VariableLine {
 
   }
 
-  static VariableLine of(String line, IdeLogger logger, Object source) {
+  /**
+   * Parses a {@link VariableLine} from {@link String}.
+   *
+   * @param line the {@link VariableLine} as {@link String} to parse.
+   * @param logger the {@link IdeLogger}.
+   * @param source the source where the given {@link String} to parse is from (e.g. the file path).
+   * @return the parsed {@link VariableLine}.
+   */
+  public static VariableLine of(String line, IdeLogger logger, Object source) {
 
     int len = line.length();
     int start = 0;
@@ -271,7 +279,13 @@ public abstract class VariableLine {
     return new Garbage(line);
   }
 
-  static VariableLine of(boolean export, String name, String value) {
+  /**
+   * @param export the {@link #isExport() export flag}.
+   * @param name the {@link #getName() name}.
+   * @param value the {@link #getValue() value}.
+   * @return the {@link VariableLine} for the given values.
+   */
+  public static VariableLine of(boolean export, String name, String value) {
 
     return new Variable(export, name, value);
   }

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandletTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeTestContextMock;
+import com.devonfw.tools.ide.environment.VariableLine;
 
 /**
  * Test of {@link EnvironmentCommandlet}.
@@ -24,6 +25,9 @@ public class EnvironmentCommandletTest extends AbstractIdeContextTest {
         .isEqualTo("C:\\Windows\\system32\\drivers\\etc\\hosts");
     assertThat(env.normalizeWindowsValue("C:\\Windows\\system32\\drivers\\etc\\hosts"))
         .isEqualTo("C:\\Windows\\system32\\drivers\\etc\\hosts");
+    assertThat(env.normalizeWindowsValue("C:\\Users\\login/.ide/scripts/ide"))
+        .isEqualTo("C:\\Users\\login\\.ide\\scripts\\ide");
+    assertThat(env.normalizeWindowsValue("\\login/.ide/scripts/ide")).isEqualTo("\\login/.ide/scripts/ide");
   }
 
   /**
@@ -41,6 +45,23 @@ public class EnvironmentCommandletTest extends AbstractIdeContextTest {
         .isEqualTo("/c/Windows/system32/drivers/etc/hosts");
     assertThat(env.normalizeWindowsValue("/c/Windows/system32/drivers/etc/hosts"))
         .isEqualTo("/c/Windows/system32/drivers/etc/hosts");
+  }
+
+  /**
+   * Test of {@link EnvironmentCommandlet#normalizeWindowsValue(VariableLine)} for Windows.
+   */
+  @Test
+  public void testNormalizeWindowsLine() {
+
+    // arrange
+    VariableLine line = VariableLine.of(true, "MAGIC_PATH", "/c/Windows/system32/drivers/etc/hosts");
+    EnvironmentCommandlet env = new EnvironmentCommandlet(IdeTestContextMock.get());
+    // act
+    VariableLine normalized = env.normalizeWindowsValue(line);
+    // assert
+    assertThat(normalized.getValue()).isEqualTo("C:\\Windows\\system32\\drivers\\etc\\hosts");
+    assertThat(normalized.isExport()).isTrue();
+    assertThat(normalized.getName()).isEqualTo("MAGIC_PATH");
   }
 
 }


### PR DESCRIPTION
For #5:
* fixed EnvironmentCommandlet to properly normalize path values for Windows or Bash/MSys
* fixed EnvironmentCommandlet to also export PATH properly
* extended JUnit to cover the bug cases