### PR TITLE
#1087: Fix MSI Build Job in GitHub Workflows

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -44,6 +44,7 @@ jobs:
           mkdir -p windows-installer/msi-files
           cp documentation/target/generated-docs/IDEasy.pdf windows-installer/msi-files
           cp -r cli/target/package/* windows-installer/msi-files
+          cp cli/target/ideasy.exe windows-installer/msi-files/bin
           cd windows-installer
           dotnet tool install --global wix --version 5.0.2
           wix extension add WixToolset.UI.wixext/5.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
           mkdir -p windows-installer/msi-files
           cp documentation/target/generated-docs/IDEasy.pdf windows-installer/msi-files
           cp -r cli/target/package/* windows-installer/msi-files
+          cp cli/target/ideasy.exe windows-installer/msi-files/bin
           cd windows-installer
           dotnet tool install --global wix --version 5.0.2
           wix extension add WixToolset.UI.wixext/5.0.2


### PR DESCRIPTION
Fixes: #1087 
 
This PR fixes the missing include of `ideasy.exe` in the MSI build process for the `nightly build `and for the `release ` workflow.