### PR TITLE
#1087: Fix MSI Installation with setup.bat workaround

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -276,7 +276,7 @@
                 <configuration>
                   <tasks>
                     <move file="${project.basedir}/target/msi/ideasy.msi"
-                      tofile="${project.basedir}/target/${project.artifactId}-${revision}.msi"/>
+                      tofile="${project.basedir}/target/${project.artifactId}-${revision}-windows-x64.msi"/>
                   </tasks>
                 </configuration>
               </execution>
@@ -294,7 +294,7 @@
                 <configuration>
                   <artifacts>
                     <artifact>
-                      <file>${project.basedir}/target/${project.artifactId}-${revision}.msi</file>
+                      <file>${project.basedir}/target/${project.artifactId}-${revision}-windows-x64.msi</file>
                       <type>msi</type>
                     </artifact>
                   </artifacts>

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -52,7 +52,7 @@
     <!-- Execution of uninstall command-->
     <SetProperty
       Id="RunUninstallAction"
-			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;[INSTALLFOLDER]bin\ideasy.exe -f uninstall&quot;"
+			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;%IDE_ROOT%\_ide\installation\bin\ideasy.exe -f uninstall&quot;"
       Before="RunUninstallAction"
       Sequence="execute"
       />
@@ -62,7 +62,7 @@
       DllEntry="WixQuietExec"
       Execute="deferred"
       Impersonate="yes"
-      Return="check"
+      Return="ignore"
       />
 
 		<!-- Specifying when Custom Actions should run -->

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -36,7 +36,7 @@
 		<!-- Execution of install command-->
 		<SetProperty
 			Id="RunInstallAction"
-			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;[INSTALLFOLDER]bin\ideasy.exe -f install&quot;"
+			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;[INSTALLFOLDER]setup.bat -b&quot;"
 			Before="RunInstallAction"
 			Sequence="execute"
 			/>


### PR DESCRIPTION
Fixes: #1087 

This PR implements 

- a workaround for the MSI Installation Setup by executing `setup.bat -b` instead of `ideasy.exe -f install`
- add hardcoded `windows-64` in filename
- change uninstall path and ignore return