### PR TITLE
#1159: Fixed SNAPSHOT version handling

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/1159[#1159]: ide upgrade cannot find latest version at least for SNAPSHOTs
 * https://github.com/devonfw/IDEasy/issues/1153[#1153]: Print SystemInfo in ide status
 * https://github.com/devonfw/IDEasy/issues/1006[#1006]: Eclipse automation opens UI that blocks further processing until closed
 * https://github.com/devonfw/IDEasy/issues/1110[#1110]: ide status fails with IllegalStateException when offline

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/UpgradeMode.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/UpgradeMode.java
@@ -14,7 +14,7 @@ public enum UpgradeMode {
   UNSTABLE(VersionIdentifier.LATEST_UNSTABLE),
 
   /** Mode to get latest SNAPSHOT release version. */
-  SNAPSHOT(VersionIdentifier.of("*-SNAPSHOT"));
+  SNAPSHOT(VersionIdentifier.of("*!-SNAPSHOT"));
 
   private final VersionIdentifier version;
 

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionPhase.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionPhase.java
@@ -12,7 +12,7 @@ public enum VersionPhase implements AbstractVersionPhase {
   REVISION(Boolean.TRUE, "revision", "rev"),
 
   /** A snapshot version from development (e.g. "-SNAPSHOT" suffix in maven). */
-  SNAPSHOT(Boolean.FALSE, "snapshot", "dev"),
+  SNAPSHOT(Boolean.FALSE, "beta-snapshot", "snapshot", "dev"),
 
   /** A nightly build version from continuous-integration (CI) process. */
   NIGHTLY("nightly", "nb", "ci"),
@@ -130,7 +130,7 @@ public enum VersionPhase implements AbstractVersionPhase {
 
   /**
    * @param letters the {@link VersionSegment#getLettersString() letter-sequence} of a {@link VersionSegment} in
-   * {@link String#toLowerCase(java.util.Locale) lower-case}.
+   *     {@link String#toLowerCase(java.util.Locale) lower-case}.
    * @return the corresponding {@link VersionPhase}. Will be {@code #UNDEFINED} if undefined (e.g. "apple" or "banana").
    */
   public static VersionPhase of(String letters) {

--- a/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
@@ -248,4 +248,28 @@ public class VersionIdentifierTest extends Assertions {
     assertThat(v21_0_3_9).isGreaterThan(v21_35);
   }
 
+  /**
+   * Tests if unstable SNAPSHOT versions can be detected properly. See: <a href="https://github.com/devonfw/IDEasy/issues/1159">1159</a>
+   */
+  @Test
+  public void testSnapshotStarFindsUnstableVersions() {
+    VersionIdentifier snapshot_star = VersionIdentifier.of("*!-SNAPSHOT");
+    assertThat(snapshot_star.isValid()).isFalse();
+    assertThat(snapshot_star.isPattern()).isTrue();
+    assertThat(snapshot_star.matches(VersionIdentifier.of("2025.03.001-SNAPSHOT"))).isTrue();
+    assertThat(snapshot_star.matches(VersionIdentifier.of("2025.02.001-beta-SNAPSHOT"))).isTrue();
+  }
+
+  /**
+   * Tests if unstable versions will not match. See: <a href="https://github.com/devonfw/IDEasy/issues/1159">1159</a>
+   */
+  @Test
+  public void testSnapshotStarNotMatchingUnstableVersions() {
+    VersionIdentifier snapshot_star = VersionIdentifier.of("*-SNAPSHOT");
+    assertThat(snapshot_star.isValid()).isFalse();
+    assertThat(snapshot_star.isPattern()).isTrue();
+    assertThat(snapshot_star.matches(VersionIdentifier.of("2025.03.001-beta-SNAPSHOT"))).isFalse();
+    assertThat(snapshot_star.matches(VersionIdentifier.of("2025.03.001-SNAPSHOT"))).isFalse();
+  }
+
 }


### PR DESCRIPTION
Fixes: #1159

**Implements**
* changed UpgradeMode SNAPSHOT to *!=SNAPSHOT
* added beta-snapshot to VersionPhase SNAPSHOT
* added tests for unstable version and snapshot detection