### PR TITLE
#958: instead of upgrade better remove epub since we do not need it

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -36,7 +36,6 @@
     <maven.build.timestamp.format>yyyy-MM-dd_HH.mm.ss</maven.build.timestamp.format>
     <asciidoctor.maven.plugin.version>1.6.0</asciidoctor.maven.plugin.version>
     <asciidoctorj.pdf.version>1.5.0-alpha.18</asciidoctorj.pdf.version>
-    <asciidoctorj.epub.version>1.5.0-alpha.9</asciidoctorj.epub.version>
     <jruby.version>9.2.6.0</jruby.version>
     <asciidoctor.skip>false</asciidoctor.skip>
     <flatten.mode>resolveCiFriendliesOnly</flatten.mode>
@@ -226,11 +225,6 @@
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-pdf</artifactId>
             <version>${asciidoctorj.pdf.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.asciidoctor</groupId>
-            <artifactId>asciidoctorj-epub3</artifactId>
-            <version>${asciidoctorj.epub.version}</version>
           </dependency>
           <dependency>
             <groupId>org.jruby</groupId>


### PR DESCRIPTION
See #958 
Since we only want to generate PDF, we do not need epub and better remove it so we do not need the upgrade #958 and all future upgrades that may come.