### PR TITLE
#744: Fix MAVEN_ARGS by separating arguments

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/Mvn.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/Mvn.java
@@ -249,7 +249,7 @@ public class Mvn extends PluginBasedCommandlet {
       return null;
     }
     String settingsPath = mvnSettingsFile.toString();
-    return "-s " + settingsPath + getDsettingsSecurityProperty();
+    return "-s " + settingsPath + " " + getDsettingsSecurityProperty();
   }
 
   private String getDsettingsSecurityProperty() {


### PR DESCRIPTION
Fixes: #744 

This quick bug fixes the MAVEN_ARGS variable. The reason for the bug was a missing whitespace that separates the arguments. 