### PR TITLE
#435 Fix version pattern for NpmUrlUpdater

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/npm/NpmUrlUpdater.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/npm/NpmUrlUpdater.java
@@ -1,9 +1,9 @@
 package com.devonfw.tools.ide.tool.npm;
 
-import java.util.regex.Pattern;
-
 import com.devonfw.tools.ide.url.model.folder.UrlVersion;
 import com.devonfw.tools.ide.url.updater.WebsiteUrlUpdater;
+
+import java.util.regex.Pattern;
 
 /**
  * {@link WebsiteUrlUpdater} for npm (node package manager).
@@ -31,7 +31,7 @@ public class NpmUrlUpdater extends WebsiteUrlUpdater {
   @Override
   protected Pattern getVersionPattern() {
 
-    return Pattern.compile("npm-(\\d\\.\\d{1,2}\\.\\d+)");
+    return Pattern.compile("npm-(\\d{1,2}\\.\\d{1,2}\\.\\d+)");
   }
 
   @Override


### PR DESCRIPTION
Fixes #435. 

While a rewrite of `NpmUrlUpdater` might be necessary to not use `WebsiteUrlUpdater` to parse versions from JSON, this provides a quick fix to additionally make versions 10.0.0, 10.1.0, 10.2.0, 10.2.1, 10.2.2, **10.2.3**, 10.2.4, 10.2.5, 10.3.0, 10.4.0, 10.5.0, 10.5.1, 10.5.2, 10.6.0, 10.7.0, 10.8.0, and 10.8.1 of npm available.