### PR TITLE
Update AssertJ to 3.24.2

### DIFF
--- a/cli/src/test/java/com/devonfw/tools/ide/tool/UrlUpdaterTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/UrlUpdaterTest.java
@@ -145,7 +145,7 @@ public class UrlUpdaterTest extends AbstractUrlUpdaterTest {
     Integer errorCode = urlStatus.getError().getCode();
 
     assertThat(errorCode).isEqualTo(404);
-    assertThat(errorTimestamp).isGreaterThan(successTimestamp);
+    assertThat(errorTimestamp).isAfter(successTimestamp);
 
     stubFor(
         any(urlMatching("/os/.*")).willReturn(aResponse().withStatus(200).withHeader("Content-Type", "text/plain")));
@@ -165,7 +165,7 @@ public class UrlUpdaterTest extends AbstractUrlUpdaterTest {
     errorCode = urlStatus.getError().getCode();
 
     assertThat(errorCode).isEqualTo(200);
-    assertThat(errorTimestamp).isGreaterThan(successTimestamp);
+    assertThat(errorTimestamp).isAfter(successTimestamp);
 
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.6.0</version>
+      <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
We had AssertJ version `2.6.0` that was entirely outdated and caused errors with Java17:
```
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private ... accessible: module java.base does not "opens java.util" to unnamed module @7fbe847c
```
This is fixed with the update so we can use `SoftAssertions` and other modern features of AssertJ.
As AssertJ renamed some assertion methods for `java.time.*`, I had to fix a test and rename the method calls.