### PR TITLE
#585: fix if FETCH_HEAD does not exist, also fixed behavior on force mode

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/RepositoryCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/RepositoryCommandlet.java
@@ -95,7 +95,7 @@ public class RepositoryCommandlet extends Commandlet {
     this.context.getFileAccess().mkdirs(workspacePath);
 
     Path repositoryPath = workspacePath.resolve(repository);
-    this.context.getGitContext().pullOrClone(gitUrl, repositoryConfig.gitBranch(), repositoryPath);
+    this.context.getGitContext().pullOrClone(gitUrl, repositoryPath, repositoryConfig.gitBranch());
 
     String buildCmd = repositoryConfig.buildCmd();
     this.context.debug("Building repository with ide command: {}", buildCmd);

--- a/cli/src/main/java/com/devonfw/tools/ide/context/GitContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/GitContext.java
@@ -15,6 +15,9 @@ public interface GitContext {
   /** The default git url of the settings repository for IDEasy developers */
   String DEFAULT_SETTINGS_GIT_URL = "https://github.com/devonfw/ide-settings.git";
 
+  /** The name of the internal metadata folder of a git repository. */
+  String GIT_FOLDER = ".git";
+
   /**
    * Checks if the Git repository in the specified target folder needs an update by inspecting the modification time of a magic file.
    *

--- a/cli/src/main/java/com/devonfw/tools/ide/context/GitContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/GitContext.java
@@ -119,12 +119,12 @@ public interface GitContext {
    * Runs a git pull or a git clone.
    *
    * @param gitRepoUrl the git remote URL to clone from.
-   * @param branch the explicit name of the branch to checkout e.g. "main" or {@code null} to use the default branch.
    * @param targetRepository the {@link Path} to the target folder where the git repository should be cloned or pulled. It is not the parent directory where
    *     git will by default create a sub-folder by default on clone but the final folder that will contain the ".git" subfolder.
+   * @param branch the explicit name of the branch to checkout e.g. "main" or {@code null} to use the default branch.
    * @throws CliOfflineException if offline and cloning is needed.
    */
-  void pullOrClone(String gitRepoUrl, String branch, Path targetRepository);
+  void pullOrClone(String gitRepoUrl, Path targetRepository, String branch);
 
   /**
    * Runs a git clone.

--- a/cli/src/main/java/com/devonfw/tools/ide/context/GitContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/GitContextImpl.java
@@ -1,11 +1,8 @@
 package com.devonfw.tools.ide.context;
 
-import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.FileTime;
-import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.List;
@@ -23,10 +20,6 @@ import com.devonfw.tools.ide.process.ProcessResult;
  * Implements the {@link GitContext}.
  */
 public class GitContextImpl implements GitContext {
-
-  private static final Duration GIT_PULL_CACHE_DELAY_MILLIS = Duration.ofMinutes(30);
-
-  private static final Duration GIT_FETCH_CACHE_DELAY = Duration.ofMinutes(5);
 
   private final IdeContext context;
 
@@ -47,93 +40,19 @@ public class GitContextImpl implements GitContext {
   @Override
   public void pullOrCloneIfNeeded(String repoUrl, String branch, Path targetRepository) {
 
-    Path gitDirectory = targetRepository.resolve(".git");
-
-    // Check if the .git directory exists
-    if (!this.context.isForceMode() && Files.isDirectory(gitDirectory)) {
-      Path magicFilePath = gitDirectory.resolve("HEAD");
-      long currentTime = System.currentTimeMillis();
-      // Get the modification time of the magic file
-      try {
-        long fileModifiedTime = Files.getLastModifiedTime(magicFilePath).toMillis();
-        // Check if the file modification time is older than the delta threshold
-        if ((currentTime - fileModifiedTime > GIT_PULL_CACHE_DELAY_MILLIS.toMillis())) {
-          pullOrClone(repoUrl, targetRepository);
-          try {
-            Files.setLastModifiedTime(magicFilePath, FileTime.fromMillis(currentTime));
-          } catch (IOException e) {
-            this.context.warning().log(e, "Could not update modification-time of {}", magicFilePath);
-          }
-        }
-        return;
-      } catch (IOException e) {
-        this.context.error(e);
-      }
-    }
-    // If the .git directory does not exist or in case of an error, perform git operation directly
-    pullOrClone(repoUrl, branch, targetRepository);
+    GitOperation.PULL_OR_CLONE.executeIfNeeded(this, repoUrl, targetRepository, null, branch);
   }
 
   @Override
   public boolean fetchIfNeeded(Path targetRepository) {
 
-    Optional<String[]> remoteAndBranchOpt = getLocalRemoteAndBranch(targetRepository);
-
-    if (remoteAndBranchOpt.isEmpty()) {
-      context.warning("Could not determine the remote or branch for the repository at " + targetRepository);
-      return false;
-    }
-
-    String[] remoteAndBranch = remoteAndBranchOpt.get();
-    String remoteName = remoteAndBranch[0];
-    String branch = remoteAndBranch[1];
-
-    return fetchIfNeeded(targetRepository, remoteName, branch);
+    return fetchIfNeeded(targetRepository, null, null);
   }
 
   @Override
-  public boolean fetchIfNeeded(Path targetRepository, String remoteName, String branch) {
+  public boolean fetchIfNeeded(Path targetRepository, String remote, String branch) {
 
-    if (isFetchNeeded(targetRepository)) {
-      fetch(targetRepository, remoteName, branch);
-      // TODO: see JavaDoc, implementation incorrect. fetch needs to return boolean if changes have been fetched
-      // and then this result must be returned - or JavaDoc needs to changed
-      return true;
-    } else {
-      this.context.debug("Skipping git fetch on {} since already fetched short time ago to avoid overhead", targetRepository);
-      return false;
-    }
-  }
-
-  private boolean isFetchNeeded(Path targetRepository) {
-
-    if (this.context.isOffline()) {
-      return false;
-    } else if (this.context.isForceMode()) {
-      return true;
-    }
-    Path gitDirectory = targetRepository.resolve(".git");
-    if (!Files.isDirectory(gitDirectory)) {
-      return true; // technically this is an error that will be triggered by fetch method
-    }
-    Path fetchHeadPath = gitDirectory.resolve("FETCH_HEAD");
-    if (Files.exists(fetchHeadPath)) {
-      long currentTime = System.currentTimeMillis();
-      try {
-        long fileModifiedTime = Files.getLastModifiedTime(fetchHeadPath).toMillis();
-        // Check if the file modification time is older than the delta threshold
-        if ((currentTime - fileModifiedTime > GIT_FETCH_CACHE_DELAY.toMillis())) {
-          return true;
-        } else {
-          return false;
-        }
-      } catch (IOException e) {
-        this.context.warning().log(e, "Could not update modification-time of {}", fetchHeadPath);
-        return true;
-      }
-    } else {
-      return true;
-    }
+    return GitOperation.FETCH.executeIfNeeded(this, null, targetRepository, remote, branch);
   }
 
   @Override
@@ -187,7 +106,7 @@ public class GitContextImpl implements GitContext {
       throw new IllegalArgumentException("Invalid git URL '" + gitRepoUrl + "'!");
     }
 
-    if (Files.isDirectory(targetRepository.resolve(".git"))) {
+    if (Files.isDirectory(targetRepository.resolve(GIT_FOLDER))) {
       // checks for remotes
       this.processContext.directory(targetRepository);
       ProcessResult result = this.processContext.addArg("remote").run(ProcessMode.DEFAULT_CAPTURE);
@@ -283,6 +202,21 @@ public class GitContextImpl implements GitContext {
 
   @Override
   public void fetch(Path targetRepository, String remote, String branch) {
+
+    if ((remote == null) || (branch == null)) {
+      Optional<String[]> remoteAndBranchOpt = getLocalRemoteAndBranch(targetRepository);
+      if (remoteAndBranchOpt.isEmpty()) {
+        context.warning("Could not determine the remote or branch for the git repository at {}", targetRepository);
+        return; // false;
+      }
+      String[] remoteAndBranch = remoteAndBranchOpt.get();
+      if (remote == null) {
+        remote = remoteAndBranch[0];
+      }
+      if (branch == null) {
+        branch = remoteAndBranch[1];
+      }
+    }
 
     this.processContext.directory(targetRepository);
     ProcessResult result;
@@ -394,6 +328,10 @@ public class GitContextImpl implements GitContext {
     return null;
   }
 
+  IdeContext getContext() {
+
+    return this.context;
+  }
 }
 
 

--- a/cli/src/main/java/com/devonfw/tools/ide/context/GitContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/GitContextImpl.java
@@ -40,7 +40,7 @@ public class GitContextImpl implements GitContext {
   @Override
   public void pullOrCloneIfNeeded(String repoUrl, String branch, Path targetRepository) {
 
-    GitOperation.PULL_OR_CLONE.executeIfNeeded(this, repoUrl, targetRepository, null, branch);
+    GitOperation.PULL_OR_CLONE.executeIfNeeded(this.context, repoUrl, targetRepository, null, branch);
   }
 
   @Override
@@ -52,7 +52,7 @@ public class GitContextImpl implements GitContext {
   @Override
   public boolean fetchIfNeeded(Path targetRepository, String remote, String branch) {
 
-    return GitOperation.FETCH.executeIfNeeded(this, null, targetRepository, remote, branch);
+    return GitOperation.FETCH.executeIfNeeded(this.context, null, targetRepository, remote, branch);
   }
 
   @Override
@@ -93,11 +93,11 @@ public class GitContextImpl implements GitContext {
   @Override
   public void pullOrClone(String gitRepoUrl, Path targetRepository) {
 
-    pullOrClone(gitRepoUrl, null, targetRepository);
+    pullOrClone(gitRepoUrl, targetRepository, null);
   }
 
   @Override
-  public void pullOrClone(String gitRepoUrl, String branch, Path targetRepository) {
+  public void pullOrClone(String gitRepoUrl, Path targetRepository, String branch) {
 
     Objects.requireNonNull(targetRepository);
     Objects.requireNonNull(gitRepoUrl);

--- a/cli/src/main/java/com/devonfw/tools/ide/context/GitOperation.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/GitOperation.java
@@ -1,0 +1,177 @@
+package com.devonfw.tools.ide.context;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+/**
+ * An {@link Enum} for specific Git operations where we add caching support.
+ *
+ * @see GitContextImpl
+ */
+public enum GitOperation {
+
+  FETCH("fetch", "FETCH_HEAD", Duration.ofMinutes(5)) {
+    @Override
+    protected boolean execute(GitContextImpl gitContext, String gitRepoUrl, Path targetRepository, String remote, String branch) {
+
+      gitContext.fetch(targetRepository, remote, branch);
+      // TODO: see JavaDoc, implementation incorrect. fetch needs to return boolean if changes have been fetched
+      // and then this result must be returned - or JavaDoc needs to changed
+      return true;
+    }
+  },
+
+  PULL_OR_CLONE("pull/clone", "HEAD", Duration.ofMinutes(30)) {
+    @Override
+    protected boolean execute(GitContextImpl gitContext, String gitRepoUrl, Path targetRepository, String remote, String branch) {
+
+      gitContext.pullOrClone(gitRepoUrl, branch, targetRepository);
+      return true;
+    }
+  };
+
+  private final String name;
+
+  private final String timestampFilename;
+
+  private final Duration cacheDuration;
+
+  private GitOperation(String name, String timestampFilename, Duration cacheDuration) {
+
+    this.name = name;
+    this.timestampFilename = timestampFilename;
+    this.cacheDuration = cacheDuration;
+  }
+
+  /**
+   * @return the human readable name of this {@link GitOperation}.
+   */
+  public String getName() {
+
+    return this.name;
+  }
+
+  /**
+   * @return the name of the file inside the ".git" folder to get the timestamp (modification time) from in order to determine how long the last
+   *     {@link GitOperation} was ago.
+   */
+  public String getTimestampFilename() {
+
+    return this.timestampFilename;
+  }
+
+  /**
+   * @return the {@link Duration} how long this {@link GitOperation} will be skipped.
+   */
+  public Duration getCacheDuration() {
+
+    return cacheDuration;
+  }
+
+  /**
+   * @return {@code true} if this operation requires the ".git" folder to be present, {@code false} otherwise.
+   */
+  public boolean isRequireGitFolder() {
+
+    return this == FETCH;
+  }
+
+  /**
+   * @return {@code true} if after this operation the {@link #getTimestampFilename() timestamp file} should be updated, {@code false} otherwise.
+   */
+  public boolean isForceUpdateTimestampFile() {
+
+    return this == PULL_OR_CLONE;
+  }
+
+  /**
+   * Executes this {@link GitOperation} physically.
+   *
+   * @param gitContext the {@link GitContextImpl}.
+   * @param gitRepoUrl the git repository URL. Maybe {@code null} if not required by the operation.
+   * @param targetRepository the {@link Path} to the git repository.
+   * @param remote the git remote (e.g. "origin"). Maybe {@code null} if not required by the operation.
+   * @param branch the explicit git branch (e.g. "main"). Maybe {@code null} for default branch or if not required by the operation.
+   * @return {@code true} if changes were received from git, {@code false} otherwise.
+   */
+  protected abstract boolean execute(GitContextImpl gitContext, String gitRepoUrl, Path targetRepository, String remote, String branch);
+
+  /**
+   * Executes this {@link GitOperation} if {@link #isNeeded(Path, IdeContext) needed}.
+   *
+   * @param gitContext the {@link GitContextImpl}.
+   * @param gitRepoUrl the git repository URL. Maybe {@code null} if not required by the operation.
+   * @param targetRepository the {@link Path} to the git repository.
+   * @param remote the git remote (e.g. "origin"). Maybe {@code null} if not required by the operation.
+   * @param branch the explicit git branch (e.g. "main"). Maybe {@code null} for default branch or if not required by the operation.
+   * @return {@code true} if changes were received from git, {@code false} otherwise (e.g. no git operation was invoked at all).
+   */
+  boolean executeIfNeeded(GitContextImpl gitContext, String gitRepoUrl, Path targetRepository, String remote, String branch) {
+
+    IdeContext context = gitContext.getContext();
+    if (isNeeded(targetRepository, context)) {
+      boolean result = execute(gitContext, gitRepoUrl, targetRepository, remote, branch);
+      gitContext.fetch(targetRepository, remote, branch);
+      if (isForceUpdateTimestampFile()) {
+        Path timestampPath = targetRepository.resolve(GitContext.GIT_FOLDER).resolve(this.timestampFilename);
+        try {
+          context.getFileAccess().touch(timestampPath);
+        } catch (IllegalStateException e) {
+          context.warning(e.getMessage());
+        }
+      }
+      return result;
+    } else {
+      context.trace("Skipped git {}.", this.name);
+      return false;
+    }
+  }
+
+  private boolean isNeeded(Path targetRepository, IdeContext context) {
+
+    if (context.isOffline()) {
+      context.info("Skipping git {} on {} because we are offline.", this.name, targetRepository);
+      return false;
+    } else if (context.isForceMode()) {
+      context.debug("Enforcing git {} on {} because force mode is active.", this.name, targetRepository);
+      return true;
+    }
+    Path gitDirectory = targetRepository.resolve(".git");
+    if (!Files.isDirectory(gitDirectory)) {
+      if (isRequireGitFolder()) {
+        context.warning("Missing .git folder in {}.", targetRepository);
+      } else {
+        context.debug("Enforcing git {} on {} because .git folder is not present.", this.name, targetRepository);
+      }
+      return true; // technically this is an error that will be triggered by fetch method
+    }
+    Path timestampFilePath = gitDirectory.resolve(this.timestampFilename);
+    if (Files.exists(timestampFilePath)) {
+      long currentTime = System.currentTimeMillis();
+      try {
+        long fileModifiedTime = Files.getLastModifiedTime(timestampFilePath).toMillis();
+        // Check if the file modification time is older than the delta threshold
+        Duration lastFileUpdateDuration = Duration.ofMillis(currentTime - fileModifiedTime);
+        context.debug("In git repository {} the timestamp file {} was last updated {} ago and caching duration in {}.", targetRepository,
+            timestampFilename, lastFileUpdateDuration, this.cacheDuration);
+        if ((lastFileUpdateDuration.toMillis() > this.cacheDuration.toMillis())) {
+          context.debug("Will need to do git {} on {} because last fetch is some time ago.", this.name, targetRepository);
+          return true;
+        } else {
+          context.debug("Skipping git {} on {} because last fetch was just recently to avoid overhead.", this.name,
+              targetRepository, this.cacheDuration);
+          return false;
+        }
+      } catch (IOException e) {
+        context.warning().log(e, "Could not update modification-time of {}. Will have to do git {}.", timestampFilePath, this.name);
+        return true;
+      }
+    } else {
+      context.debug("Will need to do git {} on {} because {} is missing.", this.name, targetRepository, timestampFilename);
+      return true;
+    }
+  }
+
+}

--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccess.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccess.java
@@ -245,7 +245,16 @@ public interface FileAccess {
   /**
    * Makes a file executable. Equivalent of using 'chmod a+x'. Adds execute permissions to current file permissions.
    *
-   * @param filePath Path to the file.
+   * @param filePath {@link Path} to the file.
    */
   void makeExecutable(Path filePath);
+
+  /**
+   * Like the linux touch command this method will update the modification time of the given {@link Path} to the current
+   * {@link System#currentTimeMillis() system time}. In case the file does not exist, it will be created as empty file. If already the
+   * {@link Path#getParent() parent folder} does not exist, the operation will fail.
+   *
+   * @param filePath the {@link Path} to the file or folder.
+   */
+  void touch(Path filePath);
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -20,6 +20,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.DigestInputStream;
@@ -913,6 +914,24 @@ public class FileAccessImpl implements FileAccess {
       }
     } else {
       this.context.warning("Cannot set executable flag on file that does not exist: {}", filePath);
+    }
+  }
+
+  @Override
+  public void touch(Path filePath) {
+
+    if (Files.exists(filePath)) {
+      try {
+        Files.setLastModifiedTime(filePath, FileTime.fromMillis(System.currentTimeMillis()));
+      } catch (IOException e) {
+        throw new IllegalStateException("Could not update modification-time of " + filePath, e);
+      }
+    } else {
+      try {
+        Files.createFile(filePath);
+      } catch (IOException e) {
+        throw new IllegalStateException("Could not create empty file " + filePath, e);
+      }
     }
   }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/context/GitContextMock.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/GitContextMock.java
@@ -25,7 +25,7 @@ public class GitContextMock implements GitContext {
   }
 
   @Override
-  public void pullOrClone(String gitRepoUrl, String branch, Path targetRepository) {
+  public void pullOrClone(String gitRepoUrl, Path targetRepository, String branch) {
 
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/context/GitContextTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/GitContextTest.java
@@ -50,7 +50,7 @@ public class GitContextTest extends AbstractIdeContextTest {
     //IdeContext context = newGitContext(tempDir, errors, outs, 0, false);
     // act
     CliException e1 = assertThrows(CliException.class, () -> {
-      context.getGitContext().pullOrClone(gitRepoUrl, "", tempDir);
+      context.getGitContext().pullOrClone(gitRepoUrl, tempDir, "");
     });
     // assert
     assertThat(e1).hasMessageContaining(gitRepoUrl).hasMessageContaining(tempDir.toString())

--- a/cli/src/test/java/com/devonfw/tools/ide/context/GitOperationTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/GitOperationTest.java
@@ -191,6 +191,25 @@ public class GitOperationTest extends AbstractIdeContextTest {
     Mockito.verifyNoInteractions(mock);
   }
 
+  @Test
+  public void testPullOrCloneSkippedIfRepoNotInitializedAndOfflineMode(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.PULL_OR_CLONE;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    context.getStartContext().setOfflineMode(true);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = tempDir.resolve("git-repository");
+    Files.createDirectories(repo);
+
+    // act
+    operation.executeIfNeeded(context, URL, repo, null, BRANCH);
+
+    // assert
+    Mockito.verify(mock).pullOrClone(URL, repo, BRANCH);
+  }
+
   private Path createFakeGitRepo(Path dir, String file) throws Exception {
 
     return createFakeGitRepo(dir, file, false);

--- a/cli/src/test/java/com/devonfw/tools/ide/context/GitOperationTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/GitOperationTest.java
@@ -1,0 +1,214 @@
+package com.devonfw.tools.ide.context;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+/**
+ * Test of {@link GitOperation}.
+ */
+public class GitOperationTest extends AbstractIdeContextTest {
+
+  private static final String URL = "https://github.com/devonfw/IDEasy.git";
+  private static final String REMOTE = "origin";
+  private static final String BRANCH = "main";
+
+  @Test
+  public void testFetchSkippedIfTimestampFileUpToDate(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.FETCH;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, operation.getTimestampFilename());
+
+    // act
+    operation.executeIfNeeded(context, null, repo, REMOTE, BRANCH);
+
+    // assert
+    Mockito.verifyNoInteractions(mock);
+  }
+
+  @Test
+  public void testFetchCalledIfTimestampFileNotPresent(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.FETCH;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, null);
+
+    // act
+    operation.executeIfNeeded(context, null, repo, REMOTE, BRANCH);
+
+    // assert
+    Mockito.verify(mock).fetch(repo, REMOTE, BRANCH);
+  }
+
+  @Test
+  public void testFetchCalledIfTimestampFileOutdated(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.FETCH;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, operation.getTimestampFilename(), true);
+
+    // act
+    operation.executeIfNeeded(context, null, repo, REMOTE, BRANCH);
+
+    // assert
+    Mockito.verify(mock).fetch(repo, REMOTE, BRANCH);
+  }
+
+  @Test
+  public void testFetchCalledIfTimestampFileUpToDateButForceMode(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.FETCH;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    context.getStartContext().setForceMode(true);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, operation.getTimestampFilename(), true);
+
+    // act
+    operation.executeIfNeeded(context, null, repo, REMOTE, BRANCH);
+
+    // assert
+    Mockito.verify(mock).fetch(repo, REMOTE, BRANCH);
+  }
+
+  @Test
+  public void testFetchSkippedIfTimestampFileNotPresentButOfflineMode(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.FETCH;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    context.getStartContext().setOfflineMode(true);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, null);
+
+    // act
+    operation.executeIfNeeded(context, null, repo, REMOTE, BRANCH);
+
+    // assert
+    Mockito.verifyNoInteractions(mock);
+  }
+
+  @Test
+  public void testPullOrCloneSkippedIfTimestampFileUpToDate(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.PULL_OR_CLONE;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, operation.getTimestampFilename());
+
+    // act
+    operation.executeIfNeeded(context, URL, repo, null, BRANCH);
+
+    // assert
+    Mockito.verifyNoInteractions(mock);
+  }
+
+  @Test
+  public void testPullOrCloneCalledIfTimestampFileNotPresent(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.PULL_OR_CLONE;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, null);
+
+    // act
+    operation.executeIfNeeded(context, URL, repo, null, BRANCH);
+
+    // assert
+    Mockito.verify(mock).pullOrClone(URL, repo, BRANCH);
+  }
+
+  @Test
+  public void testPullOrCloneCalledIfTimestampFileOutdated(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.PULL_OR_CLONE;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, operation.getTimestampFilename(), true);
+
+    // act
+    operation.executeIfNeeded(context, URL, repo, null, BRANCH);
+
+    // assert
+    Mockito.verify(mock).pullOrClone(URL, repo, BRANCH);
+  }
+
+  @Test
+  public void testPullOrCloneCalledIfTimestampFileUpToDateButForceMode(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.PULL_OR_CLONE;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    context.getStartContext().setForceMode(true);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, operation.getTimestampFilename(), true);
+
+    // act
+    operation.executeIfNeeded(context, URL, repo, null, BRANCH);
+
+    // assert
+    Mockito.verify(mock).pullOrClone(URL, repo, BRANCH);
+  }
+
+  @Test
+  public void testPullOrCloneSkippedIfTimestampFileNotPresentButOfflineMode(@TempDir Path tempDir) throws Exception {
+
+    // arrange
+    GitOperation operation = GitOperation.PULL_OR_CLONE;
+    IdeTestContext context = newContext(PROJECT_BASIC, null, false);
+    context.getStartContext().setOfflineMode(true);
+    GitContext mock = Mockito.mock(GitContext.class);
+    context.setGitContext(mock);
+    Path repo = createFakeGitRepo(tempDir, null);
+
+    // act
+    operation.executeIfNeeded(context, URL, repo, null, BRANCH);
+
+    // assert
+    Mockito.verifyNoInteractions(mock);
+  }
+
+  private Path createFakeGitRepo(Path dir, String file) throws Exception {
+
+    return createFakeGitRepo(dir, file, false);
+  }
+
+  private Path createFakeGitRepo(Path dir, String file, boolean outdated) throws Exception {
+
+    Path repo = dir.resolve("git-repository");
+    Path gitFolder = repo.resolve(GitContext.GIT_FOLDER);
+    Files.createDirectories(gitFolder);
+    if (file != null) {
+      Path timestampFile = gitFolder.resolve(file);
+      Files.createFile(timestampFile);
+      if (outdated) {
+        Files.setLastModifiedTime(timestampFile, FileTime.fromMillis(12345678L));
+      }
+    }
+    return repo;
+  }
+
+}


### PR DESCRIPTION
fixes #585 
* check if FETCH_HEAD does not exist
* also properly handle force mode (always fetch)
* add debug logging if fetch was skipped
* make code more readable
* extracted generic code pattern to `GitOperation` that is now reused for `fetchIfNeeded` and `pullOrCloneIfNeeded`.
* the method `pullOrCloneIfNeeded` had the same bug with force mode that is now also fixed.
* added JUnit test to test all variants