### PR TITLE
fix HelpCommandletTest to work locale insensitive

### DIFF
--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/HelpCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/HelpCommandletTest.java
@@ -47,7 +47,9 @@ public class HelpCommandletTest extends AbstractIdeContextTest {
 
     // arrange
     IdeTestContext context = IdeTestContext.of();
+    context.getStartContext().setLocale(Locale.ROOT);
     HelpCommandlet help = new HelpCommandlet(context);
+
     // act
     help.run();
     // assert
@@ -68,6 +70,7 @@ public class HelpCommandletTest extends AbstractIdeContextTest {
 
     // arrange
     IdeTestContext context = newContext(PROJECT_BASIC);
+    context.getStartContext().setLocale(Locale.ROOT);
     HelpCommandlet help = context.getCommandletManager().getCommandlet(HelpCommandlet.class);
     help.commandlet.setValueAsString("mvn", context);
     // act


### PR DESCRIPTION
On my machine an update caused the default local to be German and then `HelpCommandletTest` fails.
Tests must never dependent on system specific settings such as locale, timezone, encoding, etc.