### PR TITLE
#935: followup - remove implicit status invocation

### DIFF
--- a/cli/src/main/package/functions
+++ b/cli/src/main/package/functions
@@ -15,7 +15,6 @@ function ide() {
   if [ $? = 0 ]; then
     eval "${ide_env}"
     if [ $# = 0 ]; then
-      ideasy ${IDE_OPTIONS} status
       echo "IDE environment variables have been set for ${IDE_HOME} in workspace ${WORKSPACE}"
     fi
   fi


### PR DESCRIPTION
follow up fix of #935

do not make `ide` command without args call `ideasy status`.
User shall explicitly call `ide status` to get the status to avoid undesired log "spam".