### PR TITLE
#979: configure reflection to make xpath work

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/com.devonfw.tools.IDEasy/ide-cli/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/com.devonfw.tools.IDEasy/ide-cli/reflect-config.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "com.sun.org.apache.xpath.internal.functions.FuncNormalizeSpace",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.org.apache.xpath.internal.functions.FuncLocalPart",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]


### PR DESCRIPTION
fixes #979 
add GraalVM `reflect-config.json` to fix the XPath problem in native image.
Already tested locally.