### PR TITLE
#1060: ide status runs correct in folder c:/projects (d:/project)

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/StatusCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/StatusCommandlet.java
@@ -41,8 +41,8 @@ public class StatusCommandlet extends Commandlet {
       logSettingsGitStatus();
       logSettingsLegacyStatus();
       logMigrationStatus();
-      new IdeasyCommandlet(this.context, null).checkIfUpdateIsAvailable();
     }
+    new IdeasyCommandlet(this.context, null).checkIfUpdateIsAvailable();
   }
 
   private void logSettingsLegacyStatus() {

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -271,6 +271,11 @@ public abstract class AbstractIdeContext implements IdeContext {
     return "You are not inside an IDE installation: " + this.cwd;
   }
 
+  private String getMessageIdeHomeNotSet() {
+
+    return "IDE_HOME not set. ";
+  }
+
   private String getMessageIdeRootNotFound() {
 
     String root = getSystem().getEnv("IDE_ROOT");
@@ -737,8 +742,13 @@ public abstract class AbstractIdeContext implements IdeContext {
     if (this.ideRoot != null) {
       success("IDE_ROOT is set to {}", this.ideRoot);
     }
+
     if (this.ideHome == null) {
-      warning(getMessageIdeHomeNotFound());
+      if (this.getIdeRootPathFromEnv() != null && this.getIdeRootPathFromEnv().equals(this.ideRoot)) {
+        warning(getMessageIdeHomeNotSet());
+      } else {
+        warning(getMessageIdeHomeNotFound());
+      }
     } else {
       success("IDE_HOME is set to {}", this.ideHome);
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -266,14 +266,9 @@ public abstract class AbstractIdeContext implements IdeContext {
     return "IDE environment variables have been set for " + this.ideHome + " in workspace " + this.workspaceName;
   }
 
-  private String getMessageIdeHomeNotFound() {
+  private String getMessageNotInsideIdeProject() {
 
-    return "You are not inside an IDE installation: " + this.cwd;
-  }
-
-  private String getMessageIdeHomeNotSet() {
-
-    return "IDE_HOME not set. ";
+    return "You are not inside an IDE project: " + this.cwd;
   }
 
   private String getMessageIdeRootNotFound() {
@@ -742,13 +737,8 @@ public abstract class AbstractIdeContext implements IdeContext {
     if (this.ideRoot != null) {
       success("IDE_ROOT is set to {}", this.ideRoot);
     }
-
     if (this.ideHome == null) {
-      if (this.getIdeRootPathFromEnv() != null && this.getIdeRootPathFromEnv().equals(this.ideRoot)) {
-        warning(getMessageIdeHomeNotSet());
-      } else {
-        warning(getMessageIdeHomeNotFound());
-      }
+      warning(getMessageNotInsideIdeProject());
     } else {
       success("IDE_HOME is set to {}", this.ideHome);
     }
@@ -928,7 +918,7 @@ public abstract class AbstractIdeContext implements IdeContext {
     if (result.isValid()) {
       debug("Running commandlet {}", cmd);
       if (cmd.isIdeHomeRequired() && (this.ideHome == null)) {
-        throw new CliException(getMessageIdeHomeNotFound(), ProcessResult.NO_IDE_HOME);
+        throw new CliException(getMessageNotInsideIdeProject(), ProcessResult.NO_IDE_HOME);
       } else if (cmd.isIdeRootRequired() && (this.ideRoot == null)) {
         throw new CliException(getMessageIdeRootNotFound(), ProcessResult.NO_IDE_ROOT);
       }

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/StatusCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/StatusCommandletTest.java
@@ -24,6 +24,6 @@ public class StatusCommandletTest extends AbstractIdeContextTest {
     context.run(args);
 
     //assert
-    assertThat(context).logAtWarning().hasMessageContaining("You are not inside an IDE installation: ");
+    assertThat(context).logAtWarning().hasMessageContaining("You are not inside an IDE project: ");
   }
 }


### PR DESCRIPTION
Fixes #1060
- Check "checkIfUpdateIsAvailable" also if execution folder is the projects folder (e.g. "c:\projects") 
- Warning that IDE_HOME is not set if execution folder is the projects folder (e.g. "c:\projects")