### PR TITLE
#264: prevent Windows file lock

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -1,5 +1,19 @@
 package com.devonfw.tools.ide.io;
 
+import com.devonfw.tools.ide.cli.CliException;
+import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.os.SystemInfoImpl;
+import com.devonfw.tools.ide.process.ProcessContext;
+import com.devonfw.tools.ide.url.model.file.UrlChecksum;
+import com.devonfw.tools.ide.util.DateTimeUtil;
+import com.devonfw.tools.ide.util.FilenameUtil;
+import com.devonfw.tools.ide.util.HexUtil;
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+
 import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -31,21 +45,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
-import org.apache.commons.compress.archivers.ArchiveEntry;
-import org.apache.commons.compress.archivers.ArchiveInputStream;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
-
-import com.devonfw.tools.ide.cli.CliException;
-import com.devonfw.tools.ide.context.IdeContext;
-import com.devonfw.tools.ide.os.SystemInfoImpl;
-import com.devonfw.tools.ide.process.ProcessContext;
-import com.devonfw.tools.ide.url.model.file.UrlChecksum;
-import com.devonfw.tools.ide.util.DateTimeUtil;
-import com.devonfw.tools.ide.util.FilenameUtil;
-import com.devonfw.tools.ide.util.HexUtil;
 
 /**
  * Implementation of {@link FileAccess}.
@@ -106,14 +105,11 @@ public class FileAccessImpl implements FileAccess {
    * @param target Path of the target directory.
    * @param response the {@link HttpResponse} to use.
    */
