### PR TITLE
#89: fix deletion of the copied msi file

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
@@ -461,7 +461,7 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
       } else if ("msi".equals(extension)) {
         this.context.newProcess().executable("msiexec").addArgs("/a", file, "/qn", "TARGETDIR=" + targetDir).run();
         // msiexec also creates a copy of the MSI
-        Path msiCopy = targetDir.resolve(targetDir.getFileName());
+        Path msiCopy = targetDir.resolve(file.getFileName());
         fileAccess.delete(msiCopy);
       } else if ("pkg".equals(extension)) {
 


### PR DESCRIPTION
When we extract an MSI file with `msiexec` for whatever reason that creates a copy of the MSI file in the target folder.
We never found a CLI option to prevent `msiexec` from doing this. Therefore we just have to delete that copied MSI file afterwards.
However, the code to delete it was bug and that is now fixed with this PR.