### PR TITLE
#195: java installation in macos

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -173,7 +173,10 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
     }
     if (linkDir != rootDir) {
       assert (!linkDir.equals(rootDir));
-      this.context.getFileAccess().copy(toolVersionFile, linkDir, FileCopyMode.COPY_FILE_OVERRIDE);
+      if (newInstallation) {
+        linkDir = linkDir.resolve(this.context.FILE_SOFTWARE_VERSION);
+        this.context.getFileAccess().copy(toolVersionFile, linkDir, FileCopyMode.COPY_FILE_OVERRIDE);
+      }
     }
     return new ToolInstallation(rootDir, linkDir, binDir, resolvedVersion, newInstallation);
   }


### PR DESCRIPTION
Fixes: #195 

## CAUSE of the issue:
* copying `.ide.software.version` to the target Path was failing.
the problem was to my understanding and after my researches, that the source is a specific file path but the target is not recognized as a directory as it is, so when it tries to replace the target directory with the source file it fails.

## SOLUTION:
* adding .ide.software.version to the target Path solves the problem.
* the file has to be copied just if it is a new installation, so it is possible to enclose it in a if statement that checks it's a new installation

## COMMENTS:
* works fine for me,  but
* still not super experienced about all the installation of commandlets. Would be nice if someone else could have a look.

