### PR TITLE
#751: Moved postInstall() and changed toll installation message

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
@@ -147,12 +147,11 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
       fileAccess.delete(tmpDir);
     }
     if (exitCode == 0) {
-      this.context.success("Successfully installed {} in version {}", this.tool, resolvedVersion);
+      this.context.success("Installation process for {} in version {} has started", this.tool, resolvedVersion);
     } else {
       this.context.warning("{} in version {} was not successfully installed", this.tool, resolvedVersion);
       return false;
     }
-    postInstall();
     return true;
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -106,6 +106,7 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
       } else {
         step.success("Successfully installed {} in version {} replacing previous version {}", this.tool, resolvedVersion, installedVersion);
       }
+      postInstall();
       return true;
     } catch (RuntimeException e) {
       step.error(e, true);


### PR DESCRIPTION
### Fixes: #751 

### Implements:

- Moved the method postInstall() from GlobalToolCommandlet to LocalToolCommandlet
- Changed the installation message so that the user is not getting confused