### PR TITLE
#85: Fixed the executing order of the tools

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
@@ -29,6 +29,8 @@ public class SystemPath {
   
   private final IdeContext context;
 
+  private static final List<String> EXTENSION_PRIORITY = List.of(".exe", ".cmd", ".bat", ".msi", ".ps1", "");
+
   /**
    * The constructor.
    *
@@ -89,6 +91,7 @@ public class SystemPath {
             if (Files.isDirectory(bin)) {
               toolPath = bin;
             }
+            this.paths.add(0, toolPath);
             this.tool2pathMap.put(child.getFileName().toString(), toolPath);
           }
         }
@@ -110,6 +113,41 @@ public class SystemPath {
       }
     }
     return null;
+  }
+
+  private Path findBinaryInOrder(Path path, String tool) {
+
+    for (String extension : EXTENSION_PRIORITY) {
+
+      Path fileToExecute = path.resolve(tool + extension);
+
+      if (Files.exists(fileToExecute)) {
+        return fileToExecute;
+      }
+    }
+
+    return null;
+  }
+
+  public Path findBinary(Path toolPath) {
+    Path parent = toolPath.getParent();
+    String fileName = toolPath.getFileName().toString();
+
+    if (parent == null) {
+      for (Path path : this.paths) {
+        Path binaryPath = findBinaryInOrder(path, fileName);
+        if (binaryPath != null) {
+          return binaryPath;
+        }
+      }
+    } else {
+      Path binaryPath = findBinaryInOrder(parent, fileName);
+      if (binaryPath != null) {
+        return binaryPath;
+      }
+    }
+
+    return toolPath;
   }
 
   /**

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
@@ -30,32 +30,32 @@ public interface ProcessContext {
    *        called via CMD shell on windows while a *.sh file will be called via Bash, etc.
    * @return this {@link ProcessContext} for fluent API calls.
    */
-  ProcessContext executable(Path executable, String tool);
+  ProcessContext executable(Path executable);
 
   /**
    * Sets the executable command to be {@link #run()}.
    *
    * @param executable the command to be executed by {@link #run()}.
    * @return this {@link ProcessContext} for fluent API calls.
-   * @see #executable(Path, String)
+   * @see #executable(Path)
    */
   default ProcessContext executable(String executable) {
 
-    return executable(Paths.get(executable), "");
+    return executable(Paths.get(executable));
   }
 
   /**
-   * Adds a single argument for {@link #executable(Path, String) command}.
+   * Adds a single argument for {@link #executable(Path) command}.
    *
-   * @param arg the next argument for {@link #executable(Path, String) command} to be added.
+   * @param arg the next argument for {@link #executable(Path) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   ProcessContext addArg(String arg);
 
   /**
-   * Adds a single argument for {@link #executable(Path, String) command}.
+   * Adds a single argument for {@link #executable(Path) command}.
    *
-   * @param arg the next argument for {@link #executable(Path, String) command} to be added.
+   * @param arg the next argument for {@link #executable(Path) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   default ProcessContext addArg(Object arg) {
@@ -65,12 +65,12 @@ public interface ProcessContext {
   }
 
   /**
-   * Adds the given arguments for {@link #executable(Path, String) command}. E.g. for {@link #executable(Path, String) command} "mvn"
+   * Adds the given arguments for {@link #executable(Path) command}. E.g. for {@link #executable(Path) command} "mvn"
    * the arguments "clean" and "install" may be added here to run "mvn clean install". If this method would be called
    * again with "-Pmyprofile" and "-X" before {@link #run()} gets called then "mvn clean install -Pmyprofile -X" would
    * be run.
    *
-   * @param args the arguments for {@link #executable(Path, String) command} to be added.
+   * @param args the arguments for {@link #executable(Path) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   default ProcessContext addArgs(String... args) {
@@ -82,10 +82,10 @@ public interface ProcessContext {
   }
 
   /**
-   * Adds the given arguments for {@link #executable(Path, String) command} as arbitrary Java objects. It will add the
+   * Adds the given arguments for {@link #executable(Path) command} as arbitrary Java objects. It will add the
    * {@link Object#toString() string representation} of these arguments to the command.
    *
-   * @param args the arguments for {@link #executable(Path, String) command} to be added.
+   * @param args the arguments for {@link #executable(Path) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   default ProcessContext addArgs(Object... args) {
@@ -97,10 +97,10 @@ public interface ProcessContext {
   }
 
   /**
-   * Adds the given arguments for {@link #executable(Path, String) command} as arbitrary Java objects. It will add the
+   * Adds the given arguments for {@link #executable(Path) command} as arbitrary Java objects. It will add the
    * {@link Object#toString() string representation} of these arguments to the command.
    *
-   * @param args the {@link List} of arguments for {@link #executable(Path, String) command} to be added.
+   * @param args the {@link List} of arguments for {@link #executable(Path) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   default ProcessContext addArgs(List<?>... args) {
@@ -112,8 +112,8 @@ public interface ProcessContext {
   }
 
   /**
-   * Runs the previously configured {@link #executable(Path, String) command} with the configured {@link #addArgs(String...)
-   * arguments}. Will reset the {@link #addArgs(String...) arguments} but not the {@link #executable(Path, String) command} for
+   * Runs the previously configured {@link #executable(Path) command} with the configured {@link #addArgs(String...)
+   * arguments}. Will reset the {@link #addArgs(String...) arguments} but not the {@link #executable(Path) command} for
    * sub-sequent calls.
    *
    * @return the exit code. Will be {@link ProcessResult#SUCCESS} on successful completion of the {@link Process}.
@@ -124,8 +124,8 @@ public interface ProcessContext {
   }
 
   /**
-   * Runs the previously configured {@link #executable(Path, String) command} with the configured {@link #addArgs(String...)
-   * arguments}. Will reset the {@link #addArgs(String...) arguments} but not the {@link #executable(Path, String) command} for
+   * Runs the previously configured {@link #executable(Path) command} with the configured {@link #addArgs(String...)
+   * arguments}. Will reset the {@link #addArgs(String...) arguments} but not the {@link #executable(Path) command} for
    * sub-sequent calls.
    *
    * @param capture - {@code true} to capture standard {@link ProcessResult#getOut() out} and

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
@@ -30,32 +30,32 @@ public interface ProcessContext {
    *        called via CMD shell on windows while a *.sh file will be called via Bash, etc.
    * @return this {@link ProcessContext} for fluent API calls.
    */
-  ProcessContext executable(Path executable);
+  ProcessContext executable(Path executable, String tool);
 
   /**
    * Sets the executable command to be {@link #run()}.
    *
    * @param executable the command to be executed by {@link #run()}.
    * @return this {@link ProcessContext} for fluent API calls.
-   * @see #executable(Path)
+   * @see #executable(Path, String)
    */
   default ProcessContext executable(String executable) {
 
-    return executable(Paths.get(executable));
+    return executable(Paths.get(executable), "");
   }
 
   /**
-   * Adds a single argument for {@link #executable(Path) command}.
+   * Adds a single argument for {@link #executable(Path, String) command}.
    *
-   * @param arg the next argument for {@link #executable(Path) command} to be added.
+   * @param arg the next argument for {@link #executable(Path, String) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   ProcessContext addArg(String arg);
 
   /**
-   * Adds a single argument for {@link #executable(Path) command}.
+   * Adds a single argument for {@link #executable(Path, String) command}.
    *
-   * @param arg the next argument for {@link #executable(Path) command} to be added.
+   * @param arg the next argument for {@link #executable(Path, String) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   default ProcessContext addArg(Object arg) {
@@ -65,12 +65,12 @@ public interface ProcessContext {
   }
 
   /**
-   * Adds the given arguments for {@link #executable(Path) command}. E.g. for {@link #executable(Path) command} "mvn"
+   * Adds the given arguments for {@link #executable(Path, String) command}. E.g. for {@link #executable(Path, String) command} "mvn"
    * the arguments "clean" and "install" may be added here to run "mvn clean install". If this method would be called
    * again with "-Pmyprofile" and "-X" before {@link #run()} gets called then "mvn clean install -Pmyprofile -X" would
    * be run.
    *
-   * @param args the arguments for {@link #executable(Path) command} to be added.
+   * @param args the arguments for {@link #executable(Path, String) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   default ProcessContext addArgs(String... args) {
@@ -82,10 +82,10 @@ public interface ProcessContext {
   }
 
   /**
-   * Adds the given arguments for {@link #executable(Path) command} as arbitrary Java objects. It will add the
+   * Adds the given arguments for {@link #executable(Path, String) command} as arbitrary Java objects. It will add the
    * {@link Object#toString() string representation} of these arguments to the command.
    *
-   * @param args the arguments for {@link #executable(Path) command} to be added.
+   * @param args the arguments for {@link #executable(Path, String) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   default ProcessContext addArgs(Object... args) {
@@ -97,10 +97,10 @@ public interface ProcessContext {
   }
 
   /**
-   * Adds the given arguments for {@link #executable(Path) command} as arbitrary Java objects. It will add the
+   * Adds the given arguments for {@link #executable(Path, String) command} as arbitrary Java objects. It will add the
    * {@link Object#toString() string representation} of these arguments to the command.
    *
-   * @param args the {@link List} of arguments for {@link #executable(Path) command} to be added.
+   * @param args the {@link List} of arguments for {@link #executable(Path, String) command} to be added.
    * @return this {@link ProcessContext} for fluent API calls.
    */
   default ProcessContext addArgs(List<?>... args) {
@@ -112,8 +112,8 @@ public interface ProcessContext {
   }
 
   /**
-   * Runs the previously configured {@link #executable(Path) command} with the configured {@link #addArgs(String...)
-   * arguments}. Will reset the {@link #addArgs(String...) arguments} but not the {@link #executable(Path) command} for
+   * Runs the previously configured {@link #executable(Path, String) command} with the configured {@link #addArgs(String...)
+   * arguments}. Will reset the {@link #addArgs(String...) arguments} but not the {@link #executable(Path, String) command} for
    * sub-sequent calls.
    *
    * @return the exit code. Will be {@link ProcessResult#SUCCESS} on successful completion of the {@link Process}.
@@ -124,8 +124,8 @@ public interface ProcessContext {
   }
 
   /**
-   * Runs the previously configured {@link #executable(Path) command} with the configured {@link #addArgs(String...)
-   * arguments}. Will reset the {@link #addArgs(String...) arguments} but not the {@link #executable(Path) command} for
+   * Runs the previously configured {@link #executable(Path, String) command} with the configured {@link #addArgs(String...)
+   * arguments}. Will reset the {@link #addArgs(String...) arguments} but not the {@link #executable(Path, String) command} for
    * sub-sequent calls.
    *
    * @param capture - {@code true} to capture standard {@link ProcessResult#getOut() out} and

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
@@ -4,7 +4,6 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
-import java.io.File;
 import java.lang.ProcessBuilder.Redirect;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,8 +33,6 @@ public final class ProcessContextImpl implements ProcessContext {
   private Path executable;
 
   private ProcessErrorHandling errorHandling;
-
-  private final List<String> EXTENSION_PRIORITY = List.of(".exe", ".cmd", ".bat", ".msi", ".ps1", "");
 
   /**
    * The constructor.
@@ -75,30 +72,13 @@ public final class ProcessContextImpl implements ProcessContext {
   }
 
   @Override
-  public ProcessContext executable(Path toolPath) {
+  public ProcessContext executable(Path command) {
 
     if (!this.arguments.isEmpty()) {
       throw new IllegalStateException("Arguments already present - did you forget to call run for previous call?");
     }
 
-    Path executable = toolPath;
-
-    if (executable.isAbsolute()) {
-      for (String extension : EXTENSION_PRIORITY) {
-
-        Path fileToExecute = Paths.get(toolPath + extension);
-
-        if (Files.exists(fileToExecute)) {
-          executable = fileToExecute;
-          break;
-        }
-      }
-    }
-    if (!executable.isAbsolute()) {
-      this.context.debug("Using " + executable.getFileName() + "for " + executable);
-    }
-
-    this.executable = executable;
+    this.executable = this.context.getPath().findBinary(command);
     return this;
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
@@ -35,6 +35,8 @@ public final class ProcessContextImpl implements ProcessContext {
 
   private ProcessErrorHandling errorHandling;
 
+  private final List<String> EXTENSION_PRIORITY = List.of(".exe", ".cmd", ".bat", ".msi", ".ps1", "");
+
   /**
    * The constructor.
    *
@@ -73,28 +75,27 @@ public final class ProcessContextImpl implements ProcessContext {
   }
 
   @Override
-  public ProcessContext executable(Path toolPath, String tool) {
+  public ProcessContext executable(Path toolPath) {
 
     if (!this.arguments.isEmpty()) {
       throw new IllegalStateException("Arguments already present - did you forget to call run for previous call?");
     }
 
-    String[] possibleExtensions = { ".exe", ".cmd", ".bat", ".msi", ".ps1", "" };
-
     Path executable = toolPath;
+
     if (executable.isAbsolute()) {
-      for (String extension : possibleExtensions) {
+      for (String extension : EXTENSION_PRIORITY) {
 
-        File fileToExecute = new File(toolPath + "\\" + tool + extension);
+        Path fileToExecute = Paths.get(toolPath + extension);
 
-        if (fileToExecute.exists()) {
-          executable = fileToExecute.toPath();
+        if (Files.exists(fileToExecute)) {
+          executable = fileToExecute;
           break;
         }
       }
     }
     if (!executable.isAbsolute()) {
-      this.context.debug("Using " + executable.getFileName() + "for " + tool);
+      this.context.debug("Using " + executable.getFileName() + "for " + executable);
     }
 
     this.executable = executable;

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
@@ -3,6 +3,7 @@ package com.devonfw.tools.ide.tool;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Set;
@@ -90,7 +91,7 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
   public void runTool(VersionIdentifier toolVersion, String... args) {
 
     Path binaryPath;
-    Path toolPath = getToolBinPath().resolve(getBinaryName());
+    Path toolPath = Paths.get(getBinaryName());
     if (toolVersion == null) {
       install(true);
       binaryPath = toolPath;

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
@@ -88,41 +88,16 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
   public void runTool(VersionIdentifier toolVersion, String... args) {
 
     Path binary;
+
     if (toolVersion == null) {
       install(true);
-      binary = getToolBinary();
+          binary = getToolBinPath();
     } else {
       throw new UnsupportedOperationException("Not yet implemented!");
     }
-    ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.WARNING).executable(binary)
-        .addArgs(args);
+    ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.WARNING)
+        .executable(binary, getBinaryName()).addArgs(args);
     pc.run();
-  }
-
-  /**
-   * @return the {@link Path} where the main executable file of this tool is installed.
-   */
-  public Path getToolBinary() {
-
-    Path binPath = getToolBinPath();
-    Path binary = this.context.getFileAccess().findFirst(binPath, this::isBinary, false);
-    if (binary == null) {
-      throw new IllegalStateException("Could not find executable binary for " + getName() + " in " + binPath);
-    }
-    return binary;
-  }
-
-  protected boolean isBinary(Path path) {
-
-    String filename = path.getFileName().toString();
-    String binaryName = getBinaryName();
-    if (filename.equals(binaryName)) {
-      return true;
-    } else if (filename.startsWith(binaryName)) {
-      String suffix = filename.substring(binaryName.length());
-      return this.context.getSystemInfo().getOs().isExecutable(suffix);
-    }
-    return false;
   }
 
   protected String getBinaryName() {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
@@ -89,16 +89,16 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
    */
   public void runTool(VersionIdentifier toolVersion, String... args) {
 
-    Path binary;
-
+    Path binaryPath;
+    Path toolPath = getToolBinPath().resolve(getBinaryName());
     if (toolVersion == null) {
       install(true);
-          binary = getToolBinPath();
+      binaryPath = toolPath;
     } else {
       throw new UnsupportedOperationException("Not yet implemented!");
     }
-    ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.WARNING)
-        .executable(binary, getBinaryName()).addArgs(args);
+    ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.WARNING).executable(binaryPath)
+        .addArgs(args);
     pc.run();
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
@@ -52,12 +52,12 @@ public class Eclipse extends IdeToolCommandlet {
    */
   protected ProcessResult runEclipse(boolean log, String... args) {
 
-    Path toolPath = getToolBinPath();
+    Path toolPath = getToolBinPath().resolve(getBinaryName());
     ProcessContext pc = this.context.newProcess();
     if (log) {
       pc.errorHandling(ProcessErrorHandling.ERROR);
     }
-    pc.executable(toolPath, getBinaryName());
+    pc.executable(toolPath);
     Path configurationPath = getPluginsInstallationPath().resolve("configuration");
     this.context.getFileAccess().mkdirs(configurationPath);
     if (log) {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
@@ -1,6 +1,7 @@
 package com.devonfw.tools.ide.tool.eclipse;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 
@@ -52,7 +53,7 @@ public class Eclipse extends IdeToolCommandlet {
    */
   protected ProcessResult runEclipse(boolean log, String... args) {
 
-    Path toolPath = getToolBinPath().resolve(getBinaryName());
+    Path toolPath = Paths.get(getBinaryName());
     ProcessContext pc = this.context.newProcess();
     if (log) {
       pc.errorHandling(ProcessErrorHandling.ERROR);

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
@@ -52,12 +52,12 @@ public class Eclipse extends IdeToolCommandlet {
    */
   protected ProcessResult runEclipse(boolean log, String... args) {
 
-    Path binary = getToolBinary();
+    Path toolPath = getToolBinPath();
     ProcessContext pc = this.context.newProcess();
     if (log) {
       pc.errorHandling(ProcessErrorHandling.ERROR);
     }
-    pc.executable(binary);
+    pc.executable(toolPath, getBinaryName());
     Path configurationPath = getPluginsInstallationPath().resolve("configuration");
     this.context.getFileAccess().mkdirs(configurationPath);
     if (log) {
@@ -69,7 +69,7 @@ public class Eclipse extends IdeToolCommandlet {
     }
     pc.addArg("-configuration").addArg(configurationPath);
     // TODO ability to use different Java version
-    Path javaPath = getCommandlet(Java.class).getToolBinary();
+    Path javaPath = getCommandlet(Java.class).getToolBinPath();
     pc.addArg("-vm").addArg(javaPath);
     pc.addArgs(args);
     return pc.run(log);


### PR DESCRIPTION
Addresses: #85 

I have found a solution to the issue #85. The order of the executing files is now in the same order as requested by the issue. But in order to do so, I had to change the interface of the executable() method, I had to add the String tool so that the tool name is passed to this method as an argument, in order to work with the name and the extension of the tool. Since I changed the interface, I had to make small changes to the Eclipse.java class as well, and as far as I tested it works correctly. 

If this solution is not clean, I have another option in mind, but that would require that we keep the getToolBinary() method and make changes to it. I am keeping this PR as a draft until it is decided that it is a correct solution.