### PR TITLE
#146 Implement automated coverage tools

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,3 +14,5 @@ jobs:
           java-version: '17'
       - name: Build project with Maven
         run: mvn -B -ntp -Dstyle.color=always install
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@v2.2.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,5 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: mvn --settings .mvn/settings.xml -DskipTests=true -Darchetype.test.skip=true -Dmaven.install.skip=true -Dstyle.color=always -B -ntp deploy
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@v2.2.3

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,26 @@
           <updatePomFile>true</updatePomFile>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.11</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
closes #146 implement automated coverage tool

Jacoco has been added 

Coverall has been added to the GitHub workflow, to be used in PRs
Some Steps are needed to activate Coverall:

- [x] 1. Sign up to Coveralls.io on their website using the Repo owner
- [x] 2.  On the Coverall website navigate to settings and Activate "leave comments?" and set them to detailed, bevor saving the changes. (Once signed up the link to the settings will be https://coveralls.io/github/devonfw/IDEasy/settings )
- [x] 3. The coverall bot needs to be added to the repo, with write permissions (https://github.com/coveralls)

(Documentation can also be found on the Coveralls [docu page ](https://docs.coveralls.io/app-notifications#pull-request-comments))