### PR TITLE
#655: Update Versions of Common Compress and XML-Unit Core

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.23.0</version>
+      <version>1.26.0</version>
     </dependency>
     <!-- JSON and XML support -->
     <dependency>
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
-      <version>2.9.0</version>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>


### PR DESCRIPTION
Fixes: #655 

This PR updates the versions of maven libraries that are detected by CVE scan.

Fixes: https://nvd.nist.gov/vuln/detail/CVE-2024-26308