### PR TITLE
#287: return empty string instead of null in method getMavenArgs

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
@@ -398,7 +398,7 @@ public interface IdeContext extends IdeLogger {
   GitContext getGitContext();
 
   /**
-   * @return the String value for the variable MAVEN_ARGS, or null if called outside an IDEasy installation.
+   * @return the String value for the variable MAVEN_ARGS, or empty String if called outside an IDEasy installation.
    */
   default String getMavenArgs() {
 
@@ -406,14 +406,14 @@ public interface IdeContext extends IdeLogger {
     if (ideHome != null) {
       return "-s " + ideHome.resolve("conf/.m2/settings.xml");
     } else {
-      return null;
+      return "";
     }
   }
 
   /**
-   * Updates the current working directory (CWD) and configures the environment paths according to the specified parameters.
-   * This method is central to changing the IDE's notion of where it operates, affecting where configurations, workspaces,
-   * settings, and other resources are located or loaded from.
+   * Updates the current working directory (CWD) and configures the environment paths according to the specified parameters. This method is central to changing
+   * the IDE's notion of where it operates, affecting where configurations, workspaces, settings, and other resources are located or loaded from.
+   *
    * @return the current {@link Step} of processing.
    */
   Step getCurrentStep();
@@ -446,9 +446,8 @@ public interface IdeContext extends IdeLogger {
   Step newStep(boolean silent, String name, Object... parameters);
 
   /**
-   * Updates the current working directory (CWD) and configures the environment paths according to the specified
-   * parameters. This method is central to changing the IDE's notion of where it operates, affecting where
-   * configurations, workspaces, settings, and other resources are located or loaded from.
+   * Updates the current working directory (CWD) and configures the environment paths according to the specified parameters. This method is central to changing
+   * the IDE's notion of where it operates, affecting where configurations, workspaces, settings, and other resources are located or loaded from.
    *
    * @param ideHome The path to the IDE home directory.
    */
@@ -458,9 +457,8 @@ public interface IdeContext extends IdeLogger {
   }
 
   /**
-   * Updates the current working directory (CWD) and configures the environment paths according to the specified
-   * parameters. This method is central to changing the IDE's notion of where it operates, affecting where
-   * configurations, workspaces, settings, and other resources are located or loaded from.
+   * Updates the current working directory (CWD) and configures the environment paths according to the specified parameters. This method is central to changing
+   * the IDE's notion of where it operates, affecting where configurations, workspaces, settings, and other resources are located or loaded from.
    *
    * @param userDir The path to set as the current working directory.
    * @param workspace The name of the workspace within the IDE's environment.


### PR DESCRIPTION
fixes #287 
Now the method getMavenArgs() returns an empty string instead of null.