### PR TITLE
#1095: Fix MSI Installation Drive Selection

### DIFF
--- a/windows-installer/Package.en-us.wxl
+++ b/windows-installer/Package.en-us.wxl
@@ -8,9 +8,9 @@ This file contains the declaration of all the localizable strings.
   <String Id="InstallPathDlgTitle" Value="{\WixUI_Font_Title}Select Project Folder" />
   <String Id="InstallPathDlgDescription" Value="Click Next to install to the default folder or customize with options below." />
   <String Id="InstallDirDlgBannerBitmap" Value="WixUI_Bmp_Banner"/>
-  <String Id="SelectRootDrive" Value="Please choose the drive where you want to install IDEasy:"/>
-  <String Id="SelectRootDriveText" Value="Please choose the drive where you want to install IDEasy:"/>
+  <String Id="SelectCustomDrive" Value="Please choose the drive where you want to install IDEasy:"/>
+  <String Id="SelectCustomDriveText" Value="Please choose the drive where you want to install IDEasy:"/>
   <String Id="SelectInstallLocationText" Value="Select your preferred installation location:"/>
-  <String Id="InstallRootOption" Value="Install in Root Directory (e.g., C:\projects)"/>
-  <String Id="InstallHomeOption" Value="Install in Home Directory (e.g., C:\Users\YourUsername\projects)"/>
+  <String Id="InstallUserHomeOption" Value="Install in Home Directory (e.g., C:\Users\YourUsername\projects)"/>
+  <String Id="InstallCustomOption" Value="Install in Custom Directory (e.g., C:\projects)"/>
 </WixLocalization>

--- a/windows-installer/Package.en-us.wxl
+++ b/windows-installer/Package.en-us.wxl
@@ -11,6 +11,6 @@ This file contains the declaration of all the localizable strings.
   <String Id="SelectCustomDrive" Value="Please choose the drive where you want to install IDEasy:"/>
   <String Id="SelectCustomDriveText" Value="Please choose the drive where you want to install IDEasy:"/>
   <String Id="SelectInstallLocationText" Value="Select your preferred installation location:"/>
-  <String Id="InstallUserHomeOption" Value="Install in Home Directory (e.g., C:\Users\YourUsername\projects)"/>
-  <String Id="InstallCustomOption" Value="Install in Custom Directory (e.g., C:\projects)"/>
+  <String Id="InstallUserHomeOption" Value="Install in Home Directory - [USERFOLDER]projects"/>
+  <String Id="InstallCustomOption" Value="Install in Custom Directory - e.g., [ROOTDRIVE]projects"/>
 </WixLocalization>

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -10,9 +10,9 @@
 		<Feature Id="main">
 			<!-- Include files that has to be installed -->
 			<Files Include="msi-files\**" />
-      <Component Id="setEnv" Directory="INSTALLFOLDER" Guid="1014136b-a934-47db-bf69-5da949b2528b">
+      <Component Id="setEnv" Directory="INSTALLFOLDER" Guid="8bea8575-87ca-4847-8b8b-202b6e34901e">
         <CreateFolder/>
-        <Environment Id="IdeRoot" Name="IDE_ROOT" Value="[IDE_ROOT]" Permanent="yes" Part="last" Action="set" System="no" />
+        <Environment Id="IdeRoot" Name="IDE_ROOT" Value="[IDE_ROOT]" Permanent="yes" Action="set" System="no" />
       </Component>
 		</Feature>
 
@@ -30,12 +30,12 @@
 		<Directory Id="ROOTDIRECTORY" />
 
     <CustomAction Id="SetIDE_ROOT" Property="IDE_ROOT" Value="[ROOTDIRECTORY]projects" Execute="immediate" Return="check" />
-    <CustomAction Id="SetTEMP_FOLDER" Property="INSTALLFOLDER" Value="[IDE_ROOT]\temp\ideasy" Execute="immediate" Return="check" />
+    <CustomAction Id="SetTEMP_FOLDER" Property="INSTALLFOLDER" Value="[IDE_ROOT]\_ide\temp\ideasy" Execute="immediate" Return="check" />
 
 		<!-- Execution of install command-->
 		<SetProperty
 			Id="RunInstallAction"
-			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;[INSTALLFOLDER]setup.bat -b&quot;"
+			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;cd /d &quot;[INSTALLFOLDER]&quot; &amp;&amp; bin\ideasy.exe -f install&quot;"
 			Before="RunInstallAction"
 			Sequence="execute"
 			/>
@@ -72,6 +72,5 @@
 
 		<!-- Custom UI Reference -->
 		<ui:WixUI Id="WixUI_InstallDirCustom" InstallDirectory="INSTALLFOLDER" />
