### PR TITLE
1019: extra spaces should not cause problem in version range expression

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionRange.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionRange.java
@@ -174,11 +174,11 @@ public final class VersionRange implements Comparable<VersionRange>, GenericVers
       max = min;
     } else {
       String minString = value.substring(0, index);
-      if (!minString.isEmpty()) {
+      if (!minString.isBlank()) {
         min = VersionIdentifier.of(minString);
       }
       String maxString = value.substring(index + 1);
-      if (!maxString.isEmpty()) {
+      if (!maxString.isBlank()) {
         max = VersionIdentifier.of(maxString);
       }
     }

--- a/cli/src/test/java/com/devonfw/tools/ide/version/VersionRangeTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/version/VersionRangeTest.java
@@ -16,6 +16,7 @@ public class VersionRangeTest extends Assertions {
     checkVersionRange("[1.2,3]", "1.2", "3", BoundaryType.CLOSED);
     checkVersionRange("1,)", "1", null, BoundaryType.RIGHT_OPEN);
     checkVersionRange("[1,)", "1", null, BoundaryType.RIGHT_OPEN);
+    checkVersionRange("[1, )", "1", null, BoundaryType.RIGHT_OPEN);
     checkVersionRange("(1.2,3.4", "1.2", "3.4", BoundaryType.LEFT_OPEN);
     checkVersionRange("(1.2,3.4]", "1.2", "3.4", BoundaryType.LEFT_OPEN);
     checkVersionRange("1.2,3.4)", "1.2", "3.4", BoundaryType.RIGHT_OPEN);


### PR DESCRIPTION
#1019 
"blank" strings should be treated as "empty" strings, rather than causing errors