### PR TITLE
reduce cast hacks

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/environment/AbstractEnvironmentVariables.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/AbstractEnvironmentVariables.java
@@ -7,7 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.devonfw.tools.ide.log.IdeLogger;
+import com.devonfw.tools.ide.context.IdeContext;
 
 /**
  * Abstract base implementation of {@link EnvironmentVariables}.
@@ -17,8 +17,8 @@ public abstract class AbstractEnvironmentVariables implements EnvironmentVariabl
   /** @see #getParent() */
   protected final AbstractEnvironmentVariables parent;
 
-  /** The {@link IdeLogger} instance. */
-  protected final IdeLogger logger;
+  /** The {@link IdeContext} instance. */
+  protected final IdeContext context;
 
   private String source;
 
@@ -26,19 +26,19 @@ public abstract class AbstractEnvironmentVariables implements EnvironmentVariabl
    * The constructor.
    *
    * @param parent the parent {@link EnvironmentVariables} to inherit from.
-   * @param logger the {@link IdeLogger}.
+   * @param context the {@link IdeContext}.
    */
-  public AbstractEnvironmentVariables(AbstractEnvironmentVariables parent, IdeLogger logger) {
+  public AbstractEnvironmentVariables(AbstractEnvironmentVariables parent, IdeContext context) {
 
     super();
     this.parent = parent;
-    if (logger == null) {
+    if (context == null) {
       if (parent == null) {
         throw new IllegalArgumentException("parent and logger must not both be null!");
       }
-      this.logger = parent.logger;
+      this.context = parent.context;
     } else {
-      this.logger = logger;
+      this.context = context;
     }
   }
 
@@ -126,7 +126,7 @@ public abstract class AbstractEnvironmentVariables implements EnvironmentVariabl
    */
   public AbstractEnvironmentVariables extend(Path propertiesFilePath, EnvironmentVariablesType type) {
 
-    return new EnvironmentVariablesPropertiesFile(this, type, propertiesFilePath, this.logger);
+    return new EnvironmentVariablesPropertiesFile(this, type, propertiesFilePath, this.context);
   }
 
   /**

--- a/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariables.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariables.java
@@ -5,7 +5,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Locale;
 
-import com.devonfw.tools.ide.log.IdeLogger;
+import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
@@ -181,12 +181,12 @@ public interface EnvironmentVariables {
   Collection<VariableLine> collectExportedVariables();
 
   /**
-   * @param logger the {@link IdeLogger}.
+   * @param context the {@link IdeContext}.
    * @return the system {@link EnvironmentVariables} building the root of the {@link EnvironmentVariables} hierarchy.
    */
-  static AbstractEnvironmentVariables ofSystem(IdeLogger logger) {
+  static AbstractEnvironmentVariables ofSystem(IdeContext context) {
 
-    return EnvironmentVariablesSystem.of(logger);
+    return EnvironmentVariablesSystem.of(context);
   }
 
   /**

--- a/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesMap.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesMap.java
@@ -2,7 +2,7 @@ package com.devonfw.tools.ide.environment;
 
 import java.util.Map;
 
-import com.devonfw.tools.ide.log.IdeLogger;
+import com.devonfw.tools.ide.context.IdeContext;
 
 /**
  * Implementation of {@link EnvironmentVariables}.
@@ -13,11 +13,11 @@ abstract class EnvironmentVariablesMap extends AbstractEnvironmentVariables {
    * The constructor.
    *
    * @param parent the parent {@link EnvironmentVariables} to inherit from.
-   * @param logger the {@link IdeLogger}.
+   * @param context the {@link IdeContext}.
    */
-  EnvironmentVariablesMap(AbstractEnvironmentVariables parent, IdeLogger logger) {
+  EnvironmentVariablesMap(AbstractEnvironmentVariables parent, IdeContext context) {
 
-    super(parent, logger);
+    super(parent, context);
   }
 
   /**
@@ -31,9 +31,9 @@ abstract class EnvironmentVariablesMap extends AbstractEnvironmentVariables {
 
     String value = getVariables().get(name);
     if (value == null) {
-      this.logger.trace("{}: Variable {} is undefined.", getSource(), name);
+      this.context.trace("{}: Variable {} is undefined.", getSource(), name);
     } else {
-      this.logger.trace("{}: Variable {}={}", getSource(), name, value);
+      this.context.trace("{}: Variable {}={}", getSource(), name, value);
     }
     return value;
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesPropertiesFile.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesPropertiesFile.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import com.devonfw.tools.ide.log.IdeLogger;
+import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.variable.IdeVariables;
 import com.devonfw.tools.ide.variable.VariableDefinition;
 
@@ -41,13 +41,13 @@ final class EnvironmentVariablesPropertiesFile extends EnvironmentVariablesMap {
    * @param parent the parent {@link EnvironmentVariables} to inherit from.
    * @param type the {@link #getType() type}.
    * @param source the {@link #getSource() source}.
-   * @param logger the {@link IdeLogger}.
+   * @param context the {@link IdeContext}.
    * @param variables the underlying variables.
    */
   EnvironmentVariablesPropertiesFile(AbstractEnvironmentVariables parent, EnvironmentVariablesType type,
-      Path propertiesFilePath, IdeLogger logger) {
+      Path propertiesFilePath, IdeContext context) {
 
-    super(parent, logger);
+    super(parent, context);
     Objects.requireNonNull(type);
     assert (type != EnvironmentVariablesType.RESOLVED);
     this.type = type;
@@ -64,16 +64,16 @@ final class EnvironmentVariablesPropertiesFile extends EnvironmentVariablesMap {
       return;
     }
     if (!Files.exists(this.propertiesFilePath)) {
-      this.logger.trace("Properties not found at {}", this.propertiesFilePath);
+      this.context.trace("Properties not found at {}", this.propertiesFilePath);
       return;
     }
-    this.logger.trace("Loading properties from {}", this.propertiesFilePath);
+    this.context.trace("Loading properties from {}", this.propertiesFilePath);
     try (BufferedReader reader = Files.newBufferedReader(this.propertiesFilePath)) {
       String line;
       do {
         line = reader.readLine();
         if (line != null) {
-          VariableLine variableLine = VariableLine.of(line, this.logger, this.propertiesFilePath);
+          VariableLine variableLine = VariableLine.of(line, this.context, this.propertiesFilePath);
           String name = variableLine.getName();
           if (name != null) {
             variableLine = migrateLine(variableLine, false);
@@ -95,14 +95,14 @@ final class EnvironmentVariablesPropertiesFile extends EnvironmentVariablesMap {
   public void save() {
 
     if (this.modifiedVariables.isEmpty()) {
-      this.logger.trace("No changes to save in properties file {}", this.propertiesFilePath);
+      this.context.trace("No changes to save in properties file {}", this.propertiesFilePath);
       return;
     }
     Path newPropertiesFilePath = this.propertiesFilePath;
     String propertiesFileName = this.propertiesFilePath.getFileName().toString();
     if (LEGACY_PROPERTIES.equals(propertiesFileName)) {
       newPropertiesFilePath = this.propertiesFilePath.getParent().resolve(DEFAULT_PROPERTIES);
-      this.logger.info("Converting legacy properties to {}", newPropertiesFilePath);
+      this.context.info("Converting legacy properties to {}", newPropertiesFilePath);
     }
     List<VariableLine> lines = new ArrayList<>();
     try (BufferedReader reader = Files.newBufferedReader(this.propertiesFilePath)) {
@@ -110,7 +110,7 @@ final class EnvironmentVariablesPropertiesFile extends EnvironmentVariablesMap {
       do {
         line = reader.readLine();
         if (line != null) {
-          VariableLine variableLine = VariableLine.of(line, this.logger, reader);
+          VariableLine variableLine = VariableLine.of(line, this.context, reader);
           lines.add(variableLine);
         }
       } while (line != null);
@@ -123,10 +123,10 @@ final class EnvironmentVariablesPropertiesFile extends EnvironmentVariablesMap {
       for (VariableLine line : lines) {
         VariableLine newLine = migrateLine(line, true);
         if (newLine == null) {
-          this.logger.debug("Removed variable line '{}' from {}", line, newPropertiesFilePath);
+          this.context.debug("Removed variable line '{}' from {}", line, newPropertiesFilePath);
         } else {
           if (newLine != line) {
-            this.logger.debug("Changed variable line from '{}' to '{}' in {}", line, newLine, newPropertiesFilePath);
+            this.context.debug("Changed variable line from '{}' to '{}' in {}", line, newLine, newPropertiesFilePath);
           }
           writer.append(newLine.toString());
           writer.append(NEWLINE);
@@ -140,7 +140,7 @@ final class EnvironmentVariablesPropertiesFile extends EnvironmentVariablesMap {
       for (String name : this.modifiedVariables) {
         String value = this.variables.get(name);
         if (value == null) {
-          this.logger.trace("Internal error: removed variable {} was not found in {}", name, this.propertiesFilePath);
+          this.context.trace("Internal error: removed variable {} was not found in {}", name, this.propertiesFilePath);
         } else {
           boolean export = this.exportedVariables.contains(name);
           VariableLine line = VariableLine.of(export, name, value);
@@ -222,9 +222,9 @@ final class EnvironmentVariablesPropertiesFile extends EnvironmentVariablesMap {
     String oldValue = this.variables.put(name, value);
     boolean flagChanged = export != this.exportedVariables.contains(name);
     if (Objects.equals(value, oldValue) && !flagChanged) {
-      this.logger.trace("Set valiable '{}={}' caused no change in {}", name, value, this.propertiesFilePath);
+      this.context.trace("Set valiable '{}={}' caused no change in {}", name, value, this.propertiesFilePath);
     } else {
-      this.logger.debug("Set valiable '{}={}' in {}", name, value, this.propertiesFilePath);
+      this.context.debug("Set valiable '{}={}' in {}", name, value, this.propertiesFilePath);
       this.modifiedVariables.add(name);
       if (export && (value != null)) {
         this.exportedVariables.add(name);

--- a/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesResolved.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesResolved.java
@@ -3,7 +3,6 @@ package com.devonfw.tools.ide.environment;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.variable.IdeVariables;
 import com.devonfw.tools.ide.variable.VariableDefinition;
 
@@ -24,7 +23,7 @@ public class EnvironmentVariablesResolved extends AbstractEnvironmentVariables {
    */
   EnvironmentVariablesResolved(AbstractEnvironmentVariables parent) {
 
-    super(parent, parent.logger);
+    super(parent, parent.context);
   }
 
   @Override
@@ -51,12 +50,10 @@ public class EnvironmentVariablesResolved extends AbstractEnvironmentVariables {
 
   private String getValue(String name) {
 
-    // this is an intended hack but only allowed here...
-    IdeContext context = (IdeContext) this.logger;
     VariableDefinition<?> var = IdeVariables.get(name);
     String value;
     if ((var != null) && var.isForceDefaultValue()) {
-      value = var.getDefaultValueAsString(context);
+      value = var.getDefaultValueAsString(this.context);
     } else {
       value = this.parent.get(name);
     }
@@ -66,11 +63,11 @@ public class EnvironmentVariablesResolved extends AbstractEnvironmentVariables {
         value = this.parent.get(key);
       }
       if (value != null) {
-        value = var.getDefaultValueAsString(context);
+        value = var.getDefaultValueAsString(this.context);
       }
     }
     if ((value != null) && (value.startsWith("~/"))) {
-      value = context.getUserHome() + value.substring(1);
+      value = this.context.getUserHome() + value.substring(1);
     }
     return value;
   }
@@ -94,7 +91,7 @@ public class EnvironmentVariablesResolved extends AbstractEnvironmentVariables {
       String variableName = matcher.group(2);
       String variableValue = getValue(variableName);
       if (variableValue == null) {
-        this.logger.warning("Undefined variable {} in '{}={}' for root '{}={}'", variableName, name, value, rootName,
+        this.context.warning("Undefined variable {} in '{}={}' for root '{}={}'", variableName, name, value, rootName,
             rootValue);
       } else {
         String replacement = resolve(variableValue, variableName, recursion, rootName, rootValue);

--- a/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesSystem.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesSystem.java
@@ -2,7 +2,7 @@ package com.devonfw.tools.ide.environment;
 
 import java.util.Map;
 
-import com.devonfw.tools.ide.log.IdeLogger;
+import com.devonfw.tools.ide.context.IdeContext;
 
 /**
  * Implementation of {@link EnvironmentVariables} using {@link System#getenv()}.
@@ -11,9 +11,9 @@ import com.devonfw.tools.ide.log.IdeLogger;
  */
 public final class EnvironmentVariablesSystem extends EnvironmentVariablesMap {
 
-  private EnvironmentVariablesSystem(IdeLogger logger) {
+  private EnvironmentVariablesSystem(IdeContext context) {
 
-    super(null, logger);
+    super(null, context);
   }
 
   @Override
@@ -29,12 +29,12 @@ public final class EnvironmentVariablesSystem extends EnvironmentVariablesMap {
   }
 
   /**
-   * @param logger the {@link IdeLogger}.
+   * @param context the {@link IdeContext}.
    * @return the {@link EnvironmentVariablesSystem} instance.
    */
-  static EnvironmentVariablesSystem of(IdeLogger logger) {
+  static EnvironmentVariablesSystem of(IdeContext context) {
 
-    return new EnvironmentVariablesSystem(logger);
+    return new EnvironmentVariablesSystem(context);
   }
 
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/environment/VariableLine.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/VariableLine.java
@@ -221,7 +221,7 @@ public abstract class VariableLine {
    * Parses a {@link VariableLine} from {@link String}.
    *
    * @param line the {@link VariableLine} as {@link String} to parse.
-   * @param logger the {@link IdeLogger}.
+   * @param context the {@link IdeLogger}.
    * @param source the source where the given {@link String} to parse is from (e.g. the file path).
    * @return the parsed {@link VariableLine}.
    */

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/HelpCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/HelpCommandletTest.java
@@ -1,10 +1,12 @@
 package com.devonfw.tools.ide.commandlet;
 
+import org.junit.jupiter.api.Test;
+
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.context.IdeTestContext;
 import com.devonfw.tools.ide.context.IdeTestContextMock;
 import com.devonfw.tools.ide.log.IdeLogLevel;
-import org.junit.jupiter.api.Test;
 
 /**
  * Integration test of {@link HelpCommandlet}.
@@ -32,7 +34,7 @@ public class HelpCommandletTest extends AbstractIdeContextTest {
   public void testRun() {
 
     // arrange
-    IdeContext context = IdeTestContextMock.get();
+    IdeTestContext context = IdeTestContext.of();
     HelpCommandlet help = new HelpCommandlet(context);
     // act
     help.run();
@@ -50,7 +52,7 @@ public class HelpCommandletTest extends AbstractIdeContextTest {
 
     // arrange
     String path = "workspaces/foo-test/my-git-repo";
-    IdeContext context = newContext("basic", path, true);
+    IdeTestContext context = newContext("basic", path, true);
     HelpCommandlet help = context.getCommandletManager().getCommandlet(HelpCommandlet.class);
     help.commandlet.setValueAsString("mvn");
     // act
@@ -65,7 +67,7 @@ public class HelpCommandletTest extends AbstractIdeContextTest {
   /**
    * Assertion for the options that should be displayed.
    */
-  public void assertOptionLogMessages(IdeContext context) {
+  private void assertOptionLogMessages(IdeTestContext context) {
 
     assertLogMessage(context, IdeLogLevel.INFO, "--locale        the locale (e.g. 'de' for German language)");
     assertLogMessage(context, IdeLogLevel.INFO, "-b | --batch    enable batch mode (non-interactive)");
@@ -82,7 +84,7 @@ public class HelpCommandletTest extends AbstractIdeContextTest {
   /**
    * Assertion for the IDE-Logo that should be displayed.
    */
-  public void assertLogoMessage(IdeContext context) {
+  private void assertLogoMessage(IdeTestContext context) {
 
     assertLogMessage(context, IdeLogLevel.INFO, HelpCommandlet.LOGO);
   }

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/VersionGetCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/VersionGetCommandletTest.java
@@ -1,51 +1,53 @@
 package com.devonfw.tools.ide.commandlet;
 
+import org.junit.jupiter.api.Test;
+
 import com.devonfw.tools.ide.cli.CliException;
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.context.IdeTestContext;
 import com.devonfw.tools.ide.log.IdeLogLevel;
-import org.junit.jupiter.api.Test;
-
 
 /**
-   * Integration test of {@link VersionGetCommandlet}.
+ * Integration test of {@link VersionGetCommandlet}.
+ */
+public class VersionGetCommandletTest extends AbstractIdeContextTest {
+
+  /**
+   * Test of {@link VersionGetCommandlet} run, when Installed Version is null.
    */
-public class VersionGetCommandletTest extends AbstractIdeContextTest{
+  @Test
+  public void testVersionGetCommandletRunThrowsCliExeption() {
 
-    /**
-     * Test of {@link VersionGetCommandlet} run, when Installed Version is null.
-     */
-    @Test
-    public void testVersionGetCommandletRunThrowsCliExeption(){
-      // arrange
-      String path = "workspaces/foo-test/my-git-repo";
-      IdeContext context = newContext("basic", path, false);
-      VersionGetCommandlet versionGet = context.getCommandletManager().getCommandlet(VersionGetCommandlet.class);
-      versionGet.tool.setValueAsString("java");
-      // act
-      try {
-        versionGet.run();
-        failBecauseExceptionWasNotThrown(CliException.class);
-      } catch (CliException e) {
-        //assert
-        assertThat(e).hasMessageContaining("Tool java is not installed!");
-      }
-    }
-
-    /**
-     * Test of {@link VersionGetCommandlet} run.
-     */
-    @Test
-    public void testVersionGetCommandletRun(){
-      //arrange
-      String path = "workspaces/foo-test/my-git-repo";
-      IdeContext context = newContext("basic", path, false);
-      VersionGetCommandlet versionGet = context.getCommandletManager().getCommandlet(VersionGetCommandlet.class);
-      //act
-      versionGet.tool.setValueAsString("mvn");
+    // arrange
+    String path = "workspaces/foo-test/my-git-repo";
+    IdeContext context = newContext("basic", path, false);
+    VersionGetCommandlet versionGet = context.getCommandletManager().getCommandlet(VersionGetCommandlet.class);
+    versionGet.tool.setValueAsString("java");
+    // act
+    try {
       versionGet.run();
-      //assert
-      assertLogMessage(context, IdeLogLevel.INFO, "3.9.4");
+      failBecauseExceptionWasNotThrown(CliException.class);
+    } catch (CliException e) {
+      // assert
+      assertThat(e).hasMessageContaining("Tool java is not installed!");
     }
   }
 
+  /**
+   * Test of {@link VersionGetCommandlet} run.
+   */
+  @Test
+  public void testVersionGetCommandletRun() {
+
+    // arrange
+    String path = "workspaces/foo-test/my-git-repo";
+    IdeTestContext context = newContext("basic", path, false);
+    VersionGetCommandlet versionGet = context.getCommandletManager().getCommandlet(VersionGetCommandlet.class);
+    // act
+    versionGet.tool.setValueAsString("mvn");
+    versionGet.run();
+    // assert
+    assertLogMessage(context, IdeLogLevel.INFO, "3.9.4");
+  }
+}

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/VersionListCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/VersionListCommandletTest.java
@@ -1,11 +1,10 @@
 package com.devonfw.tools.ide.commandlet;
 
-import com.devonfw.tools.ide.context.AbstractIdeContextTest;
-import com.devonfw.tools.ide.context.IdeContext;
-import com.devonfw.tools.ide.context.IdeTestContextMock;
-import com.devonfw.tools.ide.log.IdeLogLevel;
 import org.junit.jupiter.api.Test;
 
+import com.devonfw.tools.ide.context.AbstractIdeContextTest;
+import com.devonfw.tools.ide.context.IdeTestContext;
+import com.devonfw.tools.ide.log.IdeLogLevel;
 
 /**
  * Integration test of {@link VersionListCommandlet}.
@@ -17,14 +16,15 @@ public class VersionListCommandletTest extends AbstractIdeContextTest {
    */
   @Test
   public void testVersionListCommandletRun() {
-    //arrange
+
+    // arrange
     String path = "workspaces/foo-test/my-git-repo";
-    IdeContext context = newContext("basic", path, false);
+    IdeTestContext context = newContext("basic", path, false);
     VersionListCommandlet versionList = context.getCommandletManager().getCommandlet(VersionListCommandlet.class);
     versionList.tool.setValueAsString("mvn");
-    //act
+    // act
     versionList.run();
-    //assert
+    // assert
     assertLogMessage(context, IdeLogLevel.INFO, "3.0.5");
     assertLogMessage(context, IdeLogLevel.INFO, "3.1.0");
     assertLogMessage(context, IdeLogLevel.INFO, "3.2.1");

--- a/cli/src/test/java/com/devonfw/tools/ide/context/AbstractIdeContextTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/AbstractIdeContextTest.java
@@ -35,9 +35,9 @@ public abstract class AbstractIdeContextTest extends Assertions {
 
   /**
    * @param projectName the (folder)name of the test project in {@link #PATH_PROJECTS}. E.g. "basic".
-   * @return the {@link IdeContext} pointing to that project.
+   * @return the {@link IdeTestContext} pointing to that project.
    */
-  protected IdeContext newContext(String projectName) {
+  protected IdeTestContext newContext(String projectName) {
 
     return newContext(projectName, null, true);
   }
@@ -45,9 +45,9 @@ public abstract class AbstractIdeContextTest extends Assertions {
   /**
    * @param projectName the (folder)name of the test project in {@link #PATH_PROJECTS}. E.g. "basic".
    * @param projectPath the relative path inside the test project where to create the context.
-   * @return the {@link IdeContext} pointing to that project.
+   * @return the {@link IdeTestContext} pointing to that project.
    */
-  protected static IdeContext newContext(String projectName, String projectPath) {
+  protected static IdeTestContext newContext(String projectName, String projectPath) {
 
     return newContext(projectName, projectPath, true);
   }
@@ -58,9 +58,9 @@ public abstract class AbstractIdeContextTest extends Assertions {
    * @param copyForMutation - {@code true} to create a copy of the project that can be modified by the test,
    *        {@code false} otherwise (only to save resources if you are 100% sure that your test never modifies anything
    *        in that project.
-   * @return the {@link IdeContext} pointing to that project.
+   * @return the {@link IdeTestContext} pointing to that project.
    */
-  protected static IdeContext newContext(String projectName, String projectPath, boolean copyForMutation) {
+  protected static IdeTestContext newContext(String projectName, String projectPath, boolean copyForMutation) {
 
     Path sourceDir = PATH_PROJECTS.resolve(projectName);
     Path userDir = sourceDir;
@@ -68,7 +68,7 @@ public abstract class AbstractIdeContextTest extends Assertions {
       userDir = sourceDir.resolve(projectPath);
     }
     CommandletManagerResetter.reset();
-    IdeContext context;
+    IdeTestContext context;
     if (copyForMutation) {
       Path projectDir = PATH_PROJECTS_COPY.resolve(projectName);
       FileAccess fileAccess = new FileAccessImpl(IdeTestContextMock.get());
@@ -84,7 +84,11 @@ public abstract class AbstractIdeContextTest extends Assertions {
     return context;
   }
 
-  protected static IdeContext newContext(Path projectPath) {
+  /**
+   * @param projectPath the relative path inside the test project where to create the context.
+   * @return the {@link IdeTestContext} pointing to that project.
+   */
+  protected static IdeTestContext newContext(Path projectPath) {
 
     return new IdeTestContext(projectPath);
   }
@@ -94,7 +98,7 @@ public abstract class AbstractIdeContextTest extends Assertions {
    * @param level the expected {@link IdeLogLevel}.
    * @param message the expected {@link com.devonfw.tools.ide.log.IdeSubLogger#log(String) log message}.
    */
-  protected static void assertLogMessage(IdeContext context, IdeLogLevel level, String message) {
+  protected static void assertLogMessage(IdeTestContext context, IdeLogLevel level, String message) {
 
     assertLogMessage(context, level, message, false);
   }
@@ -106,9 +110,9 @@ public abstract class AbstractIdeContextTest extends Assertions {
    * @param contains - {@code true} if the given {@code message} may only be a sub-string of the log-message to assert,
    *        {@code false} otherwise (the entire log message including potential parameters being filled in is asserted).
    */
-  protected static void assertLogMessage(IdeContext context, IdeLogLevel level, String message, boolean contains) {
+  protected static void assertLogMessage(IdeTestContext context, IdeLogLevel level, String message, boolean contains) {
 
-    IdeTestLogger logger = (IdeTestLogger) context.level(level);
+    IdeTestLogger logger = context.level(level);
     ListAssert<String> assertion = assertThat(logger.getMessages()).as(level.name() + "-Log messages");
     if (contains) {
       Condition<String> condition = new Condition<>() {
@@ -125,7 +129,7 @@ public abstract class AbstractIdeContextTest extends Assertions {
 
   /**
    * Checks if a {@link com.devonfw.tools.ide.io.IdeProgressBar} was implemented correctly and reflects a default
-   * behaviour
+   * behavior
    *
    * @param context the {@link IdeContext} that was created via the {@link #newContext(String) newContext} method.
    * @param taskName name of the task e.g. Downloading.

--- a/cli/src/test/java/com/devonfw/tools/ide/context/IdeContextTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/IdeContextTest.java
@@ -24,7 +24,7 @@ public class IdeContextTest extends AbstractIdeContextTest {
     // arrange
     String path = "workspaces/foo-test/my-git-repo";
     // act
-    IdeContext context = newContext(PROJECT_BASIC, path, false);
+    IdeTestContext context = newContext(PROJECT_BASIC, path, false);
     // assert
     assertThat(context.getWorkspaceName()).isEqualTo("foo-test");
     assertThat(IdeVariables.DOCKER_EDITION.get(context)).isEqualTo("docker");

--- a/cli/src/test/java/com/devonfw/tools/ide/context/IdeTestContext.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/IdeTestContext.java
@@ -1,7 +1,9 @@
 package com.devonfw.tools.ide.context;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import com.devonfw.tools.ide.log.IdeLogLevel;
 import com.devonfw.tools.ide.log.IdeTestLogger;
 
 /**
@@ -18,6 +20,20 @@ public class IdeTestContext extends AbstractIdeTestContext {
   public IdeTestContext(Path userDir, String... answers) {
 
     super(level -> new IdeTestLogger(level), userDir, answers);
+  }
+
+  @Override
+  public IdeTestLogger level(IdeLogLevel level) {
+
+    return (IdeTestLogger) super.level(level);
+  }
+
+  /**
+   * @return a dummy {@link IdeTestContext}.
+   */
+  public static IdeTestContext of() {
+
+    return new IdeTestContext(Paths.get("/"));
   }
 
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/context/IdeTestContextMock.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/IdeTestContextMock.java
@@ -7,7 +7,7 @@ import java.nio.file.Paths;
  *
  * @see #get()
  */
-public class IdeTestContextMock extends IdeTestContext {
+public class IdeTestContextMock extends IdeSlf4jContext {
 
   private static final IdeTestContextMock INSTANCE = new IdeTestContextMock();
 

--- a/cli/src/test/java/com/devonfw/tools/ide/environment/EnvironmentVariablesPropertiesFileTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/environment/EnvironmentVariablesPropertiesFileTest.java
@@ -9,15 +9,13 @@ import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.devonfw.tools.ide.log.IdeSlf4jRootLogger;
+import com.devonfw.tools.ide.context.IdeTestContextMock;
 
 /**
  * Test of {@link EnvironmentVariablesPropertiesFile}.
  */
 @SuppressWarnings("javadoc")
 class EnvironmentVariablesPropertiesFileTest extends Assertions {
-
-  private static final IdeSlf4jRootLogger LOGGER = IdeSlf4jRootLogger.of();
 
   /**
    * Test of {@link EnvironmentVariablesPropertiesFile} including legacy support.
@@ -31,7 +29,7 @@ class EnvironmentVariablesPropertiesFileTest extends Assertions {
     EnvironmentVariablesType type = EnvironmentVariablesType.SETTINGS;
     // act
     EnvironmentVariablesPropertiesFile variables = new EnvironmentVariablesPropertiesFile(parent, type,
-        propertiesFilePath, LOGGER);
+        propertiesFilePath, IdeTestContextMock.get());
     // assert
     assertThat(variables.getType()).isSameAs(type);
     assertThat(variables.get("MVN_VERSION")).isEqualTo("3.9.0");
@@ -72,7 +70,7 @@ class EnvironmentVariablesPropertiesFileTest extends Assertions {
     EnvironmentVariablesType type = EnvironmentVariablesType.SETTINGS;
 
     EnvironmentVariablesPropertiesFile variables = new EnvironmentVariablesPropertiesFile(parent, type,
-        propertiesFilePath, LOGGER);
+        propertiesFilePath, IdeTestContextMock.get());
 
     // act
     variables.set("var5", "5", true);


### PR DESCRIPTION
* `EnvironmentVariables` has `IdeContext` and not only `IdeLogger` that gets casted
* `assertLogMessage` only on `IdeTestContext`
* `IdeTestContextMock` uses `SLF4J` to avoid collecting logs from different tests in static instance