### PR TITLE
#673: fixed tomcat and improved logging

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/Commandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/Commandlet.java
@@ -231,6 +231,8 @@ public abstract class Commandlet {
 
   /**
    * Provide additional usage help of this {@link Commandlet} to the user.
+   *
+   * @param bundle the {@link NlsBundle} to get I18N messages from.
    */
   public void printHelp(NlsBundle bundle) {
 

--- a/cli/src/main/java/com/devonfw/tools/ide/repo/DefaultToolRepository.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/repo/DefaultToolRepository.java
@@ -56,6 +56,6 @@ public class DefaultToolRepository extends AbstractToolRepository {
   public Collection<ToolDependency> findDependencies(String tool, String edition, VersionIdentifier version) {
 
     UrlDependencyFile dependencyFile = this.context.getUrls().getEdition(tool, edition).getDependencyFile();
-    return dependencyFile.getDependencies().findDependencies(version);
+    return dependencyFile.getDependencies().findDependencies(version, this.context);
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -251,7 +251,11 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
 
   private void installToolDependencies(VersionIdentifier version, String edition, EnvironmentContext environmentContext, ToolRepository toolRepository) {
     Collection<ToolDependency> dependencies = toolRepository.findDependencies(this.tool, edition, version);
+    String toolWithEdition = getToolWithEdition(this.tool, edition);
+    int size = dependencies.size();
+    this.context.debug("Tool {} has {} other tool(s) as dependency", toolWithEdition, size);
     for (ToolDependency dependency : dependencies) {
+      this.context.trace("Ensuring dependency {} for tool {}", dependency.tool(), toolWithEdition);
       LocalToolCommandlet dependencyTool = this.context.getCommandletManager().getRequiredLocalToolCommandlet(dependency.tool());
       dependencyTool.installAsDependency(dependency.versionRange(), environmentContext);
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -234,7 +234,7 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
     VersionIdentifier configuredVersion = getConfiguredVersion();
     if (version.contains(configuredVersion)) {
       // prefer configured version if contained in version range
-      return install();
+      return install(false, environmentContext);
     } else {
       if (isIgnoreSoftwareRepo()) {
         throw new IllegalStateException(

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/graalvm/GraalVm.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/graalvm/GraalVm.java
@@ -7,7 +7,6 @@ import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.environment.EnvironmentVariables;
 import com.devonfw.tools.ide.environment.EnvironmentVariablesType;
-import com.devonfw.tools.ide.process.ProcessContext;
 import com.devonfw.tools.ide.process.ProcessErrorHandling;
 import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.step.Step;


### PR DESCRIPTION
fixes #673 
* One fix was also in ide-urls [commit](https://github.com/devonfw/ide-urls/commit/a33c2eee78a489df424ff94be071ec6fe25ac09c)
* The main fix here was that `environmentContext` was not passed to recursive `install` method (in such situations a NPE would have been preferred that is prevented by the EMPTY instance of EnvironmentContext)
* And for the record: IntelliJ has a severe flaw. When you run this use-case from IntelliJ, there is no way to stop the process in Intellij. The only way to end it and being able to start another run is to find and kill the process manually in task manager (what requires ProcessExplorer). This works flawless in Eclipse.