### PR TITLE
#1111: create license agreement file

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/1111[#1111]: MSI Installer hangs because it does not create .license.agreement
 * https://github.com/devonfw/IDEasy/issues/910[#910]: Cannot update Intellij on Linux - FileAlreadyExistsException
 * https://github.com/devonfw/IDEasy/issues/38[#38]: Implement ToolCommandlet for Python
 

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -51,7 +51,7 @@
     <!-- Execution of uninstall command-->
     <SetProperty
       Id="RunUninstallAction"
-			Value='"[%SystemFolder]cmd.exe" /c "[%IDE_ROOT]\_ide\installation\bin\ideasy.exe -f uninstall > [%IDE_ROOT]\uninstall.log"'
+			Value='"[%SystemFolder]cmd.exe" /c "mkdir [%USERPROFILE]\.ide &amp;&amp; echo On %date% you accepted the IDEasy License. > [%USERPROFILE]\.ide\.license.agreement &amp;&amp; [%IDE_ROOT]\_ide\installation\bin\ideasy.exe -f uninstall > [%IDE_ROOT]\uninstall.log"'
       Before="RunUninstallAction"
       Sequence="execute"
       />

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -35,7 +35,7 @@
 		<!-- Execution of install command-->
 		<SetProperty
 			Id="RunInstallAction"
-			Value='"[%SystemFolder]cmd.exe" /c "cd /d [INSTALLFOLDER] &amp;&amp; bin\ideasy.exe -f install > install.log"'
+			Value='"[%SystemFolder]cmd.exe" /c "mkdir [%USERPROFILE]\.ide &amp;&amp; echo On %date% you accepted the IDEasy License. > [%USERPROFILE]\.ide\.license.agreement &amp;&amp; cd /d [INSTALLFOLDER] &amp;&amp; bin\ideasy.exe -f install > install.log"'
 			Before="RunInstallAction"
 			Sequence="execute"
 			/>
@@ -51,7 +51,7 @@
     <!-- Execution of uninstall command-->
     <SetProperty
       Id="RunUninstallAction"
-			Value='"[%SystemFolder]cmd.exe" /c "mkdir [%USERPROFILE]\.ide &amp;&amp; echo On %date% you accepted the IDEasy License. > [%USERPROFILE]\.ide\.license.agreement &amp;&amp; [%IDE_ROOT]\_ide\installation\bin\ideasy.exe -f uninstall > [%IDE_ROOT]\uninstall.log"'
+			Value='"[%SystemFolder]cmd.exe" /c "[%IDE_ROOT]\_ide\installation\bin\ideasy.exe -f uninstall > [%IDE_ROOT]\uninstall.log"'
       Before="RunUninstallAction"
       Sequence="execute"
       />


### PR DESCRIPTION
fixes #1111
simplified and minimized alternative to PR #1119
Currently testing via GHA on my fork.
https://github.com/hohwille/IDEasy/actions/runs/13768602112/job/38501245151

MSI: https://github.com/hohwille/IDEasy/actions/runs/13768602112/artifacts/2723410455

Test negative :x: Installer hangs, license agreement not created.

OK. Stupid me, I followed the story suggestion that was pointing to the line with the uninstallation instead of the installation.
Fixed. Next try:

https://github.com/hohwille/IDEasy/actions/runs/13769078901/job/38502875404

MSI: https://github.com/hohwille/IDEasy/actions/runs/13769078901/artifacts/2723565003

Test positive: :white_check_mark: works now.