### PR TITLE
#914: #940: quickfix to print correct filename

### DIFF
--- a/cli/src/main/package/setup
+++ b/cli/src/main/package/setup
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 function createFileIfNotExists() {
-  local file=$1
-  if [ ! -f "${file}" ]; then
-    touch "$file"
-    echo "Created ${file}"
+  local configFile=$1
+  if [ ! -f "${configFile}" ]; then
+    touch "${configFile}"
+    echo "Created ${configFile}"
   fi
 }
 


### PR DESCRIPTION
fixes #914
fixes #940 

Before:
```
Setting up IDEasy in D:\projects\_ide
IDEasy is already added to your PATH.
Found bash at C:\Program Files\Git\bin\bash.exe
"C:\Program Files\Git\bin\bash.exe" -l -c "cd \"D:\projects\_ide\";./setup"
Setting up IDEasy in /d/projects/_ide
2025.01.001-beta-01_21_02-SNAPSHOT
Created /home/runner/work/IDEasy/IDEasy/cli/pom.xml
Configuring IDEasy in /c/Users/hohwille/.bashrc.
Created /home/runner/work/IDEasy/IDEasy/cli/pom.xml
Configuring IDEasy in /c/Users/hohwille/.zshrc.
ATTENTION: IDEasy has been setup for your shells but you need to start a new shell to make it work.
Only if you invoked this setup script by sourcing it, you are able to run 'ide' and 'icd' commands without starting a new shell.

Setup of IDEasy completed
Drücken Sie eine beliebige Taste . . .
```

Bug is wrong filename in 
```
Created /home/runner/work/IDEasy/IDEasy/cli/pom.xml
```

With this fix I get:
```
Setting up IDEasy in D:\projects\_ide
IDEasy is already added to your PATH.
Found bash at C:\Program Files\Git\bin\bash.exe
"C:\Program Files\Git\bin\bash.exe" -l -c "cd \"D:\projects\_ide\";./setup"
Setting up IDEasy in /d/projects/_ide
2025.01.001-beta-01_21_02-SNAPSHOT
Created /c/Users/hohwille/.bashrc
Configuring IDEasy in /c/Users/hohwille/.bashrc.
Created /c/Users/hohwille/.zshrc
Configuring IDEasy in /c/Users/hohwille/.zshrc.
ATTENTION: IDEasy has been setup for your shells but you need to start a new shell to make it work.
Only if you invoked this setup script by sourcing it, you are able to run 'ide' and 'icd' commands without starting a new shell.

Setup of IDEasy completed
Drücken Sie eine beliebige Taste . . .
```

Only problem: I have no clue why the error happened before...
The adding of curly braces should not be the reason.
So renaming of the local variable did fix it???