### PR TITLE
#692 : UrlUpdater fetches every defined version

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/docker/DockerDesktopUrlUpdater.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/docker/DockerDesktopUrlUpdater.java
@@ -31,13 +31,13 @@ public class DockerDesktopUrlUpdater extends WebsiteUrlUpdater {
     // get Code for version
     String body = doGetResponseBodyAsString("https://docs.docker.com/desktop/release-notes/");
     String regex = "href=#" + version
-        // .......1.........................................................2.................
-        + ".{8,12}(\r\n|\r|\n).{0,350}href=https://desktop\\.docker\\.com.*?(\\d{5,6}).*\\.exe";
+        // .....................................................(Group.1.)..........
+        + ".{8,12}.{0,350}href=https://desktop\\.docker\\.com.*?(\\d{5,6}).*\\.exe";
     Pattern pattern = Pattern.compile(regex, Pattern.DOTALL);
     Matcher matcher = pattern.matcher(body);
     String code;
     if (matcher.find()) {
-      code = matcher.group(2);
+      code = matcher.group(1);
       boolean success = doAddVersion(urlVersion,
           "https://desktop.docker.com/win/main/amd64/" + code + "/Docker%20Desktop%20Installer.exe", WINDOWS);
       if (!success) {


### PR DESCRIPTION
Fix: #692 

- deleted the new line patterns out of the regex in DockerDesktopUrlUpdater because Pattern.DOTALL already handles this
- TBH I do not know why this pattern now works, because it also should have worked with the (\n\r...) regex. Maybe both, regex and DOTALL don't work together
- changed the group to group1 because there is only one group left

With this implementation i was able to create versionzed folders in my custom repository for the defined docker versions:
![{5977D301-C902-4C5E-B262-B6CA530FBE01}](https://github.com/user-attachments/assets/938cdfa1-a613-4c69-ab43-ded3f460f845)

This still needs to be tested with workflow because test <-> workflow isn't the same environment and so on.