### PR TITLE
#489: Fix separator comparison

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
@@ -216,11 +216,18 @@ public class VersionSegment implements VersionObject<VersionSegment> {
     if (!lettersResult.isEqual()) {
       return lettersResult;
     }
-    //a version with a separator is greater than a version without, a version with a "." separator is greater than a version with a "_" separator
-    if ((!"".equals(this.separator) && "".equals(other.separator)) || (".".equals(this.separator) && "_".equals(other.separator))) {
-      return VersionComparisonResult.GREATER;
-    } else if (("".equals(this.separator) && !"".equals(other.separator)) || ("_".equals(this.separator) && ".".equals(other.separator))) {
-      return VersionComparisonResult.LESS;
+    if ((!"_".equals(this.separator) && "_".equals(other.separator))) {
+      if ("".equals(this.separator)) {
+        return VersionComparisonResult.LESS;
+      } else {
+        return VersionComparisonResult.GREATER;
+      }
+    } else if (("_".equals(this.separator) && !"_".equals(other.separator))) {
+      if ("".equals(other.separator)) {
+        return VersionComparisonResult.GREATER;
+      } else {
+        return VersionComparisonResult.LESS;
+      }
     }
 
     if (this.number < other.number) {

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
@@ -216,9 +216,10 @@ public class VersionSegment implements VersionObject<VersionSegment> {
     if (!lettersResult.isEqual()) {
       return lettersResult;
     }
-    if (!"_".equals(this.separator) && "_".equals(other.separator)) {
+    //a version with a separator is greater than a version without, a version with a "." separator is greater than a version with a "_" separator
+    if ((!"".equals(this.separator) && "".equals(other.separator)) || (".".equals(this.separator) && "_".equals(other.separator))) {
       return VersionComparisonResult.GREATER;
-    } else if ("_".equals(this.separator) && !"_".equals(other.separator)) {
+    } else if (("".equals(this.separator) && !"".equals(other.separator)) || ("_".equals(this.separator) && ".".equals(other.separator))) {
       return VersionComparisonResult.LESS;
     }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
@@ -216,13 +216,13 @@ public class VersionSegment implements VersionObject<VersionSegment> {
     if (!lettersResult.isEqual()) {
       return lettersResult;
     }
-    if ((!"_".equals(this.separator) && "_".equals(other.separator))) {
+    if (!"_".equals(this.separator) && "_".equals(other.separator)) {
       if ("".equals(this.separator)) {
         return VersionComparisonResult.LESS;
       } else {
         return VersionComparisonResult.GREATER;
       }
-    } else if (("_".equals(this.separator) && !"_".equals(other.separator))) {
+    } else if ("_".equals(this.separator) && !"_".equals(other.separator)) {
       if ("".equals(other.separator)) {
         return VersionComparisonResult.GREATER;
       } else {

--- a/cli/src/test/java/com/devonfw/tools/ide/version/VersionRangeTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/version/VersionRangeTest.java
@@ -89,9 +89,16 @@ public class VersionRangeTest extends Assertions {
     assertThat(VersionRange.of("1.2,3.4").contains(VersionIdentifier.of("2"))).isTrue();
     assertThat(VersionRange.of("1.2,3.4").contains(VersionIdentifier.of("3.4"))).isTrue();
 
+    assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("1.2"))).isFalse();
     assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("1.2.1"))).isTrue();
     assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("2"))).isTrue();
     assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("3.3.9"))).isTrue();
+    assertThat(VersionRange.of("(1.2,3.4)").contains(VersionIdentifier.of("3.4"))).isFalse();
+
+    assertThat(VersionRange.of("[11,22]").contains(VersionIdentifier.of("11"))).isTrue();
+    assertThat(VersionRange.of("[11,22]").contains(VersionIdentifier.of("22"))).isTrue();
+    assertThat(VersionRange.of("[11,22]").contains(VersionIdentifier.of("22.1"))).isFalse();
+    assertThat(VersionRange.of("[11,22]").contains(VersionIdentifier.of("22_1"))).isFalse();
   }
 
   /**


### PR DESCRIPTION
Closes #489. 

Fixes the issue, now ensures that "22_1 > 22", while still "22_1 < 22.1".