-  private void downloadFileWithProgressBar(String url, Path target, HttpResponse<InputStream> response)
-      throws IOException {
+  private void downloadFileWithProgressBar(String url, Path target, HttpResponse<InputStream> response) throws IOException {
 
     long contentLength = response.headers().firstValueAsLong("content-length").orElse(0);
     if (contentLength == 0) {
-      this.context.warning(
-          "Content-Length was not provided by download source : {} using fallback for the progress bar which will be inaccurate.",
-          url);
+      this.context.warning("Content-Length was not provided by download source : {} using fallback for the progress bar which will be inaccurate.", url);
       contentLength = 10000000;
     }
 
@@ -147,8 +143,7 @@ public class FileAccessImpl implements FileAccess {
    */
   private void copyFileWithProgressBar(Path source, Path target) throws IOException {
 
-    try (InputStream in = new FileInputStream(source.toFile());
-        OutputStream out = new FileOutputStream(target.toFile())) {
+    try (InputStream in = new FileInputStream(source.toFile()); OutputStream out = new FileOutputStream(target.toFile())) {
 
       long size = source.toFile().length();
       byte[] buf = new byte[1024];
@@ -238,8 +233,7 @@ public class FileAccessImpl implements FileAccess {
       return false; // file doesn't exist
     } catch (IOException e) {
       // errors in reading the attributes of the file
-      throw new IllegalStateException(
-          "An unexpected error occurred whilst checking if the file: " + path + " is a junction", e);
+      throw new IllegalStateException("An unexpected error occurred whilst checking if the file: " + path + " is a junction", e);
     }
   }
 
@@ -331,9 +325,8 @@ public class FileAccessImpl implements FileAccess {
   }
 
   /**
-   * Deletes the given {@link Path} if it is a symbolic link or a Windows junction. And throws an
-   * {@link IllegalStateException} if there is a file at the given {@link Path} that is neither a symbolic link nor a
-   * Windows junction.
+   * Deletes the given {@link Path} if it is a symbolic link or a Windows junction. And throws an {@link IllegalStateException} if there is a file at the given
+   * {@link Path} that is neither a symbolic link nor a Windows junction.
    *
    * @param path the {@link Path} to delete.
    * @throws IOException if the actual {@link Files#delete(Path) deletion} fails.
@@ -352,12 +345,11 @@ public class FileAccessImpl implements FileAccess {
   }
 
   /**
-   * Adapts the given {@link Path} to be relative or absolute depending on the given {@code relative} flag.
-   * Additionally, {@link Path#toRealPath(LinkOption...)} is applied to {@code source}.
+   * Adapts the given {@link Path} to be relative or absolute depending on the given {@code relative} flag. Additionally, {@link Path#toRealPath(LinkOption...)}
+   * is applied to {@code source}.
    *
    * @param source the {@link Path} to adapt.
-   * @param targetLink the {@link Path} used to calculate the relative path to the {@code source} if {@code relative} is
-   *        set to {@code true}.
+   * @param targetLink the {@link Path} used to calculate the relative path to the {@code source} if {@code relative} is set to {@code true}.
    * @param relative the {@code relative} flag.
    * @return the adapted {@link Path}.
    * @see FileAccessImpl#symlink(Path, Path, boolean)
@@ -368,8 +360,7 @@ public class FileAccessImpl implements FileAccess {
       try {
         source = source.toRealPath(LinkOption.NOFOLLOW_LINKS); // to transform ../d1/../d2 to ../d2
       } catch (IOException e) {
-        throw new IOException(
-            "Calling toRealPath() on the source (" + source + ") in method FileAccessImpl.adaptPath() failed.", e);
+        throw new IOException("Calling toRealPath() on the source (" + source + ") in method FileAccessImpl.adaptPath() failed.", e);
       }
       if (relative) {
         source = targetLink.getParent().relativize(source);
@@ -380,15 +371,13 @@ public class FileAccessImpl implements FileAccess {
       if (relative) {
         // even though the source is already relative, toRealPath should be called to transform paths like
         // this ../d1/../d2 to ../d2
-        source = targetLink.getParent()
-            .relativize(targetLink.resolveSibling(source).toRealPath(LinkOption.NOFOLLOW_LINKS));
+        source = targetLink.getParent().relativize(targetLink.resolveSibling(source).toRealPath(LinkOption.NOFOLLOW_LINKS));
         source = (source.toString().isEmpty()) ? Path.of(".") : source;
       } else { // !relative
         try {
           source = targetLink.resolveSibling(source).toRealPath(LinkOption.NOFOLLOW_LINKS);
         } catch (IOException e) {
-          throw new IOException("Calling toRealPath() on " + targetLink + ".resolveSibling(" + source
-              + ") in method FileAccessImpl.adaptPath() failed.", e);
+          throw new IOException("Calling toRealPath() on " + targetLink + ".resolveSibling(" + source + ") in method FileAccessImpl.adaptPath() failed.", e);
         }
       }
     }
@@ -406,17 +395,14 @@ public class FileAccessImpl implements FileAccess {
     this.context.trace("Creating a Windows junction at " + targetLink + " with " + source + " as source.");
     Path fallbackPath;
     if (!source.isAbsolute()) {
-      this.context.warning(
-          "You are on Windows and you do not have permissions to create symbolic links. Junctions are used as an "
-              + "alternative, however, these can not point to relative paths. So the source (" + source
-              + ") is interpreted as an absolute path.");
+      this.context.warning("You are on Windows and you do not have permissions to create symbolic links. Junctions are used as an "
+          + "alternative, however, these can not point to relative paths. So the source (" + source + ") is interpreted as an absolute path.");
       try {
         fallbackPath = targetLink.resolveSibling(source).toRealPath(LinkOption.NOFOLLOW_LINKS);
       } catch (IOException e) {
         throw new IllegalStateException(
-            "Since Windows junctions are used, the source must be an absolute path. The transformation of the passed "
-                + "source (" + source + ") to an absolute path failed.",
-            e);
+            "Since Windows junctions are used, the source must be an absolute path. The transformation of the passed " + "source (" + source
+                + ") to an absolute path failed.", e);
       }
 
     } else {
@@ -424,11 +410,9 @@ public class FileAccessImpl implements FileAccess {
     }
     if (!Files.isDirectory(fallbackPath)) { // if source is a junction. This returns true as well.
       throw new IllegalStateException(
-          "These junctions can only point to directories or other junctions. Please make sure that the source ("
-              + fallbackPath + ") is one of these.");
+          "These junctions can only point to directories or other junctions. Please make sure that the source (" + fallbackPath + ") is one of these.");
     }
-    this.context.newProcess().executable("cmd")
-        .addArgs("/c", "mklink", "/d", "/j", targetLink.toString(), fallbackPath.toString()).run();
+    this.context.newProcess().executable("cmd").addArgs("/c", "mklink", "/d", "/j", targetLink.toString(), fallbackPath.toString()).run();
   }
 
   @Override
@@ -438,11 +422,9 @@ public class FileAccessImpl implements FileAccess {
     try {
       adaptedSource = adaptPath(source, targetLink, relative);
     } catch (IOException e) {
-      throw new IllegalStateException("Failed to adapt source for source (" + source + ") target (" + targetLink
-          + ") and relative (" + relative + ")", e);
+      throw new IllegalStateException("Failed to adapt source for source (" + source + ") target (" + targetLink + ") and relative (" + relative + ")", e);
     }
-    this.context.trace("Creating {} symbolic link {} pointing to {}", adaptedSource.isAbsolute() ? "" : "relative",
-        targetLink, adaptedSource);
+    this.context.trace("Creating {} symbolic link {} pointing to {}", adaptedSource.isAbsolute() ? "" : "relative", targetLink, adaptedSource);
 
     try {
       deleteLinkIfExists(targetLink);
@@ -455,15 +437,15 @@ public class FileAccessImpl implements FileAccess {
     } catch (FileSystemException e) {
       if (SystemInfoImpl.INSTANCE.isWindows()) {
         this.context.info("Due to lack of permissions, Microsoft's mklink with junction had to be used to create "
-            + "a Symlink. See https://github.com/devonfw/IDEasy/blob/main/documentation/symlinks.asciidoc for "
-            + "further details. Error was: " + e.getMessage());
+            + "a Symlink. See https://github.com/devonfw/IDEasy/blob/main/documentation/symlinks.asciidoc for " + "further details. Error was: "
+            + e.getMessage());
         createWindowsJunction(adaptedSource, targetLink);
       } else {
         throw new RuntimeException(e);
       }
     } catch (IOException e) {
-      throw new IllegalStateException("Failed to create a " + (adaptedSource.isAbsolute() ? "" : "relative")
-          + "symbolic link " + targetLink + " pointing to " + source, e);
+      throw new IllegalStateException(
+          "Failed to create a " + (adaptedSource.isAbsolute() ? "" : "relative") + "symbolic link " + targetLink + " pointing to " + source, e);
     }
   }
 
@@ -521,8 +503,7 @@ public class FileAccessImpl implements FileAccess {
       return;
     }
     Path tmpDir = createTempDir("extract-" + archiveFile.getFileName());
-    this.context.trace("Trying to extract the downloaded file {} to {} and move it to {}.", archiveFile, tmpDir,
-        targetDir);
+    this.context.trace("Trying to extract the downloaded file {} to {} and move it to {}.", archiveFile, tmpDir, targetDir);
     String filename = archiveFile.getFileName().toString();
     TarCompression tarCompression = TarCompression.of(filename);
     if (tarCompression != null) {
@@ -567,21 +548,19 @@ public class FileAccessImpl implements FileAccess {
 
   /**
    * @param path the {@link Path} to start the recursive search from.
-   * @return the deepest subdir {@code s} of the passed path such that all directories between {@code s} and the passed
-   *         path (including {@code s}) are the sole item in their respective directory and {@code s} is not named
-   *         "bin".
+   * @return the deepest subdir {@code s} of the passed path such that all directories between {@code s} and the passed path (including {@code s}) are the sole
+   * item in their respective directory and {@code s} is not named "bin".
    */
   private Path getProperInstallationSubDirOf(Path path, Path archiveFile) {
 
     try (Stream<Path> stream = Files.list(path)) {
       Path[] subFiles = stream.toArray(Path[]::new);
       if (subFiles.length == 0) {
-        throw new CliException("The downloaded package " + archiveFile
-            + " seems to be empty as you can check in the extracted folder " + path);
+        throw new CliException("The downloaded package " + archiveFile + " seems to be empty as you can check in the extracted folder " + path);
       } else if (subFiles.length == 1) {
         String filename = subFiles[0].getFileName().toString();
-        if (!filename.equals(IdeContext.FOLDER_BIN) && !filename.equals(IdeContext.FOLDER_CONTENTS)
-            && !filename.endsWith(".app") && Files.isDirectory(subFiles[0])) {
+        if (!filename.equals(IdeContext.FOLDER_BIN) && !filename.equals(IdeContext.FOLDER_CONTENTS) && !filename.endsWith(".app") && Files.isDirectory(
+            subFiles[0])) {
           return getProperInstallationSubDirOf(subFiles[0], archiveFile);
         }
       }
@@ -604,8 +583,7 @@ public class FileAccessImpl implements FileAccess {
   }
 
   /**
-   * @param permissions The integer as returned by {@link TarArchiveEntry#getMode()} that represents the file
-   *        permissions of a file on a Unix file system.
+   * @param permissions The integer as returned by {@link TarArchiveEntry#getMode()} that represents the file permissions of a file on a Unix file system.
    * @return A String representing the file permissions. E.g. "rwxrwxr-x" or "rw-rw-r--"
    */
   public static String generatePermissionString(int permissions) {
@@ -707,7 +685,7 @@ public class FileAccessImpl implements FileAccess {
     }
     this.context.debug("Deleting {} ...", path);
     try {
-      if (Files.isSymbolicLink(path)) {
+      if (Files.isSymbolicLink(path) || isJunction(path)) {
         Files.delete(path);
       } else {
         deleteRecursive(path);
@@ -810,7 +788,7 @@ public class FileAccessImpl implements FileAccess {
           return filePath;
         }
       } catch (Exception e) {
-        throw new IllegalStateException("Unexpected error while checking existence of file "+filePath+" .", e);
+        throw new IllegalStateException("Unexpected error while checking existence of file " + filePath + " .", e);
       }
     }
     return null;


### PR DESCRIPTION
Fixes: #264
Fixes: #230 

After extensive research and several attempts, it's evident that the reported issue isn't a bug but rather a result of **using devon instead of ideasy** while installing new tools. For instance:

The problem we were getting was that the moving of the installed software directory fails because of the windows file lock on the directory, e.g.` java.lang.IllegalStateException: Failed to move D:\projects\IDEasy\software\java to D:\projects\IDEasy\updates\backups\2024-03-22\java_17-13-29`.

This issue specifically arises when the tools are installed using 'devon' (**_as a directory_**) instead of 'ideasy' (**_as a junction_**).
When installed with 'ideasy', the file lock automatically applies to the target path of the junction `IDE_ROOT/_ide/software/default/...`, allowing the deletion of the junction itself in `IDE_HOME/software/`. Consequently, updating a tool version becomes seamless.

The only fix it had to be implemented is for a another exception that was arising in the `delete `method in `FileaccessImpl`, that wasn't properly recognizing and deleting junctions.

```diff
-      if (Files.isSymbolicLink(path)) {
+      if (Files.isSymbolicLink(path) || isJunction(path)) {
        Files.delete(path);
```
