### PR TITLE
#209: Quick Fix for CI build failure

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
@@ -12,6 +12,7 @@ import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.io.FileAccess;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
+import com.devonfw.tools.ide.tool.java.Java;
 
 /**
  * {@link ToolCommandlet} for <a href="https://www.oracle.com/java/technologies/jdk-mission-control.html">JDK Mission
@@ -32,8 +33,7 @@ public class Jmc extends LocalToolCommandlet {
   @Override
   public boolean doInstall(boolean silent) {
 
-    // TODO The Java dependency should be also implemented, while the support for dependencies is not yet implemented
-    // getCommandlet(Java.class).install();
+    getCommandlet(Java.class).install();
     return super.doInstall(silent);
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
@@ -12,7 +12,6 @@ import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.io.FileAccess;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
-import com.devonfw.tools.ide.tool.java.Java;
 
 /**
  * {@link ToolCommandlet} for <a href="https://www.oracle.com/java/technologies/jdk-mission-control.html">JDK Mission
@@ -33,7 +32,7 @@ public class Jmc extends LocalToolCommandlet {
   @Override
   public boolean doInstall(boolean silent) {
 
-    getCommandlet(Java.class).install();
+    // getCommandlet(Java.class).install();
     return super.doInstall(silent);
   }
 
@@ -56,7 +55,9 @@ public class Jmc extends LocalToolCommandlet {
         moveFilesAndDirs(oldBinaryPath, toolPath);
         fileAccess.delete(oldBinaryPath);
       } else {
-        this.context.info("JMC binary folder not found at {} - ignoring as this legacy problem may be resolved in newer versions.", oldBinaryPath);
+        this.context.info(
+            "JMC binary folder not found at {} - ignoring as this legacy problem may be resolved in newer versions.",
+            oldBinaryPath);
       }
     }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
@@ -33,7 +33,8 @@ public class Jmc extends LocalToolCommandlet {
   @Override
   public boolean doInstall(boolean silent) {
 
-    getCommandlet(Java.class).install();
+    // TODO https://github.com/devonfw/IDEasy/issues/209 currently outcommented as this breaks the tests, real fix needed asap
+    // getCommandlet(Java.class).install();
     return super.doInstall(silent);
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
@@ -56,9 +56,7 @@ public class Jmc extends LocalToolCommandlet {
         moveFilesAndDirs(oldBinaryPath, toolPath);
         fileAccess.delete(oldBinaryPath);
       } else {
-        this.context.info(
-            "JMC binary folder not found at {} - ignoring as this legacy problem may be resolved in newer versions.",
-            oldBinaryPath);
+        this.context.info("JMC binary folder not found at {} - ignoring as this legacy problem may be resolved in newer versions.", oldBinaryPath);
       }
     }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
@@ -32,6 +32,7 @@ public class Jmc extends LocalToolCommandlet {
   @Override
   public boolean doInstall(boolean silent) {
 
+    // TODO The Java dependency should be also implemented, while the support for dependencies is not yet implemented
     // getCommandlet(Java.class).install();
     return super.doInstall(silent);
   }

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/Jmc/JmcTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/Jmc/JmcTest.java
@@ -29,8 +29,7 @@ public class JmcTest extends AbstractIdeContextTest {
 
   @BeforeAll
   static void setUp() throws IOException {
-    // changed from 1111 to 1112 to solve the CI build failure
-    server = new WireMockServer(WireMockConfiguration.wireMockConfig().port(1112)); 
+    server = new WireMockServer(WireMockConfiguration.wireMockConfig().port(1112));
     server.start();
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/Jmc/JmcTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/Jmc/JmcTest.java
@@ -1,4 +1,4 @@
-package com.devonfw.tools.ide.Jmc;
+package com.devonfw.tools.ide.tool.Jmc;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -30,7 +30,7 @@ public class JmcTest extends AbstractIdeContextTest {
   @BeforeAll
   static void setUp() throws IOException {
 
-    server = new WireMockServer(WireMockConfiguration.wireMockConfig().port(1111));
+    server = new WireMockServer(WireMockConfiguration.wireMockConfig().port(1112));
     server.start();
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/Jmc/JmcTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/Jmc/JmcTest.java
@@ -29,8 +29,8 @@ public class JmcTest extends AbstractIdeContextTest {
 
   @BeforeAll
   static void setUp() throws IOException {
-
-    server = new WireMockServer(WireMockConfiguration.wireMockConfig().port(1112));
+    // changed from 1111 to 1112 to solve the CI build failure
+    server = new WireMockServer(WireMockConfiguration.wireMockConfig().port(1112)); 
     server.start();
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/jmc/JmcTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/jmc/JmcTest.java
@@ -1,4 +1,4 @@
-package com.devonfw.tools.ide.tool.jmc.Jmc;
+package com.devonfw.tools.ide.tool.jmc;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/jmc/JmcTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/jmc/JmcTest.java
@@ -1,4 +1,4 @@
-package com.devonfw.tools.ide.tool.Jmc;
+package com.devonfw.tools.ide.tool.jmc.Jmc;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;

--- a/cli/src/test/resources/ide-projects/_ide/urls/jmc/jmc/8.3.0/linux_x64.urls
+++ b/cli/src/test/resources/ide-projects/_ide/urls/jmc/jmc/8.3.0/linux_x64.urls
@@ -1,1 +1,1 @@
-http://localhost:1111/jmcTest/linux
+http://localhost:1112/jmcTest/linux

--- a/cli/src/test/resources/ide-projects/_ide/urls/jmc/jmc/8.3.0/mac_x64.urls
+++ b/cli/src/test/resources/ide-projects/_ide/urls/jmc/jmc/8.3.0/mac_x64.urls
@@ -1,1 +1,1 @@
-http://localhost:1111/jmcTest/macOS
+http://localhost:1112/jmcTest/macOS

--- a/cli/src/test/resources/ide-projects/_ide/urls/jmc/jmc/8.3.0/windows_x64.urls
+++ b/cli/src/test/resources/ide-projects/_ide/urls/jmc/jmc/8.3.0/windows_x64.urls
@@ -1,1 +1,1 @@
-http://localhost:1111/jmcTest/windows
+http://localhost:1112/jmcTest/windows


### PR DESCRIPTION
Fixes: #209 

This is a quick fix for the failure of the CI build.  In this PR is just the port number for JMC installation changed, from 1111 to 1112.

Another generally better solution is in investigation and will be implemented soon.