### PR TITLE
#1052: add official eclipse download URL

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/EclipseUrlUpdater.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/EclipseUrlUpdater.java
@@ -14,6 +14,7 @@ import com.devonfw.tools.ide.version.VersionSegment;
 public abstract class EclipseUrlUpdater extends WebsiteUrlUpdater {
 
   private static final String[] MIRRORS = {
+      "https://download.eclipse.org/technology/epp/downloads",
       "https://archive.eclipse.org/technology/epp/downloads",
       "https://ftp.osuosl.org/pub/eclipse/technology/epp/downloads" };
 


### PR DESCRIPTION
fixes #1052

add official eclipse download URL since other configured mirrors are outdated or seem obsolete