### PR TITLE
#599: graalvm compatibility mode to make x86-64 releases work on arm-64

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 Release with new features and bugfixes:
 
 * https://github.com/devonfw/IDEasy/issues/993[#993] Creation of start scripts for IDEs
+* https://github.com/devonfw/IDEasy/pull/1003[#1003] graalvm compatibility mode to make x86-64 releases work on arm-64
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/20?closed=1[milestone 2025.01.003].
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -247,6 +247,7 @@
               <buildArgs>
                 <arg>--enable-url-protocols=http,https</arg>
                 <arg>--initialize-at-build-time=org.apache.commons</arg>
+                <arg>-march=compatibility</arg>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
Improvement for #599 
Currently our windows-x64 releases do not even run on windows@arm via emulation.
This PR should fix this.