### PR TITLE
#1233: Fix dropdown width of drive selection in MSI installer

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,9 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/1233[#1233]: Fix dropdown width in MSI installer for drive selection
+
+
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/26?closed=1[milestone 2025.04.002].
 
 == 2025.04.001

--- a/windows-installer/WixUI_IDEasySetup.wxs
+++ b/windows-installer/WixUI_IDEasySetup.wxs
@@ -76,7 +76,7 @@
 				</Control>
 
 				<Control Id="VolumeSelectorText" Type="Text" X="51" Y="115" Width="250" Height="15" Transparent="yes" NoPrefix="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Text="!(loc.SelectCustomDriveText)" />
-        <Control Id="VolumeSelector" Type="VolumeSelectCombo" X="51" Y="130" Width="40" Height="40" Fixed="yes" Remote="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Property="ROOTDIRECTORY" Text="!(loc.SelectCustomDrive)" />
+        <Control Id="VolumeSelector" Type="VolumeSelectCombo" X="51" Y="130" Width="45" Height="40" Fixed="yes" Remote="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Property="ROOTDIRECTORY" Text="!(loc.SelectCustomDrive)" />
 				<Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" >
 				  <Publish Event="DoAction" Value="SetIDE_ROOT" Condition="INSTALLTYPE=&quot;CUSTOM&quot;" Order="1" />
 				  <Publish Event="DoAction" Value="SetTEMP_FOLDER" Order="2" />

--- a/windows-installer/WixUI_IDEasySetup.wxs
+++ b/windows-installer/WixUI_IDEasySetup.wxs
@@ -76,7 +76,7 @@
 				</Control>
 
 				<Control Id="VolumeSelectorText" Type="Text" X="51" Y="115" Width="250" Height="15" Transparent="yes" NoPrefix="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Text="!(loc.SelectCustomDriveText)" />
-        <Control Id="VolumeSelector" Type="VolumeSelectCombo" X="51" Y="130" Width="45" Height="40" Fixed="yes" Remote="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Property="ROOTDIRECTORY" Text="!(loc.SelectCustomDrive)" />
+        <Control Id="VolumeSelector" Type="VolumeSelectCombo" X="51" Y="130" Width="52" Height="40" Fixed="yes" Remote="yes" HideCondition="INSTALLTYPE=&quot;USERHOME&quot;" ShowCondition="INSTALLTYPE=&quot;CUSTOM&quot;" Property="ROOTDIRECTORY" Text="!(loc.SelectCustomDrive)" />
 				<Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" >
 				  <Publish Event="DoAction" Value="SetIDE_ROOT" Condition="INSTALLTYPE=&quot;CUSTOM&quot;" Order="1" />
 				  <Publish Event="DoAction" Value="SetTEMP_FOLDER" Order="2" />


### PR DESCRIPTION
Fixes: #1233

This PR increases the dropdown width of drive selection in MSI installer. The reason for that change is that with scaling set to 100%, the dropdown field was too narrow.