-		
   </Package>
 </Wix>

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -10,28 +10,27 @@
 		<Feature Id="main">
 			<!-- Include files that has to be installed -->
 			<Files Include="msi-files\**" />
+      <Component Id="setEnv" Directory="INSTALLFOLDER" Guid="1014136b-a934-47db-bf69-5da949b2528b">
+        <CreateFolder/>
+        <Environment Id="IdeRoot" Name="IDE_ROOT" Value="[IDE_ROOT]" Permanent="yes" Part="last" Action="set" System="no" />
+      </Component>
 		</Feature>
 
 		<MediaTemplate EmbedCab="yes" />
-
-		<!-- Specifying license and bitmap files -->
 		<WixVariable Id="WixUILicenseRtf" Value=".\assets\LICENSE.rtf" />
 		<WixVariable Id="WixUIBannerBmp" Value=".\assets\banner.bmp" />
 
-		<!-- Specifying Directories and Properties for installation location selection-->
-		<Property Id="INSTALLTYPE" Value="ROOT" />
-		
-		<Directory Id="ROOTDIRECTORY">
-			<Directory Id="INSTALLFOLDER" Name="projects\_ide"/>
-		</Directory>
-		
-		<Property Id="USERFOLDER" >
+		<Property Id="INSTALLTYPE" Value="HOME" />
+	  <Property Id="USERFOLDER" >
 			<DirectorySearch Id="userProfileSearch" Depth="0" Path="[%USERPROFILE]" />
 		</Property>
-
 		<Directory Id="USERFOLDER" >
-			<Directory Id="USERHOMEFOLDER" Name="projects\_ide" />
+			<Directory Id="IDE_ROOT" Name="projects" />
 		</Directory>
+		<Directory Id="ROOTDIRECTORY" />
+
+    <CustomAction Id="SetIDE_ROOT" Property="IDE_ROOT" Value="[ROOTDIRECTORY]projects" Execute="immediate" Return="check" />
+    <CustomAction Id="SetTEMP_FOLDER" Property="INSTALLFOLDER" Value="[IDE_ROOT]\temp\ideasy" Execute="immediate" Return="check" />
 
 		<!-- Execution of install command-->
 		<SetProperty
@@ -52,7 +51,7 @@
     <!-- Execution of uninstall command-->
     <SetProperty
       Id="RunUninstallAction"
-			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;%IDE_ROOT%\_ide\installation\bin\ideasy.exe -f uninstall&quot;"
+			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;[%IDE_ROOT]\_ide\installation\bin\ideasy.exe -f uninstall&quot;"
       Before="RunUninstallAction"
       Sequence="execute"
       />

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -20,7 +20,7 @@
 		<WixVariable Id="WixUILicenseRtf" Value=".\assets\LICENSE.rtf" />
 		<WixVariable Id="WixUIBannerBmp" Value=".\assets\banner.bmp" />
 
-		<Property Id="INSTALLTYPE" Value="HOME" />
+		<Property Id="INSTALLTYPE" Value="USERHOME" />
 	  <Property Id="USERFOLDER" >
 			<DirectorySearch Id="userProfileSearch" Depth="0" Path="[%USERPROFILE]" />
 		</Property>

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -35,7 +35,7 @@
 		<!-- Execution of install command-->
 		<SetProperty
 			Id="RunInstallAction"
-			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;cd /d &quot;[INSTALLFOLDER]&quot; &amp;&amp; bin\ideasy.exe -f install&quot;"
+			Value='"[%SystemFolder]cmd.exe" /c "cd /d [INSTALLFOLDER] &amp;&amp; bin\ideasy.exe -f install > install.log"'
 			Before="RunInstallAction"
 			Sequence="execute"
 			/>
@@ -51,7 +51,7 @@
     <!-- Execution of uninstall command-->
     <SetProperty
       Id="RunUninstallAction"
-			Value="&quot;[%SystemFolder]cmd.exe&quot; /c &quot;[%IDE_ROOT]\_ide\installation\bin\ideasy.exe -f uninstall&quot;"
+			Value='"[%SystemFolder]cmd.exe" /c "[%IDE_ROOT]\_ide\installation\bin\ideasy.exe -f uninstall > [%IDE_ROOT]\uninstall.log"'
       Before="RunUninstallAction"
       Sequence="execute"
       />

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -30,7 +30,7 @@
 		<Directory Id="ROOTDIRECTORY" />
 
     <CustomAction Id="SetIDE_ROOT" Property="IDE_ROOT" Value="[ROOTDIRECTORY]projects" Execute="immediate" Return="check" />
