### PR TITLE
#1115: Fix Git Action Warnings in Url Updater

### DIFF
--- a/.github/workflows/update-urls.yml
+++ b/.github/workflows/update-urls.yml
@@ -32,11 +32,11 @@ jobs:
           cd ide-urls
           git config --global user.name ${{ secrets.BUILD_USER }}
           git config --global user.email ${{ secrets.BUILD_USER_EMAIL }}
-          if [ "$(git status -z)" = "" ]
+          if git status -z | grep -q .
           then
-            echo "No changes, nothing to commit."
-          else
             git add .
             git commit -m "Update urls"
             git push
+          else
+            echo "No changes, nothing to commit."
           fi


### PR DESCRIPTION
This PR fixes: #1115 

Switch from comparing `$(git status -z)` with an empty string to using `grep -q .` to check for any output. That's because `-z` uses a null byte delimiter to separate filenames in the printed output. This leads to warnings in the logs because command substitution `$(...)` can not handle null bytes as input

