### PR TITLE
#5: Improve access method for CommandletManager

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/CommandletManagerImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/CommandletManagerImpl.java
@@ -130,10 +130,29 @@ public final class CommandletManagerImpl implements CommandletManager {
   }
 
   /**
+   * This method gives global access to the {@link CommandletManager} instance. Typically you should have access to
+   * {@link IdeContext} and use {@link IdeContext#getCommandletManager()} to access the proper instance of
+   * {@link CommandletManager}. Only in very specific cases where there is no {@link IdeContext} available, you may use
+   * this method to access it (e.g. from {@link com.devonfw.tools.ide.property.CommandletProperty})
+   *
+   * @return the static instance of this {@link CommandletManager} implementation that has already been initialized.
+   * @throws IllegalStateException if the instance has not been previously initialized via
+   *         {@link #getOrCreate(IdeContext)}.
+   */
+  public static CommandletManager get() {
+
+    return getOrCreate(null);
+  }
+
+  /**
+   * This method has to be called initially from {@link IdeContext} to create the instance of this
+   * {@link CommandletManager} implementation. It will store that instance internally in a static variable so it can
+   * later be retrieved with {@link #get()}.
+   *
    * @param context the {@link IdeContext}.
    * @return the {@link CommandletManager}.
    */
-  public static CommandletManager of(IdeContext context) {
+  public static CommandletManager getOrCreate(IdeContext context) {
 
     if (context == null) {
       if (INSTANCE == null) {

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -124,7 +124,7 @@ public abstract class AbstractIdeContext implements IdeContext {
       this.loggers.put(level, logger);
     }
     this.systemInfo = new SystemInfoImpl();
-    this.commandletManager = CommandletManagerImpl.of(this);
+    this.commandletManager = CommandletManagerImpl.getOrCreate(this);
     this.fileAccess = new FileAccessImpl(this);
     String workspace = WORKSPACE_MAIN;
     if (userDir == null) {

--- a/cli/src/main/java/com/devonfw/tools/ide/property/CommandletProperty.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/property/CommandletProperty.java
@@ -51,7 +51,7 @@ public class CommandletProperty extends Property<Commandlet> {
   public Commandlet parse(String valueAsString) {
 
     // needs to be initialized before calling this...
-    Commandlet commandlet = CommandletManagerImpl.of(null).getCommandlet(valueAsString);
+    Commandlet commandlet = CommandletManagerImpl.get().getCommandlet(valueAsString);
     if (commandlet == null) {
       throw new IllegalArgumentException(valueAsString);
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/property/ToolProperty.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/property/ToolProperty.java
@@ -51,7 +51,7 @@ public class ToolProperty extends Property<ToolCommandlet> {
   public ToolCommandlet parse(String valueAsString) {
 
     // needs to be initialized before calling this...
-    return CommandletManagerImpl.of(null).getToolCommandlet(valueAsString);
+    return CommandletManagerImpl.get().getToolCommandlet(valueAsString);
   }
 
 }


### PR DESCRIPTION
Related to #5
In our daily we discovered a confusion with `CommandletManagerImpl.of(null)` and had a general discussion about static `of` vs. `get` methods:
* static method named `of` shall be like a "Constructor" to create a new instance of something.
* static method named `get` shall be some kind of singleton access to get something that is already there and typically return the same instance when called multiple times.

I have refactored our code and properly applied this also for `CommandletManagerImpl` and also improved the JavaDoc accordingly so things should be more transparent now.