### PR TITLE
#420: exclude mac and linux content from MSI

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -44,6 +44,8 @@ jobs:
           mkdir -p windows-installer/msi-files
           cp documentation/target/generated-docs/IDEasy.pdf windows-installer/msi-files
           cp -r cli/target/package/* windows-installer/msi-files
+          rm -rf windows-installer/msi-files/system/mac
+          rm -rf windows-installer/msi-files/system/linux
           cp cli/target/ideasy.exe windows-installer/msi-files/bin
           cd windows-installer
           dotnet tool install --global wix --version 5.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
           mkdir -p windows-installer/msi-files
           cp documentation/target/generated-docs/IDEasy.pdf windows-installer/msi-files
           cp -r cli/target/package/* windows-installer/msi-files
+          rm -rf windows-installer/msi-files/system/mac
+          rm -rf windows-installer/msi-files/system/linux
           cp cli/target/ideasy.exe windows-installer/msi-files/bin
           cd windows-installer
           dotnet tool install --global wix --version 5.0.2


### PR DESCRIPTION
improvement for #420 
since we copy the `package` content in a script code from the github action, the filters configured for assembly do not apply and linux and mac content gets included in windows MSI.
https://github.com/devonfw/IDEasy/blob/7fa23c7e687fe5015fd7149266cf4b7b598c463f/cli/src/main/assembly/release-win-x64.xml#L27-L28