### PR TITLE
#834: bugfix for long options of commandlets

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/CommandletManagerImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/CommandletManagerImpl.java
@@ -135,8 +135,9 @@ public class CommandletManagerImpl implements CommandletManager {
     if (keyword != null) {
       String name = keyword.getName();
       registerKeyword(name, commandlet);
-      if (name.startsWith("--")) {
-        registerKeyword(name.substring(2), commandlet);
+      String optionName = keyword.getOptionName();
+      if (!optionName.equals(name)) {
+        registerKeyword(optionName, commandlet);
       }
       String alias = keyword.getAlias();
       if (alias != null) {

--- a/cli/src/main/java/com/devonfw/tools/ide/property/KeywordProperty.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/property/KeywordProperty.java
@@ -34,6 +34,14 @@ public class KeywordProperty extends BooleanProperty {
     return name;
   }
 
+  /**
+   * @return the option name (e.g. "--help") or the {@link #getName() name} if not an option (e.g. "install").
+   */
+  public String getOptionName() {
+
+    return this.optionName;
+  }
+
   @Override
   public boolean isValue() {
 


### PR DESCRIPTION
fixes #834

In PR #876 I did not test well enough.
It worked initially with `--help` and `help` but then I did some cleanup that was also good but stopped the long options (`--help` and `--version` from working). With this PR it is finally fixed.