### PR TITLE
#87: changed args for msiexec from double to single slash

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
@@ -277,9 +277,11 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
   }
 
   /**
-   * This method is called after the tool has been newly installed or updated to a new version. Override it to add custom post intallation logic.
+   * This method is called after the tool has been newly installed or updated to a new version. Override it to add
+   * custom post intallation logic.
    */
   protected void postInstall() {
+
     // nothing to do by default
   }
 
@@ -457,7 +459,7 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
         // rm "${target_dir}/Applications"
         // fi
       } else if ("msi".equals(extension)) {
-        this.context.newProcess().executable("msiexec").addArgs("//a", file, "//qn", "TARGETDIR=" + targetDir).run();
+        this.context.newProcess().executable("msiexec").addArgs("/a", file, "/qn", "TARGETDIR=" + targetDir).run();
         // msiexec also creates a copy of the MSI
         Path msiCopy = targetDir.resolve(targetDir.getFileName());
         fileAccess.delete(msiCopy);


### PR DESCRIPTION
We have copied the logic to extract MSI files from our bash scripts. There we had to escape slashes due to some `bash` specific behavior. Now in Java the slashes do not need to be escaped and therefore we must only use single slashes to make it work properly.