### PR TITLE
#910 Can not update intellij on linux

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -781,7 +781,7 @@ public class FileAccessImpl implements FileAccess {
   @Override
   public void delete(Path path) {
 
-    if (!Files.exists(path)) {
+    if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
       this.context.trace("Deleting {} skipped as the path does not exist.", path);
       return;
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -2,6 +2,7 @@ package com.devonfw.tools.ide.tool;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
@@ -88,7 +89,7 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
         // we need to link the version or update the link.
         Path toolPath = getToolPath();
         FileAccess fileAccess = this.context.getFileAccess();
-        if (Files.exists(toolPath)) {
+        if (Files.exists(toolPath, LinkOption.NOFOLLOW_LINKS)) {
           fileAccess.backup(toolPath);
         }
         fileAccess.mkdirs(toolPath.getParent());


### PR DESCRIPTION
This PR fixes the issue if an simlink is broken and we check the file existence or want to delete the file. 
If we wanna know if a file exists we wanna check the actual file itself and not the target where the simlink points to. That means if we wanna delete the actual file we shouldn't follow the simlink. Window automatically prevents that and always checks the file itself. Linux is a little bit "smarter" and knows that its a simlink file and automatically follows the link to the target file and checks if the target file exists. This is actually problematic, because we delete the simlink file and create a new one we a new target to update the versions.


LinkOption.NOFOLLOW_LINKS prevents both systems to follow the link in the simlink file and actually checks if the file itself exists.