### PR TITLE
#158: improved VersionRange

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/version/BoundaryType.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/BoundaryType.java
@@ -15,5 +15,67 @@ public enum BoundaryType {
   LEFT_OPEN,
 
   /** Right open interval - includes the lower bound but excludes the upper bound. */
-  RIGHT_OPEN
+  RIGHT_OPEN;
+
+  static final String START_EXCLUDING_PREFIX = "(";
+
+  static final String START_INCLUDING_PREFIX = "[";
+
+  static final String END_EXCLUDING_SUFFIX = ")";
+
+  static final String END_INCLUDING_SUFFIX = "]";
+
+  /**
+   * @return {@code true} if left exclusive, {@code false} otherwise (left inclusive).
+   */
+  public boolean isLeftExclusive() {
+
+    return (this == LEFT_OPEN) || (this == OPEN);
+  }
+
+  /**
+   * @return {@code true} if right exclusive, {@code false} otherwise (right inclusive).
+   */
+  public boolean isRightExclusive() {
+
+    return (this == RIGHT_OPEN) || (this == OPEN);
+  }
+
+  /**
+   * @return the prefix (left parenthesis or bracket for {@link #isLeftExclusive()}).
+   */
+  public String getPrefix() {
+
+    return isLeftExclusive() ? START_EXCLUDING_PREFIX : START_INCLUDING_PREFIX;
+  }
+
+  /**
+   * @return the suffix (right parenthesis or bracket for {@link #isRightExclusive()}).
+   */
+  public String getSuffix() {
+
+    return isRightExclusive() ? END_EXCLUDING_SUFFIX : END_INCLUDING_SUFFIX;
+  }
+
+  /**
+   * @param leftExclusive the {@link #isLeftExclusive() left exclusive flag}.
+   * @param rightExclusive the {@link #isRightExclusive() right exclusive flag}.
+   * @return the {@link BoundaryType} with the specified values.
+   */
+  public static BoundaryType of(boolean leftExclusive, boolean rightExclusive) {
+
+    if (leftExclusive) {
+      if (rightExclusive) {
+        return OPEN;
+      } else {
+        return LEFT_OPEN;
+      }
+    } else {
+      if (rightExclusive) {
+        return RIGHT_OPEN;
+      } else {
+        return CLOSED;
+      }
+    }
+  }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/version/VersionRangeTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/version/VersionRangeTest.java
@@ -8,16 +8,14 @@ import org.junit.jupiter.api.Test;
  */
 public class VersionRangeTest extends Assertions {
 
-  /**
-   * Test of {@link VersionRange#of(String)}.
-   */
+  /** Test of {@link VersionRange#of(String)}. */
   @Test
   public void testOf() {
 
     // arrange
-    String v1String = "1.2>3";
-    String v2String = "1>)";
-    String v3String = "(1.2>3.4]";
+    String v1String = "1.2,3";
+    String v2String = "1,)";
+    String v3String = "(1.2,3.4]";
 
     // act
     VersionRange v1 = VersionRange.of(v1String);
@@ -28,60 +26,56 @@ public class VersionRangeTest extends Assertions {
     // v1
     assertThat(v1.getMin()).isEqualTo(VersionIdentifier.of("1.2"));
     assertThat(v1.getMax()).isEqualTo(VersionIdentifier.of("3"));
-    assertThat(v1.isLeftExclusive()).isFalse();
-    assertThat(v1.isRightExclusive()).isFalse();
+    assertThat(v1.getBoundaryType().isLeftExclusive()).isFalse();
+    assertThat(v1.getBoundaryType().isRightExclusive()).isFalse();
     // v2
     assertThat(v2.getMin()).isEqualTo(VersionIdentifier.of("1"));
     assertThat(v2.getMax()).isEqualTo(null);
-    assertThat(v2.isLeftExclusive()).isFalse();
-    assertThat(v2.isRightExclusive()).isTrue();
+    assertThat(v2.getBoundaryType().isLeftExclusive()).isFalse();
+    assertThat(v2.getBoundaryType().isRightExclusive()).isTrue();
     // v3
     assertThat(v3.getMin()).isEqualTo(VersionIdentifier.of("1.2"));
     assertThat(v3.getMax()).isEqualTo(VersionIdentifier.of("3.4"));
-    assertThat(v3.isLeftExclusive()).isTrue();
-    assertThat(v3.isRightExclusive()).isFalse();
+    assertThat(v3.getBoundaryType().isLeftExclusive()).isTrue();
+    assertThat(v3.getBoundaryType().isRightExclusive()).isFalse();
   }
 
-  /**
-   * Test of {@link VersionRange#toString()}.
-   */
+  /** Test of {@link VersionRange#toString()}. */
   @Test
   public void testToString() {
 
-    assertThat(VersionRange.of("1.2>3").toString()).isEqualTo("[1.2>3]");
-    assertThat(VersionRange.of("1>)").toString()).isEqualTo("[1>)");
-    assertThat(VersionRange.of("(1.2>3.4]").toString()).isEqualTo("(1.2>3.4]");
+    assertThat(VersionRange.of("1.2,3").toString()).isEqualTo("[1.2,3]");
+    assertThat(VersionRange.of("1,)").toString()).isEqualTo("[1,)");
+    assertThat(VersionRange.of("(1.2,3.4]").toString()).isEqualTo("(1.2,3.4]");
+    assertThat(VersionRange.of(",").toString()).isEqualTo("(,)");
   }
 
-  /**
-   * Test of {@link VersionRange#equals(Object)}.
-   */
+  /** Test of {@link VersionRange#equals(Object)}. */
   @Test
   public void testEquals() {
 
     // assert
     // equals
-    assertThat(VersionRange.of("1.2>")).isEqualTo(VersionRange.of("1.2>"));
-    assertThat(VersionRange.of("(1.2>")).isEqualTo(VersionRange.of("(1.2>)"));
-    assertThat(VersionRange.of("1.2>3")).isEqualTo(VersionRange.of("1.2>3"));
-    assertThat(VersionRange.of("[1.2>3")).isEqualTo(VersionRange.of("1.2>3]"));
-    assertThat(VersionRange.of(">3)")).isEqualTo(VersionRange.of(">3)"));
-    assertThat(VersionRange.of(">")).isEqualTo(VersionRange.of(">"));
-    assertThat(VersionRange.of("[>)")).isEqualTo(VersionRange.of("(>]"));
-    assertThat(VersionRange.of("8u302b08>11.0.14_9")).isEqualTo(VersionRange.of("8u302b08>11.0.14_9"));
+    assertThat(VersionRange.of("1.2,")).isEqualTo(VersionRange.of("1.2,"));
+    assertThat(VersionRange.of("(1.2,")).isEqualTo(VersionRange.of("(1.2,)"));
+    assertThat(VersionRange.of("1.2,3")).isEqualTo(VersionRange.of("1.2,3"));
+    assertThat(VersionRange.of("[1.2,3")).isEqualTo(VersionRange.of("1.2,3]"));
+    assertThat(VersionRange.of(",3)")).isEqualTo(VersionRange.of(",3)"));
+    assertThat(VersionRange.of(",")).isEqualTo(VersionRange.of("(,)"));
+    assertThat(VersionRange.of("8u302b08,11.0.14_9")).isEqualTo(VersionRange.of("8u302b08,11.0.14_9"));
     // not equals
-    assertThat(VersionRange.of("1>")).isNotEqualTo(null);
-    assertThat(VersionRange.of("1.2>")).isNotEqualTo(VersionRange.of("1>"));
-    assertThat(VersionRange.of("1.2>3")).isNotEqualTo(VersionRange.of("1.2>"));
-    assertThat(VersionRange.of("(1.2>3")).isNotEqualTo(VersionRange.of("1.2.3>"));
-    assertThat(VersionRange.of("1.2>3")).isNotEqualTo(VersionRange.of(">3"));
-    assertThat(VersionRange.of("[1.2>")).isNotEqualTo(VersionRange.of("[1.2>3"));
-    assertThat(VersionRange.of(">3")).isNotEqualTo(VersionRange.of("1.2>3"));
-    assertThat(VersionRange.of(">3")).isNotEqualTo(VersionRange.of(">"));
-    assertThat(VersionRange.of(">")).isNotEqualTo(VersionRange.of(">3"));
-    assertThat(VersionRange.of("8u302b08>11.0.14_9")).isNotEqualTo(VersionRange.of("(8u302b08>11.0.14_9)"));
-    assertThat(VersionRange.of("8u302b08>11.0.14_9")).isNotEqualTo(VersionRange.of("8u302b08>11.0.15_9"));
-    assertThat(VersionRange.of("8u302b08>11.0.14_9")).isNotEqualTo(VersionRange.of("8u302b08>11.0.14_0"));
+    assertThat(VersionRange.of("1,")).isNotEqualTo(null);
+    assertThat(VersionRange.of("1.2,")).isNotEqualTo(VersionRange.of("1,"));
+    assertThat(VersionRange.of("1.2,3")).isNotEqualTo(VersionRange.of("1.2,"));
+    assertThat(VersionRange.of("(1.2,3")).isNotEqualTo(VersionRange.of("1.2.3,"));
+    assertThat(VersionRange.of("1.2,3")).isNotEqualTo(VersionRange.of(",3"));
+    assertThat(VersionRange.of("[1.2,")).isNotEqualTo(VersionRange.of("[1.2,3"));
+    assertThat(VersionRange.of(",3")).isNotEqualTo(VersionRange.of("1.2,3"));
+    assertThat(VersionRange.of(",3")).isNotEqualTo(VersionRange.of(","));
+    assertThat(VersionRange.of(",")).isNotEqualTo(VersionRange.of(",3"));
+    assertThat(VersionRange.of("8u302b08,11.0.14_9")).isNotEqualTo(VersionRange.of("(8u302b08,11.0.14_9)"));
+    assertThat(VersionRange.of("8u302b08,11.0.14_9")).isNotEqualTo(VersionRange.of("8u302b08,11.0.15_9"));
+    assertThat(VersionRange.of("8u302b08,11.0.14_9")).isNotEqualTo(VersionRange.of("8u302b08,11.0.14_0"));
   }
 
   /**
@@ -92,13 +86,13 @@ public class VersionRangeTest extends Assertions {
   public void testContains() {
 
     // assert
-    assertThat(VersionRange.of("1.2>3.4").contains(VersionIdentifier.of("1.2"))).isTrue();
-    assertThat(VersionRange.of("1.2>3.4").contains(VersionIdentifier.of("2"))).isTrue();
-    assertThat(VersionRange.of("1.2>3.4").contains(VersionIdentifier.of("3.4"))).isTrue();
+    assertThat(VersionRange.of("1.2,3.4").contains(VersionIdentifier.of("1.2"))).isTrue();
+    assertThat(VersionRange.of("1.2,3.4").contains(VersionIdentifier.of("2"))).isTrue();
+    assertThat(VersionRange.of("1.2,3.4").contains(VersionIdentifier.of("3.4"))).isTrue();
 
-    assertThat(VersionRange.of("(1.2>3.4)").contains(VersionIdentifier.of("1.2.1"))).isTrue();
-    assertThat(VersionRange.of("(1.2>3.4)").contains(VersionIdentifier.of("2"))).isTrue();
-    assertThat(VersionRange.of("(1.2>3.4)").contains(VersionIdentifier.of("3.3.9"))).isTrue();
+    assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("1.2.1"))).isTrue();
+    assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("2"))).isTrue();
+    assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("3.3.9"))).isTrue();
   }
 
   /**
@@ -109,44 +103,60 @@ public class VersionRangeTest extends Assertions {
   public void testNotContains() {
 
     // assert
-    assertThat(VersionRange.of("1.2>3.4").contains(VersionIdentifier.of("1.1"))).isFalse();
-    assertThat(VersionRange.of("1.2>3.4").contains(VersionIdentifier.of("3.4.1"))).isFalse();
+    assertThat(VersionRange.of("1.2,3.4").contains(VersionIdentifier.of("1.1"))).isFalse();
+    assertThat(VersionRange.of("1.2,3.4").contains(VersionIdentifier.of("3.4.1"))).isFalse();
 
-    assertThat(VersionRange.of("(1.2>3.4)").contains(VersionIdentifier.of("1.2"))).isFalse();
-    assertThat(VersionRange.of("(1.2>3.4)").contains(VersionIdentifier.of("3.4"))).isFalse();
+    assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("1.2"))).isFalse();
+    assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("3.4"))).isFalse();
   }
 
-  /**
-   * Test of {@link VersionRange#compareTo(VersionRange)} and testing if versions are compared to be the same.
-   */
+  /** Test of {@link VersionRange#compareTo(VersionRange)} and testing if versions are compared to be the same. */
   @Test
   public void testCompareToIsSame() {
 
     // assert
-    assertThat(VersionRange.of("1.2>3").compareTo(VersionRange.of("1.2>3"))).isEqualTo(0);
-    assertThat(VersionRange.of("(1.2>3").compareTo(VersionRange.of("(1.2>3"))).isEqualTo(0);
-    assertThat(VersionRange.of("[1.2>3]").compareTo(VersionRange.of("[1.2>4)"))).isEqualTo(0);
+    assertThat(VersionRange.of("1.2,3").compareTo(VersionRange.of("1.2,3"))).isEqualTo(0);
+    assertThat(VersionRange.of("(1.2,3").compareTo(VersionRange.of("(1.2,3"))).isEqualTo(0);
+    assertThat(VersionRange.of("[1.2,3]").compareTo(VersionRange.of("[1.2,4)"))).isEqualTo(0);
   }
 
-  /**
-   * Test of {@link VersionRange#compareTo(VersionRange)} and testing if first version is smaller than second.
-   */
+  /** Test of {@link VersionRange#compareTo(VersionRange)} and testing if first version is smaller than second. */
   @Test
   public void testCompareToIsSmaller() {
 
     // assert
-    assertThat(VersionRange.of("1.1.2>3").compareTo(VersionRange.of("1.2>3"))).isEqualTo(-1);
-    assertThat(VersionRange.of("[1.2>3").compareTo(VersionRange.of("(1.2>4"))).isEqualTo(-1);
+    assertThat(VersionRange.of("1.1.2,3").compareTo(VersionRange.of("1.2,3"))).isEqualTo(-1);
+    assertThat(VersionRange.of("[1.2,3").compareTo(VersionRange.of("(1.2,4"))).isEqualTo(-1);
   }
 
-  /**
-   * Test of {@link VersionRange#compareTo(VersionRange)} and testing if first version is larger than second.
-   */
+  /** Test of {@link VersionRange#compareTo(VersionRange)} and testing if first version is larger than second. */
   @Test
   public void testCompareToIsLarger() {
 
     // assert
-    assertThat(VersionRange.of("1.2.1>3").compareTo(VersionRange.of("1.2>3"))).isEqualTo(1);
-    assertThat(VersionRange.of("(1.2>3").compareTo(VersionRange.of("1.2>4"))).isEqualTo(1);
+    assertThat(VersionRange.of("1.2.1,3").compareTo(VersionRange.of("1.2,3"))).isEqualTo(1);
+    assertThat(VersionRange.of("(1.2,3").compareTo(VersionRange.of("1.2,4"))).isEqualTo(1);
+  }
+
+  /** Test of {@link VersionRange#of(String)} with illegal syntax. */
+  @Test
+  public void testIllegalSyntax() {
+
+    checkIllegalRange("[,)");
+    checkIllegalRange("(,]");
+    checkIllegalRange("[,]");
+    checkIllegalRange("[,1.0)");
+    checkIllegalRange("(1.0,]");
+    checkIllegalRange("(1.1,1.0)");
+  }
+
+  private void checkIllegalRange(String range) {
+
+    try {
+      VersionRange.of(range);
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertThat(e.getMessage()).isEqualTo(range);
+    }
   }
 }


### PR DESCRIPTION
Improvement for Version Range (#158, #159):
* Consistency (min = null means negative infinity and requires leftExclusive, max = null means positive infinity and requires rightExclusive, min must not be greater than max)
* Syntax "[min>max]" does not really make sense (as it turns out this seems to come from https://github.com/devonfw/ide/issues/1054) and I changed `>` to `,` what is rather common (same in Maven, etc.).
* Improved maintainability of code