### PR TITLE
#588: reload context after clone settings

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,8 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/440[#440]: Generalize intellij OS startup command for all OS's
 * https://github.com/devonfw/IDEasy/issues/612[#612]: Automatically generated issue URL is still pointing to ide instead of IDEasy
 * https://github.com/devonfw/IDEasy/issues/52[#52]: Adjusting Intellij settings in ide-settings
+* https://github.com/devonfw/IDEasy/issues/588[#588]: ide create installs wrong Java version
+
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/13?closed=1[milestone 2024.09.002].
 
 == 2024.09.001

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.devonfw.tools.ide.context.AbstractIdeContext;
 import com.devonfw.tools.ide.context.GitContext;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.property.FlagProperty;
@@ -45,12 +46,18 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
 
     updateSettings();
     updateConf();
+    reloadContext();
 
     if (this.skipTools.isTrue()) {
       this.context.info("Skipping installation/update of tools as specified by the user.");
     } else {
       updateSoftware();
     }
+  }
+
+  private void reloadContext() {
+
+    ((AbstractIdeContext) this.context).reload();
   }
 
   private void updateConf() {

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -92,7 +92,7 @@ public abstract class AbstractIdeContext implements IdeContext {
 
   private Path downloadPath;
 
-  private Path toolRepository;
+  private Path toolRepositoryPath;
 
   private Path userHome;
 
@@ -169,14 +169,14 @@ public abstract class AbstractIdeContext implements IdeContext {
     setCwd(userDir, workspace, currentDir);
 
     if (this.ideRoot == null) {
-      this.toolRepository = null;
+      this.toolRepositoryPath = null;
       this.urlsPath = null;
       this.tempPath = null;
       this.tempDownloadPath = null;
       this.softwareRepositoryPath = null;
     } else {
       Path ideBase = this.ideRoot.resolve(FOLDER_IDE);
-      this.toolRepository = ideBase.resolve("software");
+      this.toolRepositoryPath = ideBase.resolve("software");
       this.urlsPath = ideBase.resolve("urls");
       this.tempPath = ideBase.resolve("tmp");
       this.tempDownloadPath = this.tempPath.resolve(FOLDER_DOWNLOADS);
@@ -490,7 +490,7 @@ public abstract class AbstractIdeContext implements IdeContext {
   @Override
   public Path getToolRepositoryPath() {
 
-    return this.toolRepository;
+    return this.toolRepositoryPath;
   }
 
   @Override
@@ -1050,5 +1050,12 @@ public abstract class AbstractIdeContext implements IdeContext {
   public IdeStartContextImpl getStartContext() {
 
     return startContext;
+  }
+
+  /**
+   * Reloads this context and re-initializes the {@link #getVariables() variables}.
+   */
+  public void reload() {
+    this.variables = createVariables();
   }
 }


### PR DESCRIPTION
fixes #588
* reload `IdeContext` (variables) after settings are cloned and conf folder is initialized.