### PR TITLE
#225: Return statement in backup() function in case of symlinks

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -225,6 +225,7 @@ public class FileAccessImpl implements FileAccess {
 
     if (Files.isSymbolicLink(fileOrFolder)) {
       delete(fileOrFolder);
+      return;
     }
     Path backupPath = this.context.getIdeHome().resolve(IdeContext.FOLDER_UPDATES).resolve(IdeContext.FOLDER_BACKUPS);
     LocalDateTime now = LocalDateTime.now();


### PR DESCRIPTION
Fixes: #225 by just adding a `return;` if the file is a symlink (it is then deleted and doesen't need to be moved). 