### PR TITLE
#223: use only dynamic ports for wiremock

### DIFF
--- a/cli/src/test/java/com/devonfw/tools/ide/tool/java/JavaUrlUpdaterMock.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/java/JavaUrlUpdaterMock.java
@@ -1,21 +1,29 @@
 package com.devonfw.tools.ide.tool.java;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+
 /**
  * Mock of {@link JavaUrlUpdater} to allow integration testing with wiremock.
  */
 public class JavaUrlUpdaterMock extends JavaUrlUpdater {
 
-  private final static String TEST_URL = "http://localhost:8080/";
+  private final String baseUrl;
+
+  JavaUrlUpdaterMock(WireMockRuntimeInfo wireMockRuntimeInfo) {
+
+    super();
+    this.baseUrl = wireMockRuntimeInfo.getHttpBaseUrl();
+  }
 
   @Override
   protected String getMirror() {
 
-    return TEST_URL + "downloads/";
+    return this.baseUrl + "/downloads/";
   }
 
   @Override
   protected String doGetVersionUrl() {
 
-    return TEST_URL + "versions/";
+    return this.baseUrl + "/versions/";
   }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/java/JavaUrlUpdaterTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/java/JavaUrlUpdaterTest.java
@@ -17,12 +17,13 @@ import org.junit.jupiter.api.io.TempDir;
 import com.devonfw.tools.ide.tool.npm.NpmUrlUpdater;
 import com.devonfw.tools.ide.url.model.folder.UrlRepository;
 import com.devonfw.tools.ide.url.updater.JsonUrlUpdater;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 
 /**
  * Test class for integrations of the {@link NpmUrlUpdater}
  */
-@WireMockTest(httpPort = 8080)
+@WireMockTest
 public class JavaUrlUpdaterTest extends Assertions {
 
   /**
@@ -37,10 +38,11 @@ public class JavaUrlUpdaterTest extends Assertions {
    * Test of {@link JsonUrlUpdater} for the creation of {@link JavaUrlUpdater} download URLs and checksums.
    *
    * @param tempDir Path to a temporary directory
+   * @param wmRuntimeInfo the {@link WireMockRuntimeInfo}.
    * @throws IOException test fails
    */
   @Test
-  public void testJavaUrlUpdaterCreatesDownloadUrlsAndChecksums(@TempDir Path tempDir) throws IOException {
+  public void testJavaUrlUpdaterCreatesDownloadUrlsAndChecksums(@TempDir Path tempDir, WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
 
     // given
     stubFor(get(urlMatching("/versions/")).willReturn(aResponse().withStatus(200)
@@ -49,8 +51,7 @@ public class JavaUrlUpdaterTest extends Assertions {
     stubFor(any(urlMatching("/downloads/.*")).willReturn(aResponse().withStatus(200).withBody("aBody")));
 
     UrlRepository urlRepository = UrlRepository.load(tempDir);
-    JavaUrlUpdaterMock updater = new JavaUrlUpdaterMock();
-
+    JavaUrlUpdaterMock updater = new JavaUrlUpdaterMock(wmRuntimeInfo);
     // when
     updater.update(urlRepository);
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/npm/NpmUrlUpdaterMock.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/npm/NpmUrlUpdaterMock.java
@@ -1,15 +1,22 @@
 package com.devonfw.tools.ide.tool.npm;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+
 /**
  * Mock of {@link NpmUrlUpdater} to allow integration testing with wiremock.
  */
 public class NpmUrlUpdaterMock extends NpmUrlUpdater {
 
-  private final static String TEST_URL = "http://localhost:8080/";
+  private final String baseUrl;
+
+  NpmUrlUpdaterMock(WireMockRuntimeInfo wireMockRuntimeInfo) {
+    super();
+    this.baseUrl = wireMockRuntimeInfo.getHttpBaseUrl() + "/";
+  }
 
   @Override
   protected String getBaseUrl() {
 
-    return TEST_URL;
+    return this.baseUrl;
   }
 }

--- a/cli/src/test/resources/integrationtest/NpmJsonUrlUpdater/npm-version.json
+++ b/cli/src/test/resources/integrationtest/NpmJsonUrlUpdater/npm-version.json
@@ -36,7 +36,7 @@
       ],
       "dist": {
         "shasum": "",
-        "tarball": "http://localhost:8080/npm/-/npm-1.1.25.tgz",
+        "tarball": "${testbaseurl}/npm/-/npm-1.1.25.tgz",
         "integrity": "",
         "signatures": [
           {
@@ -126,7 +126,7 @@
       ],
       "dist": {
         "shasum": "",
-        "tarball": "http://localhost:8080/npm/-/npm-1.2.32.tgz",
+        "tarball": "${testbaseurl}/npm/-/npm-1.2.32.tgz",
         "integrity": "",
         "signatures": [
           {
@@ -214,7 +214,7 @@
       ],
       "dist": {
         "shasum": "",
-        "tarball": "http://localhost:8080/npm/-/npm-2.0.0-beta.0.tgz",
+        "tarball": "${testbaseurl}/npm/-/npm-2.0.0-beta.0.tgz",
         "integrity": "",
         "signatures": [
           {


### PR DESCRIPTION
fixes #223
still found wiremock tests with fixed port numbers and fixed them to use dynamic port