-    <CustomAction Id="SetTEMP_FOLDER" Property="INSTALLFOLDER" Value="[IDE_ROOT]\_ide\temp\ideasy" Execute="immediate" Return="check" />
+    <CustomAction Id="SetTEMP_FOLDER" Property="INSTALLFOLDER" Value="[IDE_ROOT]\_ide\tmp\ideasy" Execute="immediate" Return="check" />
 
 		<!-- Execution of install command-->
 		<SetProperty

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -45,7 +45,7 @@
 			DllEntry="WixQuietExec"
 			Execute="deferred"
 			Impersonate="yes"
-			Return="ignore"
+			Return="check"
 			/>
 
     <!-- Execution of uninstall command-->

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -45,7 +45,7 @@
 			DllEntry="WixQuietExec"
 			Execute="deferred"
 			Impersonate="yes"
-			Return="check"
+			Return="ignore"
 			/>
 
     <!-- Execution of uninstall command-->

--- a/windows-installer/README.adoc
+++ b/windows-installer/README.adoc
@@ -21,14 +21,14 @@ Ensure you have the following installed:
 
 2. **Build the MSI package**
 
-   wix build Package.wxs WixUI_IDEasySetup.wxs -loc Package.en-us.wxl -ext WixToolset.UI.wixext -ext WixToolset.Util.wixext -d ProductVersion=${current.version} -o ideasy.msi
+   wix build Package.wxs WixUI_IDEasySetup.wxs -loc Package.en-us.wxl -ext WixToolset.UI.wixext -ext WixToolset.Util.wixext -o ideasy.msi
 
 == Debugging Installation Issues
 
 To debug the installation process and capture detailed logs, use the following command:
 
 ```
-msiexec /i IDEASY.msi /l*v install.log
+msiexec /i IDEASY.msi /l*vx install.log
 ```
 
 This will create a verbose log file (`install.log`) that can help diagnose installation issues.

--- a/windows-installer/WixUI_IDEasySetup.wxs
+++ b/windows-installer/WixUI_IDEasySetup.wxs
@@ -66,22 +66,21 @@
 				<Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
 				<Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
 
-				<!-- Drive selector e.g C: -->
-				<Control Id="VolumeSelectorText" Type="Text" X="20" Y="60" Width="250" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.SelectRootDriveText)" />
-				<Control Id="VolumeSelector" Type="VolumeSelectCombo" X="20" Y="80" Width="40" Height="40" Fixed="yes" Property="ROOTDRIVE" Text="!(loc.SelectRootDrive)" />
-
 				<!-- Radio Buttons to select the ROOT or USERHOME folder -->
-				<Control Id="InstallLocationText" Type="Text" X="20" Y="115" Width="250" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.SelectInstallLocationText)" />
-				<Control Id="InstallLocation" Type="RadioButtonGroup" Property="INSTALLTYPE" X="20" Y="130" Width="280" Height="100">
+				<Control Id="InstallLocationText" Type="Text" X="20" Y="60" Width="250" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.SelectInstallLocationText)" />
+				<Control Id="InstallLocation" Type="RadioButtonGroup" Property="INSTALLTYPE" X="20" Y="75" Width="280" Height="40">
 					<RadioButtonGroup Property="INSTALLTYPE">
-						<RadioButton Value="ROOT" Text="!(loc.InstallRootOption)" X="0" Y="0" Width="260" Height="20" />
-						<RadioButton Value="HOME" Text="!(loc.InstallHomeOption)" X="0" Y="20" Width="260" Height="20" />
+						<RadioButton Value="HOME" Text="!(loc.InstallHomeOption)" X="20" Y="0" Width="260" Height="20" />
+					  <!-- Drive selector e.g C: -->
+            <RadioButton Value="ROOT" Text="!(loc.InstallRootOption)" X="20" Y="20" Width="260" Height="20" />
 					</RadioButtonGroup>
 				</Control>
 
+				<Control Id="VolumeSelectorText" Type="Text" X="40" Y="120" Width="250" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.SelectRootDriveText)" />
+        <Control Id="VolumeSelector" Type="VolumeSelectCombo" X="40" Y="135" Width="40" Height="40" Fixed="yes" Remote="yes" Property="ROOTDIRECTORY" Text="!(loc.SelectRootDrive)" />
 				<Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" >
-					<Publish Property="INSTALLFOLDER" Value="[ROOTFOLDER]" Condition="INSTALLTYPE=&quot;ROOT&quot;" Order="1" />
-					<Publish Property="INSTALLFOLDER" Value="[USERHOMEFOLDER]" Condition="INSTALLTYPE=&quot;HOME&quot;" Order="2" />
+				  <Publish Event="DoAction" Value="SetIDE_ROOT" Condition="INSTALLTYPE=&quot;ROOT&quot;" Order="1" />
+				  <Publish Event="DoAction" Value="SetTEMP_FOLDER" Order="2" />
 				</Control>
 				<Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
 				<Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">

