### PR TITLE
added properties formatting to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,12 @@ ij_smart_tabs = false
 ij_visual_guides =
 ij_wrap_on_typing = false
 
+[*.properties]
+ij_properties_align_group_field_declarations = false
+ij_properties_keep_blank_lines = false
+ij_properties_key_value_delimiter = equals
+ij_properties_spaces_around_key_value_delimiter = false
+
 [*.java]
 ij_java_align_consecutive_assignments = false
 ij_java_align_consecutive_variable_declarations = false


### PR DESCRIPTION
prevent that IntelliJ formatter removes blank lines from `*.properties` files.