### PR TITLE
#628: Fixed update fails on first error

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/628[#638]: Fixed update fails on first error
 * https://github.com/devonfw/IDEasy/issues/553[#554]: Missmatch of IDE_ROOT
 * https://github.com/devonfw/IDEasy/issues/556[#556]: ProcessContext should compute PATH on run and not in constructor
 * https://github.com/devonfw/IDEasy/issues/557[#557]: Failed to update tomcat: Cannot find a (Map) Key deserializer for type VersionRange

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -166,7 +166,7 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
         try {
           toolCommandlet.install(false);
         } catch (Exception e) {
-          step.error("Installation of " + toolCommandlet.getName() + " failed!", e);
+          step.error(e, "Installation of {} failed!", toolCommandlet.getName());
         }
 
       }

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -66,12 +66,9 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
       }
     }
 
-    Step step = this.context.newStep("Copy configuration templates", templatesFolder);
-    try {
+    try (Step step = this.context.newStep("Copy configuration templates", templatesFolder)) {
       setupConf(templatesFolder, this.context.getIdeHome());
       step.success();
-    } finally {
-      step.close();
     }
   }
 
@@ -137,14 +134,13 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
 
   private void updateSoftware() {
 
-    Step step = this.context.newStep("Install or update software");
-    try {
+    try (Step step = this.context.newStep("Install or update software")) {
       Set<ToolCommandlet> toolCommandlets = new HashSet<>();
 
       // installed tools in IDE_HOME/software
-      List<Path> softwares = this.context.getFileAccess().listChildren(this.context.getSoftwarePath(), Files::isDirectory);
-      for (Path software : softwares) {
-        String toolName = software.getFileName().toString();
+      List<Path> softwarePaths = this.context.getFileAccess().listChildren(this.context.getSoftwarePath(), Files::isDirectory);
+      for (Path softwarePath : softwarePaths) {
+        String toolName = softwarePath.getFileName().toString();
         ToolCommandlet toolCommandlet = this.context.getCommandletManager().getToolCommandletOrNull(toolName);
         if (toolCommandlet != null) {
           toolCommandlets.add(toolCommandlet);
@@ -167,11 +163,14 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
 
       // update/install the toolCommandlets
       for (ToolCommandlet toolCommandlet : toolCommandlets) {
-        toolCommandlet.install(false);
+        try {
+          toolCommandlet.install(false);
+        } catch (Exception e) {
+          step.error("Installation of " + toolCommandlet.getName() + " failed!", e);
+        }
+
       }
       step.success();
-    } finally {
-      step.close();
     }
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/UpdateCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/UpdateCommandletTest.java
@@ -56,4 +56,30 @@ class UpdateCommandletTest extends AbstractIdeContextTest {
     Files.delete(templates.getParent());
     Files.delete(templates.getParent().getParent());
   }
+
+  /**
+   * Tests if a sub step (installation of software) of update failed, the overall update process will not fail too.
+   * <p>
+   * See: <a href="https://github.com/devonfw/IDEasy/issues/628">#628</a> for reference.
+   */
+  @Test
+  public void testRunUpdateSoftwareDoesNotFailOnFailedSoftwareInstallations() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_UPDATE);
+    Path javaRepository = context.getToolRepositoryPath().resolve("default").resolve("java");
+    context.getFileAccess().delete(javaRepository);
+    Path javaDownload = context.getIdeRoot().resolve("repository").resolve("java");
+    context.getFileAccess().delete(javaDownload);
+    UpdateCommandlet uc = context.getCommandletManager().getCommandlet(UpdateCommandlet.class);
+
+    // act
+    uc.run();
+
+    // assert
+    assertThat(context).logAtError().hasMessage("Installation of java failed!");
+    assertThat(context).logAtError().hasMessage("Installation of mvn failed!");
+    assertThat(context).logAtSuccess().hasMessage("Successfully updated settings repository.");
+    assertThat(context).logAtSuccess().hasMessage("Install or update software");
+  }
 }

--- a/cli/src/test/resources/ide-projects/update/repository/java/java/default/bin/java
+++ b/cli/src/test/resources/ide-projects/update/repository/java/java/default/bin/java
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo java $*

--- a/cli/src/test/resources/ide-projects/update/repository/mvn/mvn/default/bin/mvn
+++ b/cli/src/test/resources/ide-projects/update/repository/mvn/mvn/default/bin/mvn
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "mvn $*"


### PR DESCRIPTION
Fixes: #628 

Implements:
* added catch of exceptions for ToolCommandlet installations
* converted steps to try-with-resources
* added new test for failed update substeps
* added mvn and java repositories to update test-project