### PR TITLE
#308 Group commandlets into non-tool and tool

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/HelpCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/HelpCommandlet.java
@@ -11,6 +11,7 @@ import com.devonfw.tools.ide.nls.NlsBundle;
 import com.devonfw.tools.ide.property.CommandletProperty;
 import com.devonfw.tools.ide.property.KeywordProperty;
 import com.devonfw.tools.ide.property.Property;
+import com.devonfw.tools.ide.tool.ToolCommandlet;
 import com.devonfw.tools.ide.version.IdeVersion;
 
 /**
@@ -68,7 +69,6 @@ public final class HelpCommandlet extends Commandlet {
     if (cmd == null) {
       this.context.info(bundle.get("usage") + " ide [option]* [[commandlet] [arg]*]");
       this.context.info("");
-      this.context.info(bundle.get("commandlets"));
       printCommandlets(bundle);
     } else {
       printCommandletHelp(bundle, cmd);
@@ -129,15 +129,25 @@ public final class HelpCommandlet extends Commandlet {
   private void printCommandlets(NlsBundle bundle) {
 
     Args commandlets = new Args();
+    Args toolcommandlets = new Args();
     for (Commandlet cmd : this.context.getCommandletManager().getCommandlets()) {
       String key = cmd.getName();
       String keyword = cmd.getKeyword();
       if ((keyword != null) && !keyword.equals(key)) {
         key = key + "(" + keyword + ")";
       }
-      commandlets.add(key, bundle.get(cmd));
+      if (cmd instanceof ToolCommandlet) {
+        toolcommandlets.add(key, bundle.get(cmd));
+      } else {
+        commandlets.add(key, bundle.get(cmd));
+      }
     }
+
+    this.context.info(bundle.get("commandlets"));
     commandlets.print(IdeLogLevel.INTERACTION);
+    this.context.info("");
+    this.context.info(bundle.get("toolcommandlets"));
+    toolcommandlets.print(IdeLogLevel.INTERACTION);
   }
 
   private void collectOptions(Args options, Commandlet cmd, NlsBundle bundle) {

--- a/cli/src/main/resources/nls/Help.properties
+++ b/cli/src/main/resources/nls/Help.properties
@@ -116,6 +116,7 @@ opt.--skip-tools=skip the installation/update of tools.
 opt.--trace=enable trace logging.
 opt.--version=Print the IDE version and exit.
 options=Options:
+toolcommandlets=Available tool commandlets:
 usage=Usage:
 val.args=The commandline arguments to pass to the tool.
 val.commandlet=The selected commandlet (use "ide help" to list all commandlets).

--- a/cli/src/main/resources/nls/Help_de.properties
+++ b/cli/src/main/resources/nls/Help_de.properties
@@ -116,6 +116,7 @@ opt.--skip-tools=überspringt die Installation/Aktualisierung der Tools.
 opt.--trace=Aktiviert Trace-Ausgaben (detaillierte Fehleranalyse).
 opt.--version=Zeigt die IDE Version an und beendet das Programm.
 options=Optionen:
+toolcommandlets=Verfügbare Werkzeug Kommandos:
 usage=Verwendung:
 val.args=Die Kommandozeilen-Argumente zur Übergabe an das Werkzeug.
 val.commandlet=Das ausgewählte Commandlet ("ide help" verwenden, um alle Commandlets aufzulisten).


### PR DESCRIPTION
Closes #308. The output of ide help now looks as follows: 

```
ide> help
__       ___ ___  ___
\ \     |_ _|   \| __|__ _ ____ _
 > >     | || |) | _|/ _` (_-< || |
/_/ ___ |___|___/|___\__,_/__/\_, |
   |___|                       |__/

Current version of IDE is SNAPSHOT
Usage: ide [option]* [[commandlet] [arg]*]

Available commandlets:
--version      Print the version of IDEasy.
build          Runs a build job with given arguments.
complete       Internal commandlet for bash auto-completion.
create         Create a new IDEasy project.
env            Print the environment variables to set and export.
get-edition    Get the edition of the selected tool.
get-version    Get the version of the selected tool.
help           Prints this help.
install        Install the selected tool.
list-editions  List the available editions of the selected tool.
list-versions  List the available versions of the selected tool.
repository     Setup pre-configured git repositories (clone, build, import).
set-edition    Set the edition of the selected tool.
set-version    Set the version of the selected tool.
shell          Commandlet to start built-in shell with advanced auto-completion.
uninstall      Uninstall the selected tool.
update         Pull your settings and apply updates (software, configuration and repositories).

Available tool commandlets:
android-studio  Tool commandlet for Android Studio (IDE).
aws             Tool commandlet for AWS CLI.
az              Tool commandlet for Azure CLI.
cobigen         Tool commandlet for Cobigen (code-generator).
docker          Tool commandlet for Docker.
dotnet          Tool commandlet for dotnet.
eclipse         Tool commandlet for Eclipse (IDE).
gcviewer        Tool commandlet for GC Viewer (View garbage collector logs of Java).
gh              Tool commandlet for GitHub CLI.
graalvm         Tool commandlet for GraalVm (Java with native-image).
gradle          Tool commandlet for Gradle (Build-Tool).
helm            Tool commandlet for Helm (Kubernetes Package Manager).
intellij        Tool commandlet for IntelliJ (IDE)
jasypt          Tool commandlet for Jasypt (encryption/decryption).
java            Tool commandlet for Java (OpenJDK).
jmc             Tool commandlet for JDK Mission Control (performance analysis).
kotlinc         Tool commandlet for Kotlin (compiler for JRE language).
kotlincnative   Tool commandlet for Kotlin-Native (compiler for JRE language).
lazydocker      Tool commandlet for LazyDocker.
mvn             Tool commandlet for Maven (Build-Tool).
node            Tool commandlet for Node.js (JavaScript runtime).
npm             Tool commandlet for Npm (JavaScript Node Package Manager).
oc              Tool commandlet for Openshift CLI (Kubernetes management tool).
pgadmin         Tool commandlet for pgAdmin.
quarkus         Tool commandlet for Quarkus (framework for cloud-native apps).
sonar           Tool commandlet for SonarQube.
terraform       Tool commandlet for Terraform.
tomcat          Tool commandlet for Tomcat
vscode          Tool commandlet for Visual Studio Code (IDE).

Options:
--locale        the locale (e.g. '--locale=de' for German language).
-b | --batch    enable batch mode (non-interactive).
-d | --debug    enable debug logging.
-f | --force    enable force mode.
-o | --offline  enable offline mode (skip updates or git pull, fail downloads or git clone).
-q | --quiet    disable info logging (only log success, warning or error).
-t | --trace    enable trace logging.

To get help details about a commandlet, simply call "ide help <commandlet>".
ide> 
```