### PR TITLE
#618: improve IdeProgressBarConsoleTest

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/io/AbstractIdeProgressBar.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/AbstractIdeProgressBar.java
@@ -17,9 +17,7 @@ public abstract class AbstractIdeProgressBar implements IdeProgressBar {
     this.maxLength = maxLength;
   }
 
-  /**
-   * @return the maximum length of a progress bar.
-   */
+  @Override
   public long getMaxLength() {
 
     return maxLength;
@@ -32,6 +30,15 @@ public abstract class AbstractIdeProgressBar implements IdeProgressBar {
    * @param currentProgress current progress state (used for tests only).
    */
   protected abstract void doStepBy(long stepSize, long currentProgress);
+
+  protected void stepTo(long stepPosition) {
+
+    if ((this.maxLength > 0) && (stepPosition > this.maxLength)) {
+      stepPosition = this.maxLength; // clip to max avoiding overflow
+    }
+    this.currentProgress = stepPosition;
+    doStepTo(stepPosition);
+  }
 
   /**
    * Sets the progress bar to given step position.
@@ -48,12 +55,18 @@ public abstract class AbstractIdeProgressBar implements IdeProgressBar {
       // check if maximum overflow
       if (this.currentProgress > this.maxLength) {
         this.currentProgress = this.maxLength;
-        doStepTo(this.maxLength);
+        stepTo(this.maxLength);
         return;
       }
     }
 
     doStepBy(stepSize, this.currentProgress);
+  }
+
+  @Override
+  public long getCurrentProgress() {
+
+    return this.currentProgress;
   }
 
   @Override
@@ -63,7 +76,7 @@ public abstract class AbstractIdeProgressBar implements IdeProgressBar {
     }
 
     if (this.currentProgress < this.maxLength) {
-      doStepTo(this.maxLength);
+      stepTo(this.maxLength);
     }
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/io/AbstractIdeProgressBar.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/AbstractIdeProgressBar.java
@@ -31,6 +31,11 @@ public abstract class AbstractIdeProgressBar implements IdeProgressBar {
    */
   protected abstract void doStepBy(long stepSize, long currentProgress);
 
+  /**
+   * Sets the progress bar to given step position while making sure to avoid overflow.
+   *
+   * @param stepPosition position to set to.
+   */
   protected void stepTo(long stepPosition) {
 
     if ((this.maxLength > 0) && (stepPosition > this.maxLength)) {

--- a/cli/src/main/java/com/devonfw/tools/ide/io/IdeProgressBar.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/IdeProgressBar.java
@@ -12,6 +12,16 @@ public interface IdeProgressBar extends AutoCloseable {
    */
   void stepBy(long stepSize);
 
+  /**
+   * @return the maximum value when the progress bar has reached its end or {@code -1} if the maximum is undefined.
+   */
+  long getMaxLength();
+
+  /**
+   * @return the total count accumulated with {@link #stepBy(long)} or {@link #getMaxLength()} in case of overflow.
+   */
+  long getCurrentProgress();
+
   @Override
   void close();
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/io/IdeProgressBarConsoleTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/io/IdeProgressBarConsoleTest.java
@@ -1,20 +1,31 @@
 package com.devonfw.tools.ide.io;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
+import com.devonfw.tools.ide.os.SystemInfo;
 import com.devonfw.tools.ide.os.SystemInfoImpl;
 
 /**
  * Test of {@link IdeProgressBarConsole}.
  */
+// disabled on Windows - see https://github.com/devonfw/IDEasy/issues/618
+@DisabledOnOs({ OS.WINDOWS })
 public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
+
+  private IdeProgressBarConsole newProgressBar(long maxSize) {
+    SystemInfo systemInfo = SystemInfoImpl.INSTANCE;
+    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(systemInfo, "downloading", maxSize);
+    return progressBarConsole;
+  }
 
   @Test
   public void testProgressBarMaxSizeUnknownStepBy() throws Exception {
     // arrange
     long stepSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", -1);
+    IdeProgressBarConsole progressBarConsole = newProgressBar(-1);
 
     // act
     progressBarConsole.stepBy(stepSize);
@@ -30,7 +41,7 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   public void testProgressBarMaxSizeUnknownDoStepTo() throws Exception {
     // arrange
     long stepSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", -1);
+    IdeProgressBarConsole progressBarConsole = newProgressBar(-1);
 
     // act
     progressBarConsole.stepBy(100L);
@@ -48,7 +59,7 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   public void testProgressBarMaxSizeKnownStepBy() throws Exception {
     // arrange
     long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", maxSize);
+    IdeProgressBarConsole progressBarConsole = newProgressBar(maxSize);
 
     //act
     progressBarConsole.stepBy(maxSize);
@@ -64,7 +75,7 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   public void testProgressBarMaxSizeKnownDoStepTo() throws Exception {
     // arrange
     long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", maxSize);
+    IdeProgressBarConsole progressBarConsole = newProgressBar(maxSize);
 
     //act
     progressBarConsole.doStepTo(maxSize);
@@ -80,7 +91,7 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   public void testProgressBarMaxSizeKnownIncompleteSteps() throws Exception {
     // arrange
     long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", maxSize);
+    IdeProgressBarConsole progressBarConsole = newProgressBar(maxSize);
 
     // act
     progressBarConsole.stepBy(1L);
@@ -96,7 +107,7 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   public void testProgressBarMaxOverflow() throws Exception {
     // arrange
     long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", maxSize);
+    IdeProgressBarConsole progressBarConsole = newProgressBar(maxSize);
     // act
     progressBarConsole.stepBy(20000L);
     progressBarConsole.close();

--- a/cli/src/test/java/com/devonfw/tools/ide/io/IdeProgressBarConsoleTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/io/IdeProgressBarConsoleTest.java
@@ -3,9 +3,7 @@ package com.devonfw.tools.ide.io;
 import org.junit.jupiter.api.Test;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
-import com.devonfw.tools.ide.os.SystemInfo;
 import com.devonfw.tools.ide.os.SystemInfoImpl;
-import com.devonfw.tools.ide.os.SystemInfoMock;
 
 /**
  * Test of {@link IdeProgressBarConsole}.
@@ -25,6 +23,7 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
     // assert
     assertThat(progressBarConsole.getProgressBar().isIndefinite()).isEqualTo(true);
     assertThat(progressBarConsole.getProgressBar().getMax()).isEqualTo(stepSize);
+    assertThat(progressBarConsole.getCurrentProgress()).isEqualTo(stepSize);
   }
 
   @Test
@@ -34,12 +33,14 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
     IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", -1);
 
     // act
-    progressBarConsole.doStepTo(stepSize);
+    progressBarConsole.stepBy(100L);
+    progressBarConsole.stepTo(stepSize);
     progressBarConsole.close();
 
     // assert
     assertThat(progressBarConsole.getProgressBar().isIndefinite()).isEqualTo(true);
     assertThat(progressBarConsole.getProgressBar().getMax()).isEqualTo(stepSize);
+    assertThat(progressBarConsole.getCurrentProgress()).isEqualTo(stepSize);
   }
 
 
@@ -55,7 +56,8 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
 
     // assert
     assertThat(progressBarConsole.getProgressBar().isIndefinite()).isEqualTo(false);
-    assertThat(progressBarConsole.getProgressBar().getMax()).isEqualTo(maxSize);
+    assertThat(progressBarConsole.getMaxLength()).isEqualTo(maxSize);
+    assertThat(progressBarConsole.getCurrentProgress()).isEqualTo(maxSize);
   }
 
   @Test
@@ -70,7 +72,8 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
 
     // assert
     assertThat(progressBarConsole.getProgressBar().isIndefinite()).isEqualTo(false);
-    assertThat(progressBarConsole.getProgressBar().getMax()).isEqualTo(maxSize);
+    assertThat(progressBarConsole.getMaxLength()).isEqualTo(maxSize);
+    assertThat(progressBarConsole.getCurrentProgress()).isEqualTo(maxSize);
   }
 
   @Test
@@ -81,10 +84,12 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
 
     // act
     progressBarConsole.stepBy(1L);
-    progressBarConsole.close();
-
     // assert
-    assertThat(progressBarConsole.getProgressBar().getMax()).isEqualTo(maxSize);
+    assertThat(progressBarConsole.getCurrentProgress()).isEqualTo(1L);
+    // act
+    progressBarConsole.close();
+    // assert
+    assertThat(progressBarConsole.getMaxLength()).isEqualTo(maxSize);
   }
 
   @Test
@@ -98,15 +103,7 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
 
     //assert
     assertThat(progressBarConsole.getProgressBar().getMax()).isEqualTo(maxSize);
+    assertThat(progressBarConsole.getCurrentProgress()).isEqualTo(maxSize);
   }
 
-  @Test
-  public void testProgressBarStyleSwitchOnNonWindows() throws Exception {
-    // arrange
-    SystemInfo systemInfo = SystemInfoMock.LINUX_X64;
-    long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(systemInfo, "downloading", maxSize);
-    // act
-    progressBarConsole.close();
-  }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/io/IdeProgressBarConsoleTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/io/IdeProgressBarConsoleTest.java
@@ -1,13 +1,10 @@
 package com.devonfw.tools.ide.io;
 
-import java.nio.file.Path;
-
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
-import com.devonfw.tools.ide.context.IdeTestContext;
 import com.devonfw.tools.ide.os.SystemInfo;
+import com.devonfw.tools.ide.os.SystemInfoImpl;
 import com.devonfw.tools.ide.os.SystemInfoMock;
 
 /**
@@ -16,11 +13,10 @@ import com.devonfw.tools.ide.os.SystemInfoMock;
 public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
 
   @Test
-  public void testProgressBarMaxSizeUnknownStepBy(@TempDir Path tempDir) throws Exception {
+  public void testProgressBarMaxSizeUnknownStepBy() throws Exception {
     // arrange
-    IdeTestContext context = newContext(tempDir);
     long stepSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(context.getSystemInfo(), "downloading", -1);
+    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", -1);
 
     // act
     progressBarConsole.stepBy(stepSize);
@@ -32,11 +28,10 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   }
 
   @Test
-  public void testProgressBarMaxSizeUnknownDoStepTo(@TempDir Path tempDir) throws Exception {
+  public void testProgressBarMaxSizeUnknownDoStepTo() throws Exception {
     // arrange
-    IdeTestContext context = newContext(tempDir);
     long stepSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(context.getSystemInfo(), "downloading", -1);
+    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", -1);
 
     // act
     progressBarConsole.doStepTo(stepSize);
@@ -49,11 +44,10 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
 
 
   @Test
-  public void testProgressBarMaxSizeKnownStepBy(@TempDir Path tempDir) throws Exception {
+  public void testProgressBarMaxSizeKnownStepBy() throws Exception {
     // arrange
-    IdeTestContext context = newContext(tempDir);
     long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(context.getSystemInfo(), "downloading", maxSize);
+    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", maxSize);
 
     //act
     progressBarConsole.stepBy(maxSize);
@@ -65,11 +59,10 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   }
 
   @Test
-  public void testProgressBarMaxSizeKnownDoStepTo(@TempDir Path tempDir) throws Exception {
+  public void testProgressBarMaxSizeKnownDoStepTo() throws Exception {
     // arrange
-    IdeTestContext context = newContext(tempDir);
     long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(context.getSystemInfo(), "downloading", maxSize);
+    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", maxSize);
 
     //act
     progressBarConsole.doStepTo(maxSize);
@@ -81,11 +74,10 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   }
 
   @Test
-  public void testProgressBarMaxSizeKnownIncompleteSteps(@TempDir Path tempDir) throws Exception {
+  public void testProgressBarMaxSizeKnownIncompleteSteps() throws Exception {
     // arrange
-    IdeTestContext context = newContext(tempDir);
     long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(context.getSystemInfo(), "downloading", maxSize);
+    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", maxSize);
 
     // act
     progressBarConsole.stepBy(1L);
@@ -96,11 +88,10 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   }
 
   @Test
-  public void testProgressBarMaxOverflow(@TempDir Path tempDir) throws Exception {
+  public void testProgressBarMaxOverflow() throws Exception {
     // arrange
-    IdeTestContext context = newContext(tempDir);
     long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(context.getSystemInfo(), "downloading", maxSize);
+    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(SystemInfoImpl.INSTANCE, "downloading", maxSize);
     // act
     progressBarConsole.stepBy(20000L);
     progressBarConsole.close();
@@ -110,13 +101,11 @@ public class IdeProgressBarConsoleTest extends AbstractIdeContextTest {
   }
 
   @Test
-  public void testProgressBarStyleSwitchOnNonWindows(@TempDir Path tempDir) throws Exception {
+  public void testProgressBarStyleSwitchOnNonWindows() throws Exception {
     // arrange
-    IdeTestContext context = newContext(tempDir);
-    SystemInfo systemInfo = SystemInfoMock.of("linux");
-    context.setSystemInfo(systemInfo);
+    SystemInfo systemInfo = SystemInfoMock.LINUX_X64;
     long maxSize = 10000L;
-    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(context.getSystemInfo(), "downloading", maxSize);
+    IdeProgressBarConsole progressBarConsole = new IdeProgressBarConsole(systemInfo, "downloading", maxSize);
     // act
     progressBarConsole.close();
   }


### PR DESCRIPTION
fixed #618 (not yet)

* cleanup test and removed obvious nonsense
* still the `testProgressBarStyleSwitchOnNonWindows` that testes linux on Windows seems to cause 2 Minutes of think-time if called from a real shell. My question is what is the benefit of this if the costs are that high.
* This PR is a small but nice improvement. However, it does not solve the problem described in #618 
