### PR TITLE
#420: ensure os and architecture in filename

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -296,6 +296,7 @@
                     <artifact>
                       <file>${project.basedir}/target/${project.artifactId}-${revision}-windows-x64.msi</file>
                       <type>msi</type>
+                      <classifier>windows-x64</classifier>
                     </artifact>
                   </artifacts>
                 </configuration>


### PR DESCRIPTION
improvement for #420 
have os and architecture (`windows-x64`) in filename of MSI file.