### PR TITLE
#903: fix test to avoid modification in src/test/resources causing other tests to turn red as side effect

### DIFF
--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/EditionGetCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/EditionGetCommandletTest.java
@@ -39,7 +39,7 @@ public class EditionGetCommandletTest extends AbstractIdeContextTest {
 
     // arrange
     String tool = "az";
-    IdeTestContext context = newContext(PROJECT, null, false);
+    IdeTestContext context = newContext(PROJECT, null, true);
     mockInstallTool(context, tool);
     EditionGetCommandlet editionGet = context.getCommandletManager().getCommandlet(EditionGetCommandlet.class);
     editionGet.tool.setValueAsString(tool, context);


### PR DESCRIPTION
Test-quickfix introduced by PR #903