### PR TITLE
#1172: also prevent hyphen in HOME variables

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariables.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariables.java
@@ -274,7 +274,11 @@ public interface EnvironmentVariables {
     return getToolVariablePrefix(tool) + "_EDITION";
   }
 
-  private static String getToolVariablePrefix(String tool) {
+  /**
+   * @param tool the name of the tool.
+   * @return the given {@code tool} name in UPPER_CASE without hyphen characters.
+   */
+  static String getToolVariablePrefix(String tool) {
 
     return tool.toUpperCase(Locale.ROOT).replace('-', '_');
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -6,11 +6,11 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
-import java.util.Locale;
 import java.util.Set;
 
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.environment.EnvironmentVariables;
 import com.devonfw.tools.ide.io.FileAccess;
 import com.devonfw.tools.ide.io.FileCopyMode;
 import com.devonfw.tools.ide.process.EnvironmentContext;
@@ -417,7 +417,7 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
    */
   public void setEnvironment(EnvironmentContext environmentContext, ToolInstallation toolInstallation, boolean extraInstallation) {
 
-    String pathVariable = this.tool.toUpperCase(Locale.ROOT) + "_HOME";
+    String pathVariable = EnvironmentVariables.getToolVariablePrefix(this.tool) + "_HOME";
     environmentContext.withEnvVar(pathVariable, toolInstallation.linkDir().toString());
     if (extraInstallation) {
       environmentContext.withPathEntry(toolInstallation.binDir());


### PR DESCRIPTION
fixes #1172

also needs to be `ANDROID_STUDIO_HOME` instead of `ANDROID-STUDIO_HOME`.