### PR TITLE
#951: Fix ANSI support for coloring in cmd and powershell

### DIFF
--- a/cli/src/main/package/setup.bat
+++ b/cli/src/main/package/setup.bat
@@ -8,6 +8,9 @@ Set _RESET=[0m
 pushd %~dp0
 echo Setting up IDEasy from %CD%
 
+REM activate ANSI support for colors in CMD and Powershell
+reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 1 /f
+
 REM find bash on your Windows system...
 for %%H in ( HKEY_LOCAL_MACHINE HKEY_CURRENT_USER ) do for /F "usebackq tokens=2*" %%O in (`call "%SystemRoot%"\system32\reg.exe query "%%H\Software\GitForWindows" /v "InstallPath" 2^>nul ^| "%SystemRoot%\system32\findstr.exe" REG_SZ`) do set GIT_HOME=%%P
 


### PR DESCRIPTION
Fixes: #951 

This PR fixes the `�[91m�[0m` codes in the output after running `setup.bat` in native `cmd` and `powershell` terminals (not inside windows terminal). 

It enables the support of ANSI codes by setting a registry value.
`reg add HKCU\Console /v VirtualTerminalLevel /t REG_DWORD /d 1 /f`

We may need to discuss whether we want to force this enabling with `/f` or allow the user to decide whether to enable it. Moreover, we should decide if we want to add this registry in the background without informing the user about it at all.