### PR TITLE
#556: update PATH on pc run

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 Release with new features and bugfixes:
 
 * https://github.com/devonfw/IDEasy/issues/553[#554]: Missmatch of IDE_ROOT
+* https://github.com/devonfw/IDEasy/issues/556[#556]: ProcessContext should compute PATH on run and not in constructor
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/13?closed=1[milestone 2024.09.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
@@ -88,6 +88,7 @@ public class SystemPath {
    * @param ideRoot the {@link IdeContext#getIdeRoot() IDE_ROOT}.
    * @param softwarePath the {@link IdeContext#getSoftwarePath() software path}.
    * @param pathSeparator the path separator char (';' for Windows and ':' otherwise).
+   * @param extraPathEntries the {@link List} of additional {@link Path}s to prepend.
    */
   public SystemPath(IdeContext context, String envPath, Path ideRoot, Path softwarePath, char pathSeparator, List<Path> extraPathEntries) {
 
@@ -258,6 +259,13 @@ public class SystemPath {
     return sb.toString();
   }
 
+  /**
+   * Derive a new {@link SystemPath} from this instance with the given parameters.
+   *
+   * @param overriddenPath the entire PATH to override and replace the current one from this {@link SystemPath} or {@code null} to keep the current PATH.
+   * @param extraPathEntries the {@link List} of additional PATH entries to add to the beginning of the PATH. May be empty to add nothing.
+   * @return the new {@link SystemPath} derived from this instance with the given parameters applied.
+   */
   public SystemPath withPath(String overriddenPath, List<Path> extraPathEntries) {
 
     if (overriddenPath == null) {

--- a/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
@@ -230,6 +230,17 @@ public class SystemPath {
    */
   public String toString(WindowsPathSyntax pathSyntax) {
 
+    return toString(pathSyntax, null, null);
+  }
+
+  /**
+   * @param pathSyntax the {@link WindowsPathSyntax} to convert to.
+   * @param overriddenPath the explicit "PATH" to use instead of the values from this {@link SystemPath}.
+   * @param extraPathEntries the extra PATH entries to prepend. See {@link com.devonfw.tools.ide.process.ProcessContext#withPathEntry(Path)}.
+   * @return this {@link SystemPath} as {@link String} for the PATH environment variable.
+   */
+  public String toString(WindowsPathSyntax pathSyntax, String overriddenPath, List<Path> extraPathEntries) {
+
     char separator;
     if (pathSyntax == WindowsPathSyntax.MSYS) {
       separator = ':';
@@ -237,11 +248,23 @@ public class SystemPath {
       separator = this.pathSeparator;
     }
     StringBuilder sb = new StringBuilder(this.envPath.length() + 128);
-    for (Path path : this.tool2pathMap.values()) {
-      appendPath(path, sb, separator, pathSyntax);
+    if (extraPathEntries != null) {
+      for (Path path : extraPathEntries) {
+        appendPath(path, sb, separator, pathSyntax);
+      }
     }
-    for (Path path : this.paths) {
-      appendPath(path, sb, separator, pathSyntax);
+    if (overriddenPath == null) {
+      for (Path path : this.tool2pathMap.values()) {
+        appendPath(path, sb, separator, pathSyntax);
+      }
+      for (Path path : this.paths) {
+        appendPath(path, sb, separator, pathSyntax);
+      }
+    } else {
+      if (sb.length() > 0) {
+        sb.append(separator);
+      }
+      sb.append(overriddenPath);
     }
     return sb.toString();
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/process/EnvironmentContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/EnvironmentContext.java
@@ -1,19 +1,30 @@
 package com.devonfw.tools.ide.process;
 
+import java.nio.file.Path;
+
 /**
  * Interface for the environment context relatable in the case a tool needs to be run with an environment variable.
  */
 public interface EnvironmentContext {
 
   /**
-   * Sets or overrides the specified environment variable only for the planned process execution. Please note that the environment variables are initialized
-   * when the {@link EnvironmentContext} is created. This method explicitly set an additional or overrides an existing environment and will have effect for each
-   * process execution invoked from this {@link EnvironmentContext} instance.
+   * Sets or overrides the specified environment variable only in this context. Please note that the environment variables are initialized when the
+   * {@link EnvironmentContext} is created. This method explicitly set an additional or overrides an existing environment and will have effect only within this
+   * context and not change the {@link com.devonfw.tools.ide.environment.EnvironmentVariables} or {@link com.devonfw.tools.ide.common.SystemPath}.
    *
    * @param key the name of the environment variable (E.g. "PATH").
    * @param value the value of the environment variable.
    * @return this {@link EnvironmentContext} for fluent API calls.
    */
   EnvironmentContext withEnvVar(String key, String value);
+
+  /**
+   * Extends the "PATH" variable with the given {@link Path} entry. The new entry will be added to the beginning of the "PATH" and potentially override other
+   * entries if it contains the same binary.
+   *
+   * @param path the {@link Path} pointing to the folder with the binaries to add to the "PATH" variable.
+   * @return this {@link EnvironmentContext} for fluent API calls.
+   */
+  EnvironmentContext withPathEntry(Path path);
 
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
@@ -109,17 +109,11 @@ public interface ProcessContext extends EnvironmentContext {
     return this;
   }
 
-  /**
-   * Sets or overrides the specified environment variable only for the planned {@link #run() process execution}. Please note that the environment variables are
-   * initialized when the {@link ProcessContext} is created. This method explicitly set an additional or overrides an existing environment and will have effect
-   * for each {@link #run() process execution} invoked from this {@link ProcessContext} instance. Be aware of such side-effects when reusing the same
-   * {@link ProcessContext} to {@link #run() run} multiple commands.
-   *
-   * @param key the name of the environment variable (E.g. "PATH").
-   * @param value the value of the environment variable.
-   * @return this {@link ProcessContext} for fluent API calls.
-   */
+  @Override
   ProcessContext withEnvVar(String key, String value);
+
+  @Override
+  ProcessContext withPathEntry(Path path);
 
   /**
    * Runs the previously configured {@link #executable(Path) command} with the configured {@link #addArgs(String...) arguments}. Will reset the

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
@@ -96,7 +96,7 @@ public class ProcessContextImpl implements ProcessContext {
       throw new IllegalStateException("Arguments already present - did you forget to call run for previous call?");
     }
 
-    this.executable = this.context.getPath().findBinary(command);
+    this.executable = command;
     return this;
   }
 
@@ -141,8 +141,13 @@ public class ProcessContextImpl implements ProcessContext {
       throw new IllegalStateException("Missing executable to run process!");
     }
 
-    String path = this.context.getPath().toString(null, this.overriddenPath, this.extraPathEntries);
+    SystemPath systemPath = this.context.getPath();
+    if ((this.overriddenPath != null) || !this.extraPathEntries.isEmpty()) {
+      systemPath = systemPath.withPath(this.overriddenPath, this.extraPathEntries);
+    }
+    String path = systemPath.toString();
     this.context.trace("Setting PATH for process execution of {} to {}", this.executable.getFileName(), path);
+    this.executable = systemPath.findBinary(this.executable);
     this.processBuilder.environment().put(IdeVariables.PATH.getName(), path);
     List<String> args = new ArrayList<>(this.arguments.size() + 4);
     String interpreter = addExecutable(this.executable.toString(), args);

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
@@ -23,6 +23,7 @@ import com.devonfw.tools.ide.log.IdeSubLogger;
 import com.devonfw.tools.ide.os.SystemInfoImpl;
 import com.devonfw.tools.ide.os.WindowsPathSyntax;
 import com.devonfw.tools.ide.util.FilenameUtil;
+import com.devonfw.tools.ide.variable.IdeVariables;
 
 /**
  * Implementation of {@link ProcessContext}.
@@ -39,6 +40,10 @@ public class ProcessContextImpl implements ProcessContext {
   private final List<String> arguments;
 
   private Path executable;
+
+  private String overriddenPath;
+
+  private final List<Path> extraPathEntries;
 
   private ProcessErrorHandling errorHandling;
 
@@ -60,6 +65,7 @@ public class ProcessContextImpl implements ProcessContext {
       }
     }
     this.arguments = new ArrayList<>();
+    this.extraPathEntries = new ArrayList<>();
   }
 
   @Override
@@ -104,14 +110,25 @@ public class ProcessContextImpl implements ProcessContext {
   @Override
   public ProcessContext withEnvVar(String key, String value) {
 
-    this.processBuilder.environment().put(key, value);
+    if (IdeVariables.PATH.getName().equals(key)) {
+      this.overriddenPath = value;
+    } else {
+      this.context.trace("Setting process environment variable {}={}", key, value);
+      this.processBuilder.environment().put(key, value);
+    }
+    return this;
+  }
+
+  @Override
+  public ProcessContext withPathEntry(Path path) {
+
+    this.extraPathEntries.add(path);
     return this;
   }
 
   @Override
   public ProcessResult run(ProcessMode processMode) {
 
-    // TODO ProcessMode needs to be configurable for GUI
     if (processMode == ProcessMode.DEFAULT) {
       this.processBuilder.redirectOutput(Redirect.INHERIT).redirectError(Redirect.INHERIT);
     }
@@ -123,6 +140,10 @@ public class ProcessContextImpl implements ProcessContext {
     if (this.executable == null) {
       throw new IllegalStateException("Missing executable to run process!");
     }
+
+    String path = this.context.getPath().toString(null, this.overriddenPath, this.extraPathEntries);
+    this.context.trace("Setting PATH for process execution of {} to {}", this.executable.getFileName(), path);
+    this.processBuilder.environment().put(IdeVariables.PATH.getName(), path);
     List<String> args = new ArrayList<>(this.arguments.size() + 4);
     String interpreter = addExecutable(this.executable.toString(), args);
     args.addAll(this.arguments);

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
@@ -103,14 +103,12 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
 
     Path binaryPath;
     binaryPath = Path.of(getBinaryName());
-    ProcessContext pc;
+    ProcessContext pc = createProcessContext(binaryPath, args);
 
     if (existsEnvironmentContext) {
-      pc = createProcessContext(binaryPath, args);
       install(pc, true);
     } else {
       install(true);
-      pc = createProcessContext(binaryPath, args);
     }
 
     pc.run(processMode);

--- a/cli/src/test/java/com/devonfw/tools/ide/context/ProcessContextGitMock.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/ProcessContextGitMock.java
@@ -113,6 +113,12 @@ public class ProcessContextGitMock implements ProcessContext {
   }
 
   @Override
+  public ProcessContext withPathEntry(Path path) {
+
+    return this;
+  }
+
+  @Override
   public ProcessResult run(ProcessMode processMode) {
 
     Path gitFolderPath = this.directory.resolve(".git");


### PR DESCRIPTION
fixes #556 
* add `withPathEntry(Path)` method for future implementations of `setEnvironment` methods
* add ability to create a modified `SystemPath` via `withPath` method
* change ProcessContext to track PATH changes and apply them only in `run` method
* also move the code to find the binary executable to `run` method using the final PATH
* improved logging
* changed `ToolCommandlet` to simplify after this "bug" has been fixed