### PR TITLE
#279: ability to  skip tools and repositories during create commandlet

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import com.devonfw.tools.ide.context.GitContext;
 import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.property.FlagProperty;
 import com.devonfw.tools.ide.property.StringProperty;
 import com.devonfw.tools.ide.repo.CustomTool;
 import com.devonfw.tools.ide.step.Step;
@@ -23,6 +24,9 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
   /** {@link StringProperty} for the settings repository URL. */
   protected final StringProperty settingsRepo;
 
+  /** {@link FlagProperty} for skipping installation/updating of tools */
+  protected final FlagProperty skipTools;
+
   /**
    * The constructor.
    *
@@ -32,6 +36,7 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
 
     super(context);
     this.settingsRepo = new StringProperty("", false, "settingsRepository");
+    this.skipTools = new FlagProperty("--skip-tools", false, "skipTools");
   }
 
   @Override
@@ -57,7 +62,10 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
     } finally {
       step.end();
     }
-    updateSoftware();
+
+    if (!skipTools.isTrue()) {
+      updateSoftware();
+    }
   }
 
   private void setupConf(Path template, Path conf) {

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/CreateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/CreateCommandlet.java
@@ -2,6 +2,7 @@ package com.devonfw.tools.ide.commandlet;
 
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.io.FileAccess;
+import com.devonfw.tools.ide.property.FlagProperty;
 import com.devonfw.tools.ide.property.StringProperty;
 
 import java.nio.file.Path;
@@ -11,7 +12,11 @@ import java.nio.file.Path;
  */
 public class CreateCommandlet extends AbstractUpdateCommandlet {
 
+  /** {@link StringProperty} for the name of the new project */
   public final StringProperty newProject;
+
+  /** {@link FlagProperty} for skipping the setup of git repositories */
+  public final FlagProperty skipRepositories;
 
   /**
    * The constructor.
@@ -24,6 +29,8 @@ public class CreateCommandlet extends AbstractUpdateCommandlet {
     addKeyword(getName());
     newProject = add(new StringProperty("", true, "project"));
     add(this.settingsRepo);
+    this.skipRepositories = add(new FlagProperty("--skip-repositories", false, "skipRepositories"));
+    add(this.skipTools);
   }
 
   @Override
@@ -54,7 +61,9 @@ public class CreateCommandlet extends AbstractUpdateCommandlet {
     initializeProject(newProjectPath);
     this.context.setIdeHome(newProjectPath);
     super.run();
-    updateRepositories();
+    if (!this.skipRepositories.isTrue()) {
+      updateRepositories();
+    }
     this.context.success("Successfully created new project '{}'.", newProjectName);
   }
 


### PR DESCRIPTION
PS: in files changed you'll notice that AbstractUpdateCommandlet is changed from CRLF to LF, this is IMO due to .gitattributes forcing LF EOL. Maybe the solution to this is to run `git add --renormalize .` on the main branch so that all files now change to LF.

Real changes in AbstractUpdateCommandlet are in line 28, 29 and 66.