### PR TITLE
#550: Fix download url generated from plugin id

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -3,6 +3,8 @@ package com.devonfw.tools.ide.tool.ide;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
@@ -68,7 +70,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
    */
   private String getDownloadUrl(PluginDescriptor plugin) {
     String downloadUrl = plugin.getUrl();
-    String pluginId = plugin.getId();
+    String pluginId = URLEncoder.encode(plugin.getId(), StandardCharsets.UTF_8).replaceAll("\\+", "%20");
 
     String buildVersion = readBuildVersion();
 


### PR DESCRIPTION
Closes #550. 

Requires merging of #609 to be fully function for zip compressed plugins. 