### PR TITLE
#810: added warning message to setup 

### DIFF
--- a/cli/src/main/package/functions
+++ b/cli/src/main/package/functions
@@ -30,7 +30,7 @@ function icd() {
     ide init
     return
   elif [ $# -gt 2 ]; then
-    echo -e "\033[93mInvalid usage icd $*\033[39m" >&2
+    echo -e "\033[91mInvalid usage icd $*\033[39m" >&2
     return 1  
   fi
   if [ "$1" = "-p" ]; then

--- a/cli/src/main/package/setup
+++ b/cli/src/main/package/setup
@@ -22,6 +22,7 @@ function doSetupInConfigFile() {
 cd "$(dirname "${BASH_SOURCE:-$0}")" || exit 255
 if [ "${PWD/*\//}" != "_ide" ]; then
   echo -e "\033[93mInvalid installation path $PWD - you need to install IDEasy to a folder named '_ide'.\033[39m" >&2
+  exit 1
 fi
 echo "Setting up IDEasy in ${PWD}"
 cd ..
@@ -30,3 +31,5 @@ source "$IDE_ROOT/_ide/functions"
 
 doSetupInConfigFile ~/.bashrc
 doSetupInConfigFile ~/.zshrc
+
+echo -e "\033[93mATTENTION: IDEasy has been setup for your shells but you need to start a new shell to make it work.\nOnly if you invoked this setup script by sourcing it, you are able to run 'ide' and 'icd' commands without starting a new shell.\n\033[39m" >&2


### PR DESCRIPTION
fixes #810

added warning message to setup explaining that a new shell needs to be started to use IDEasy:
```
$ unset -f ide
$ rm /d/projects/_ide/bin/ide
$ ide help
bash: /d/projects/_ide/bin/ide: No such file or directory
$ source setup
Setting up IDEasy in /d/projects/_ide
Configuring IDEasy in /c/Users/hohwille/.bashrc.
Configuring IDEasy in /c/Users/hohwille/.zshrc.
ATTENTION: IDEasy has been setup for your shells but you need to start a new shell to make it work.
Only if you invoked this setup script by sourcing it, you are able to run 'ide' and 'icd' commands without starting a new shell.
$ ide help
__       ___ ___  ___
\ \     |_ _|   \| __|__ _ ____ _
 > >     | || |) | _|/ _` (_-< || |
/_/ ___ |___|___/|___\__,_/__/\_, |
   |___|                       |__/

Current version of IDE is 2024.12.001-beta-SNAPSHOT
...
```