--- a/windows-installer/WixUI_IDEasySetup.wxs
+++ b/windows-installer/WixUI_IDEasySetup.wxs
@@ -66,20 +66,19 @@
 				<Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
 				<Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
 
-				<!-- Radio Buttons to select the ROOT or USERHOME folder -->
+				<!-- Radio Buttons to select USERHOME or CUSTOM folder -->
 				<Control Id="InstallLocationText" Type="Text" X="20" Y="60" Width="250" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.SelectInstallLocationText)" />
 				<Control Id="InstallLocation" Type="RadioButtonGroup" Property="INSTALLTYPE" X="20" Y="75" Width="280" Height="40">
 					<RadioButtonGroup Property="INSTALLTYPE">
-						<RadioButton Value="HOME" Text="!(loc.InstallHomeOption)" X="20" Y="0" Width="260" Height="20" />
-					  <!-- Drive selector e.g C: -->
-            <RadioButton Value="ROOT" Text="!(loc.InstallRootOption)" X="20" Y="20" Width="260" Height="20" />
+						<RadioButton Value="USERHOME" Text="!(loc.InstallUserHomeOption)" X="20" Y="0" Width="260" Height="20" />
+            <RadioButton Value="CUSTOM" Text="!(loc.InstallCustomOption)" X="20" Y="20" Width="260" Height="20" />
 					</RadioButtonGroup>
 				</Control>
 
-				<Control Id="VolumeSelectorText" Type="Text" X="40" Y="120" Width="250" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.SelectRootDriveText)" />
-        <Control Id="VolumeSelector" Type="VolumeSelectCombo" X="40" Y="135" Width="40" Height="40" Fixed="yes" Remote="yes" Property="ROOTDIRECTORY" Text="!(loc.SelectRootDrive)" />
+				<Control Id="VolumeSelectorText" Type="Text" X="40" Y="120" Width="250" Height="15" Transparent="yes" NoPrefix="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Text="!(loc.SelectCustomDriveText)" />
+        <Control Id="VolumeSelector" Type="VolumeSelectCombo" X="40" Y="135" Width="40" Height="40" Fixed="yes" Remote="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Property="ROOTDIRECTORY" Text="!(loc.SelectCustomDrive)" />
 				<Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" >
-				  <Publish Event="DoAction" Value="SetIDE_ROOT" Condition="INSTALLTYPE=&quot;ROOT&quot;" Order="1" />
+				  <Publish Event="DoAction" Value="SetIDE_ROOT" Condition="INSTALLTYPE=&quot;CUSTOM&quot;" Order="1" />
 				  <Publish Event="DoAction" Value="SetTEMP_FOLDER" Order="2" />
 				</Control>
 				<Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />

--- a/windows-installer/WixUI_IDEasySetup.wxs
+++ b/windows-installer/WixUI_IDEasySetup.wxs
@@ -75,8 +75,8 @@
 					</RadioButtonGroup>
 				</Control>
 
-				<Control Id="VolumeSelectorText" Type="Text" X="40" Y="120" Width="250" Height="15" Transparent="yes" NoPrefix="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Text="!(loc.SelectCustomDriveText)" />
-        <Control Id="VolumeSelector" Type="VolumeSelectCombo" X="40" Y="135" Width="40" Height="40" Fixed="yes" Remote="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Property="ROOTDIRECTORY" Text="!(loc.SelectCustomDrive)" />
+				<Control Id="VolumeSelectorText" Type="Text" X="51" Y="115" Width="250" Height="15" Transparent="yes" NoPrefix="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Text="!(loc.SelectCustomDriveText)" />
+        <Control Id="VolumeSelector" Type="VolumeSelectCombo" X="51" Y="130" Width="40" Height="40" Fixed="yes" Remote="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Property="ROOTDIRECTORY" Text="!(loc.SelectCustomDrive)" />
 				<Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" >
 				  <Publish Event="DoAction" Value="SetIDE_ROOT" Condition="INSTALLTYPE=&quot;CUSTOM&quot;" Order="1" />
 				  <Publish Event="DoAction" Value="SetTEMP_FOLDER" Order="2" />


### PR DESCRIPTION
Fixes: #1095 

This PR fixes the drive selection to install IDEasy into the user home folder or select a drive and the installation will be in e.g `C:\projects`

Further, the UI is adapted for the selection and `IDE_ROOT` is set during the installation. 

Tested with msi artifact from this run: https://github.com/alfeilex/IDEasy/actions/runs/13580678832 