### PR TITLE
#463: Set default Maven m2 repository location back to user home

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
@@ -475,7 +475,7 @@ public interface IdeContext extends IdeLogger {
   }
 
   /**
-   * @return the String value for the variable M2_REPO, or null if called outside an IDEasy installation.
+   * @return the String value for the variable M2_REPO, or falls back to the default USER_HOME/.m2 location if called outside an IDEasy installation.
    */
   default Path getMavenRepository() {
 
@@ -486,6 +486,9 @@ public interface IdeContext extends IdeLogger {
         Path m2LegacyFolder = confPath.resolve(Mvn.MVN_CONFIG_LEGACY_FOLDER);
         if (Files.isDirectory(m2LegacyFolder)) {
           m2Folder = m2LegacyFolder;
+        } else {
+          // fallback to USER_HOME/.m2 folder
+          m2Folder = getUserHome().resolve(Mvn.MVN_CONFIG_LEGACY_FOLDER);
         }
       }
       return m2Folder.resolve("repository");

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import com.devonfw.tools.ide.commandlet.InstallCommandlet;
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeTestContext;
+import com.devonfw.tools.ide.variable.IdeVariables;
 
 /**
  * Integration test of {@link Mvn}.
@@ -83,6 +84,22 @@ public class MvnTest extends AbstractIdeContextTest {
     Path settingsSecurityFile = context.getConfPath().resolve(Mvn.MVN_CONFIG_FOLDER).resolve(Mvn.SETTINGS_SECURITY_FILE);
     assertThat(settingsSecurityFile).exists();
     assertFileContent(settingsSecurityFile, List.of("masterPassword"));
+  }
+
+  /**
+   * Tests if the user is starting IDEasy without a Maven repository, IDEasy should fall back to USER_HOME/.m2/repository.
+   * <p>
+   * See: <a href="https://github.com/devonfw/IDEasy/issues/463">#463</a>
+   */
+  @Test
+  public void testMavenRepositoryPathFallsBackToUserHome() {
+    // arrange
+    String path = "project/workspaces";
+    // act
+    IdeTestContext context = newContext(PROJECT_MVN, path, false);
+    Path mavenRepository = context.getUserHome().resolve(".m2").resolve("repository");
+    // assert
+    assertThat(IdeVariables.M2_REPO.get(context)).isEqualTo(mavenRepository);
   }
 
   private void assertFileContent(Path filePath, List<String> expectedValues) throws IOException {

--- a/cli/src/test/resources/ide-projects/mvn/project/home/environment.properties
+++ b/cli/src/test/resources/ide-projects/mvn/project/home/environment.properties
@@ -1,0 +1,2 @@
+# if this file is present, it will replace and mock System.getenv in the text context
+PATH=${IDE_ROOT}/_ide/bin


### PR DESCRIPTION
Fixes: #463 

Implements:
* added fallback to USER_HOME for mvn repository
* added new testMavenRepositoryPathFallsBackToUserHome to MvnTest
* added environment.properties to mvn test resources (required for proper simulation of USER_HOME)