### PR TITLE
#894: Fix ide.bat printing for initialization and error output

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/894[#894]: Fix ide.bat printing for initialization and error output
 * https://github.com/devonfw/IDEasy/issues/888[#888]: Removed gu update functionality (needs to be run manually for old versions now).
 * https://github.com/devonfw/IDEasy/issues/885[#885]: Gcviewer starts in foreground fixed
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/894[#894]: Fix ide.bat printing for initialization and error output
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/18?closed=1[milestone 2025.01.001].
 
@@ -13,7 +14,6 @@ The full list of changes for this release can be found in https://github.com/dev
 
 Release with new features and bugfixes:
 
-* https://github.com/devonfw/IDEasy/issues/894[#894]: Fix ide.bat printing for initialization and error output
 * https://github.com/devonfw/IDEasy/issues/888[#888]: Removed gu update functionality (needs to be run manually for old versions now).
 * https://github.com/devonfw/IDEasy/issues/885[#885]: Gcviewer starts in foreground fixed
 

--- a/cli/src/main/package/bin/ide.bat
+++ b/cli/src/main/package/bin/ide.bat
@@ -20,6 +20,9 @@ REM https://stackoverflow.com/questions/61888625/what-is-f-in-the-for-loop-comma
 for /f "tokens=*" %%i in ('ideasy %IDE_OPTIONS% env') do (
   call set %%i
 )
-if not %ERRORLEVEL% == 0 (
+
+ideasy %IDE_OPTIONS% env>nul
+
+if %ERRORLEVEL% == 0 (
   echo IDE environment variables have been set for %IDE_HOME% in workspace %WORKSPACE%
 )

--- a/cli/src/main/package/bin/ide.bat
+++ b/cli/src/main/package/bin/ide.bat
@@ -39,4 +39,4 @@ if %ERRORLEVEL% == 0 (
 if not %ERRORLEVEL% == 0 (
 	echo %_fBRed%Error: IDEasy failed with exit code %ERRORLEVEL% %_RESET%
 	exit /b %ERRORLEVEL%
-  )
+)

--- a/cli/src/main/package/bin/ide.bat
+++ b/cli/src/main/package/bin/ide.bat
@@ -7,11 +7,14 @@ Set _RESET=[0m
 
 if not "%1%" == "" (
   ideasy %IDE_OPTIONS% %*
-  if not %ERRORLEVEL% == 0 (
-    echo %_fBRed%Error: IDEasy failed with exit code %ERRORLEVEL% %_RESET%
-    exit /b %ERRORLEVEL%
-  )
+  goto :output_error
 )
+
+:output_error
+if not %ERRORLEVEL% == 0 (
+	echo %_fBRed%Error: IDEasy failed with exit code %ERRORLEVEL% %_RESET%
+	exit /b %ERRORLEVEL%
+  )
 
 REM https://stackoverflow.com/questions/61888625/what-is-f-in-the-for-loop-command
 for /f "tokens=*" %%i in ('ideasy %IDE_OPTIONS% env') do (

--- a/cli/src/main/package/bin/ide.bat
+++ b/cli/src/main/package/bin/ide.bat
@@ -37,6 +37,6 @@ if %ERRORLEVEL% == 0 (
 
 :output_error
 if not %ERRORLEVEL% == 0 (
-	echo %_fBRed%Error: IDEasy failed with exit code %ERRORLEVEL% %_RESET%
-	exit /b %ERRORLEVEL%
+  echo %_fBRed%Error: IDEasy failed with exit code %ERRORLEVEL% %_RESET%
+  exit /b %ERRORLEVEL%
 )

--- a/cli/src/main/package/bin/ide.bat
+++ b/cli/src/main/package/bin/ide.bat
@@ -10,12 +10,6 @@ if not "%1%" == "" (
   goto :output_error
 )
 
-:output_error
-if not %ERRORLEVEL% == 0 (
-	echo %_fBRed%Error: IDEasy failed with exit code %ERRORLEVEL% %_RESET%
-	exit /b %ERRORLEVEL%
-  )
-
 REM https://stackoverflow.com/questions/61888625/what-is-f-in-the-for-loop-command
 for /f "tokens=*" %%i in ('ideasy %IDE_OPTIONS% env') do (
   call set %%i
@@ -26,3 +20,9 @@ ideasy %IDE_OPTIONS% env>nul
 if %ERRORLEVEL% == 0 (
   echo IDE environment variables have been set for %IDE_HOME% in workspace %WORKSPACE%
 )
+
+:output_error
+if not %ERRORLEVEL% == 0 (
+	echo %_fBRed%Error: IDEasy failed with exit code %ERRORLEVEL% %_RESET%
+	exit /b %ERRORLEVEL%
+  )


### PR DESCRIPTION
Fixes: #894 

This PR fixes ide.bat to print the correct output when an error occurs or ideasy is initialized.