### PR TITLE
#337: removed march=native

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -223,7 +223,6 @@
                 <arg>--enable-url-protocols=http,https</arg>
                 <arg>-H:IncludeResources="nls/.*"</arg>
                 <arg>--initialize-at-build-time=org.apache.commons.compress</arg>
-                <arg>-march=native</arg>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
Fixes: #337 

Implements:
* removed -march=native (because builds were not working)