### PR TITLE
avoid duplicated initialization of IDEasy

### DIFF
--- a/cli/src/main/package/setup
+++ b/cli/src/main/package/setup
@@ -15,7 +15,6 @@ function doSetupInConfigFile() {
   fi
   if ! grep -q 'source "$IDE_ROOT/_ide/functions"' "${cfg}"; then
     echo 'source "$IDE_ROOT/_ide/functions"' >> "${cfg}"
-    echo "ide init" >> "${cfg}"
   fi
 }
 


### PR DESCRIPTION
with #779 we have now functions getting sourced from `.bashrc` and that script already triggers an initialization.
As a leftover we still had the invocation of `ide init` in `.bashrc` causing a duplicate init that does not make any sense.
Also we might remove `init` as valid arg for `ide` command/function and therefore do not want to have such leftovers in `.bashrc` files of our users (from previous releases).
Having just a single line in `.bashrc` that will stay stable forever is the perfect solution.