### PR TITLE
#954: fix log message

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/git/repository/RepositoryCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/repository/RepositoryCommandlet.java
@@ -100,7 +100,7 @@ public class RepositoryCommandlet extends Commandlet {
     if (Files.isDirectory(repositoryPath.resolve(GitContext.GIT_FOLDER))) {
       this.context.info("Repository {} already exists at {}", repositoryId, repositoryPath);
       if (!this.context.isForceMode()) {
-        this.context.info("Ignoring repository {} - use --force to rerun setup.", repositoryId, repositoryPath);
+        this.context.info("Ignoring repository {} - use --force to rerun setup.", repositoryId);
         return;
       }
     }


### PR DESCRIPTION
In the Story-Review of #990 we found a simple logging bug causing:
```
Invalid log message with 2 argument(s) but less placeholders: Ignoring repository {} - use --force to rerun setup.
Ignoring repository base - use --force to rerun setup.
```

The first of the two log messages indicates a bug in our code:
https://github.com/devonfw/IDEasy/blob/e4b0f98b8cef4ed2f3814525c8409e9f6d570d85/cli/src/main/java/com/devonfw/tools/ide/git/repository/RepositoryCommandlet.java#L103

It is printed in red for every repository what is rather annoying.
Since fix is trivial and no risc, we will include it into our release.