### PR TITLE
remove init sub-command

### DIFF
--- a/cli/src/main/package/functions
+++ b/cli/src/main/package/functions
@@ -3,7 +3,7 @@
 function ide() {
   local return_code
   local ide_env
-  if [ $# != 0 ] && [ "$1" != "init" ]; then
+  if [ $# != 0 ]; then
     ideasy ${IDE_OPTIONS} "$@"
     return_code=$?
     if [ $return_code != 0 ]; then
@@ -19,7 +19,7 @@ function ide() {
       echo "IDE environment variables have been set for ${IDE_HOME} in workspace ${WORKSPACE}"
     fi
   fi
-  if [ "${OSTYPE}" = "cygwin" ] && [ "$1" != "init" ]; then
+  if [ "${OSTYPE}" = "cygwin" ] && [ "$#" != 0 ]; then
     echo -e "\033[93m--- WARNING: CYGWIN IS NOT SUPPORTED ---\nCygwin console is not supported by IDEasy.\nConsider using the git terminal instead.\nIf you want to use Cygwin with IDEasy, you will have to configure it yourself.\nA few suggestions and caveats can be found here:\nhttps://github.com/devonfw/IDEasy/blob/main/documentation/cygwin.adoc\n\033[39m"
   fi
 }
@@ -27,7 +27,7 @@ function ide() {
 function icd() {
   if [ $# = 1 ] && [ "${1::1}" != "-" ]; then
     cd $1 || return 1
-    ide init
+    ide
     return
   elif [ $# -gt 2 ]; then
     echo -e "\033[91mInvalid usage icd $*\033[39m" >&2
@@ -36,7 +36,7 @@ function icd() {
   if [ "$1" = "-p" ]; then
     if [ -d "${IDE_ROOT}/$2" ]; then
       cd "${IDE_ROOT}/$2"
-      ide init
+      ide
       return
     else
       echo -e "\033[93mNo such IDE project ${IDE_ROOT}/$2\033[39m" >&2
@@ -44,7 +44,7 @@ function icd() {
     fi
   fi
   if [ ! -d "${IDE_HOME}" ]; then
-    ide init
+    ide
   fi
   if [ $# = 0 ]; then
     if [ -d "${IDE_HOME}" ]; then
@@ -60,7 +60,7 @@ function icd() {
     fi
     if [ -d "${IDE_HOME}/workspaces/${wksp}" ]; then
       cd "${IDE_HOME}/workspaces/${wksp}"
-      ide init
+      ide
       return
     else
       echo -e "\033[93mNo such IDE workspace ${IDE_HOME}/workspaces/${wksp}\033[39m" >&2
@@ -90,5 +90,5 @@ if ! command -v ideasy &> /dev/null; then
 fi
 
 complete -F _ide_completion ide
-ide init
+ide
 


### PR DESCRIPTION
with #779 we introduced `functions` script that defines the `ide` "command" as a function instead of an alias.
There we decided to add a virtual sub-command `init` so that we distinguish `ide` from `ide init`.
The idea was that when `ide init` is called we do only a minimum initialization and print no extra messages because this is what happens when a new shell is started. On the other hand we had the idea that when the user just calles `ide` that he gets more verbose output like #758. But as we later decided that the user should explicitly call `ide status` to get such extra details we consider that calling jsut `ide` should still remain minimal and only initialize my environment variables.

ATTENTION: This PR is to be discussed with the team.
We had the idea to have the following extra features when `ide` is called explicitly by the user (compared to if `ide init` is called when the shell is started):
* `You are not inside an IDEasy project: $PWD` (see also issue #739)
* Cygwin warning (see also #715)

If we agree that we do not want or need such feedback messages if just `ide` is called, we can merge this PR to simplify our script and avoid confusion with `ide init` that does not show up in `ide help` since there is no `InitCommandlet`.