### PR TITLE
#183: removed isInstalledVersion()

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
@@ -2,6 +2,7 @@ package com.devonfw.tools.ide.tool;
 
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.io.FileAccess;
+import com.devonfw.tools.ide.log.IdeLogLevel;
 import com.devonfw.tools.ide.process.ProcessContext;
 import com.devonfw.tools.ide.process.ProcessErrorHandling;
 import com.devonfw.tools.ide.repo.ToolRepository;
@@ -31,7 +32,9 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
 
   @Override
   protected boolean isExtract() {
-    // for global tools we usually download installers and do not want to extract them (e.g. installer.msi file shall not be extracted)
+
+    // for global tools we usually download installers and do not want to extract them (e.g. installer.msi file shall
+    // not be extracted)
     return false;
   }
 
@@ -39,9 +42,10 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
   protected boolean doInstall(boolean silent) {
 
     Path binaryPath = this.context.getPath().findBinary(Path.of(getBinaryName()));
-    //if force mode is enabled, go through with the installation even if the tool is already installed
+    // if force mode is enabled, go through with the installation even if the tool is already installed
     if (binaryPath != null && Files.exists(binaryPath) && !this.context.isForceMode()) {
-      this.context.debug("{} is already installed at {}", this.tool, binaryPath);
+      IdeLogLevel level = silent ? IdeLogLevel.DEBUG : IdeLogLevel.INFO;
+      this.context.level(level).log("{} is already installed at {}", this.tool, binaryPath);
       return false;
     }
     String edition = getEdition();
@@ -57,7 +61,8 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
     if (isExtract()) {
       downloadBinaryPath = fileAccess.findFirst(downloadBinaryPath, Files::isExecutable, false);
     }
-    ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.WARNING).executable(downloadBinaryPath);
+    ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.WARNING)
+        .executable(downloadBinaryPath);
     int exitCode = pc.run();
     fileAccess.delete(tmpDir);
     fileAccess.delete(target);

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -32,7 +32,6 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
     super(context, tool, tags);
   }
 
-
   /**
    * @return the {@link Path} where the tool is located (installed).
    */
@@ -66,7 +65,7 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
     // check if we already have this version installed (linked) locally in IDE_HOME/software
     VersionIdentifier installedVersion = getInstalledVersion();
     VersionIdentifier resolvedVersion = installation.resolvedVersion();
-    if (isInstalledVersion(resolvedVersion, installedVersion, silent)) {
+    if (resolvedVersion.equals(installedVersion)) {
       return false;
     }
     // we need to link the version or update the link.
@@ -165,21 +164,6 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
       this.context.getFileAccess().copy(toolVersionFile, linkDir, FileCopyMode.COPY_FILE_OVERRIDE);
     }
     return new ToolInstallation(rootDir, linkDir, binDir, resolvedVersion);
-  }
-
-  private boolean isInstalledVersion(VersionIdentifier expectedVersion, VersionIdentifier installedVersion,
-      boolean silent) {
-
-    if (expectedVersion.equals(installedVersion)) {
-      IdeLogLevel level = IdeLogLevel.INFO;
-      if (silent) {
-        level = IdeLogLevel.DEBUG;
-      }
-      this.context.level(level).log("Version {} of tool {} is already installed", installedVersion,
-          getToolWithEdition());
-      return true;
-    }
-    return false;
   }
 
 }


### PR DESCRIPTION
Fixes #183.  `isInstalledVersion()` was only used once and caused the duplicate msg if the tool was already installed.