### PR TITLE
#793: add support for IDE_MIN_VERSION

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/CreateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/CreateCommandlet.java
@@ -1,8 +1,11 @@
 package com.devonfw.tools.ide.commandlet;
 
+import static com.devonfw.tools.ide.variable.IdeVariables.IDE_MIN_VERSION;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.devonfw.tools.ide.cli.CliException;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.git.GitUrl;
 import com.devonfw.tools.ide.io.FileAccess;
@@ -61,6 +64,12 @@ public class CreateCommandlet extends AbstractUpdateCommandlet {
 
     initializeProject(newProjectPath);
     this.context.setIdeHome(newProjectPath);
+    if (IdeVersion.getVersionIdentifier().compareVersion(IDE_MIN_VERSION.get(context)).isLess()) {
+      throw new CliException(String.format("Your version of IDEasy is currently %s\n"
+          + "However, this is too old as your project requires at latest version %s\n"
+          + "Please run the following command to update to the latest version of IDEasy and fix the problem:\n"
+          + "ide upgrade", IdeVersion.getVersionIdentifier().toString(), IDE_MIN_VERSION.get(context).toString()));
+    }
     super.run();
     this.context.getFileAccess().writeFileContent(IdeVersion.getVersionString(), newProjectPath.resolve(IdeContext.FILE_SOFTWARE_VERSION));
     this.context.success("Successfully created new project '{}'.", newProjectName);

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -1,5 +1,7 @@
 package com.devonfw.tools.ide.context;
 
+import static com.devonfw.tools.ide.variable.IdeVariables.IDE_MIN_VERSION;
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -67,6 +69,7 @@ import com.devonfw.tools.ide.validation.ValidationResult;
 import com.devonfw.tools.ide.validation.ValidationResultValid;
 import com.devonfw.tools.ide.validation.ValidationState;
 import com.devonfw.tools.ide.variable.IdeVariables;
+import com.devonfw.tools.ide.version.IdeVersion;
 import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
@@ -899,6 +902,7 @@ public abstract class AbstractIdeContext implements IdeContext {
         }
       }
       this.startContext.activateLogging();
+      verifyIdeMinVersion();
       if (result != null) {
         error(result.getErrorMessage());
       }
@@ -1058,6 +1062,15 @@ public abstract class AbstractIdeContext implements IdeContext {
               this.ideHome.getFileName(), this.ideRoot);
         }
       }
+    }
+  }
+
+  private void verifyIdeMinVersion() {
+    if (IdeVersion.getVersionIdentifier().compareVersion(IDE_MIN_VERSION.get(this)).isLess()) {
+      warning(String.format("Your version of IDEasy is currently %s\n"
+          + "However, this is too old as your project requires at latest version %s\n"
+          + "Please run the following command to update to the latest version of IDEasy and fix the problem:\n"
+          + "ide upgrade", IdeVersion.getVersionIdentifier().toString(), IDE_MIN_VERSION.get(this).toString()));
     }
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java
@@ -38,7 +38,7 @@ public interface IdeVariables {
 
   /** {@link VariableDefinition} for minimum IDE product version. */
   // TODO define initial IDEasy version as default value
-  VariableDefinitionVersion IDE_MIN_VERSION = new VariableDefinitionVersion("IDE_MIN_VERSION", "DEVON_IDE_MIN_VERSION");
+  VariableDefinitionVersion IDE_MIN_VERSION = new VariableDefinitionVersion("IDE_MIN_VERSION");
 
   /** {@link VariableDefinition} for version of maven (mvn). */
   VariableDefinitionVersion MVN_VERSION = new VariableDefinitionVersion("MVN_VERSION", "MAVEN_VERSION");

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/CreateCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/CreateCommandletTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.Test;
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.context.IdeTestContext;
+import com.devonfw.tools.ide.environment.EnvironmentVariables;
+import com.devonfw.tools.ide.environment.EnvironmentVariablesType;
+import com.devonfw.tools.ide.version.IdeVersion;
 
 /**
  * Test of {@link CreateCommandlet}.
@@ -33,5 +36,42 @@ class CreateCommandletTest extends AbstractIdeContextTest {
     assertThat(newProjectPath.resolve(IdeContext.FOLDER_PLUGINS)).exists();
     assertThat(newProjectPath.resolve(IdeContext.FOLDER_SOFTWARE)).exists();
     assertThat(newProjectPath.resolve(IdeContext.FOLDER_WORKSPACES).resolve(IdeContext.WORKSPACE_MAIN)).exists();
+  }
+
+  @Test
+  public void testIdeVersionTooSmall() {
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    CreateCommandlet cc = context.getCommandletManager().getCommandlet(CreateCommandlet.class);
+    cc.newProject.setValueAsString(NEW_PROJECT_NAME, context);
+    cc.settingsRepo.setValue(IdeContext.DEFAULT_SETTINGS_REPO_URL);
+    cc.skipTools.setValue(true);
+    EnvironmentVariables variables = context.getVariables();
+    String errorMessage = String.format("Your version of IDEasy is currently %s\n"
+        + "However, this is too old as your project requires at latest version %s\n"
+        + "Please run the following command to update to the latest version of IDEasy and fix the problem:\n"
+        + "ide upgrade", IdeVersion.getVersionIdentifier().toString(), String.valueOf(Integer.MAX_VALUE));
+    // act
+    variables.getByType(EnvironmentVariablesType.CONF).set("IDE_MIN_VERSION", String.valueOf(Integer.MAX_VALUE));
+    // assert
+    assertThatThrownBy(() -> cc.run()).hasMessage(errorMessage);
+  }
+
+  @Test
+  public void testIdeVersionOk() {
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    CreateCommandlet cc = context.getCommandletManager().getCommandlet(CreateCommandlet.class);
+    cc.newProject.setValueAsString(NEW_PROJECT_NAME, context);
+    cc.settingsRepo.setValue(IdeContext.DEFAULT_SETTINGS_REPO_URL);
+    cc.skipTools.setValue(true);
+    EnvironmentVariables variables = context.getVariables();
+    String ideVersion = IdeVersion.getVersionIdentifier().toString();
+    String errorMessage = String.format("Your version of IDEasy is currently %s\n"
+        + "However, this is too old as your project requires at latest version %s\n"
+        + "Please run the following command to update to the latest version of IDEasy and fix the problem:\n"
+        + "ide upgrade", ideVersion, ideVersion);
+    // act
+    assertThat(cc);
   }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/context/IdeContextTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/IdeContextTest.java
@@ -4,10 +4,12 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
+import com.devonfw.tools.ide.cli.CliArguments;
 import com.devonfw.tools.ide.common.SystemPath;
 import com.devonfw.tools.ide.environment.EnvironmentVariables;
 import com.devonfw.tools.ide.environment.EnvironmentVariablesType;
 import com.devonfw.tools.ide.variable.IdeVariables;
+import com.devonfw.tools.ide.version.IdeVersion;
 
 /**
  * Integration test of {@link IdeContext}.
@@ -126,6 +128,45 @@ public class IdeContextTest extends AbstractIdeContextTest {
     assertThat(IdeVariables.WORKSPACE.get(context)).isEqualTo(workspaceName);
     assertThat(workspacePath).isEqualTo(TEST_PROJECTS.resolve(PROJECT_BASIC).resolve(path).toAbsolutePath());
     assertThat(workspaceName).isEqualTo("foo-test");
+  }
+
+  // hier test einfügen mit idetestcontext
+  @Test
+  public void testIdeVersionTooSmall() {
+    // arrange
+    String path = "project/workspaces/foo-test";
+    IdeTestContext context = newContext(PROJECT_BASIC, path, false);
+    EnvironmentVariables variables = context.getVariables();
+    String ideMinVersion = String.valueOf(Integer.MAX_VALUE);
+    variables.getByType(EnvironmentVariablesType.CONF).set("IDE_MIN_VERSION", ideMinVersion);
+    CliArguments args = new CliArguments();
+    String warningMessage = String.format("Your version of IDEasy is currently %s\n"
+        + "However, this is too old as your project requires at latest version %s\n"
+        + "Please run the following command to update to the latest version of IDEasy and fix the problem:\n"
+        + "ide upgrade", IdeVersion.getVersionIdentifier().toString(), ideMinVersion);
+    // act
+    context.run(args);
+    // assert
+    assertThat(context).logAtWarning().hasMessage(warningMessage);
+  }
+
+  @Test
+  public void testIdeVersionOk() {
+    // arrange
+    String path = "project/workspaces/foo-test";
+    IdeTestContext context = newContext(PROJECT_BASIC, path, false);
+    EnvironmentVariables variables = context.getVariables();
+    String ideVersion = IdeVersion.getVersionIdentifier().toString();
+    variables.getByType(EnvironmentVariablesType.CONF).set("IDE_MIN_VERSION", ideVersion);
+    CliArguments args = new CliArguments();
+    String warningMessage = String.format("Your version of IDEasy is currently %s\n"
+        + "However, this is too old as your project requires at latest version %s\n"
+        + "Please run the following command to update to the latest version of IDEasy and fix the problem:\n"
+        + "ide upgrade", ideVersion, ideVersion);
+    // act
+    context.run(args);
+    // assert
+    assertThat(context).logAtWarning().hasNoMessage(warningMessage);
   }
 
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/environment/EnvironmentVariablesPropertiesFileTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/environment/EnvironmentVariablesPropertiesFileTest.java
@@ -44,12 +44,11 @@ class EnvironmentVariablesPropertiesFileTest extends AbstractIdeContextTest {
     assertThat(variables.get("KEY")).isEqualTo("value");
     assertThat(variables.get("IDE_MIN_VERSION")).isEqualTo("2024.11.001");
     assertThat(variables.getToolVersion("java")).isEqualTo(VersionIdentifier.LATEST);
-    assertThat(variables.getVariables()).hasSize(6);
+    assertThat(variables.getVariables()).hasSize(7);
     assertThat(context).log(IdeLogLevel.WARNING)
         .hasEntries("Duplicate variable definition MVN_VERSION with old value 'undefined' and new value '3.9.0' in " + propertiesFilePath,
             "Both legacy variable MAVEN_VERSION and official variable MVN_VERSION are configured in " + propertiesFilePath
                 + " - ignoring legacy variable declaration!",
-            "Duplicate variable definition IDE_MIN_VERSION with old value '2023.07.003' and new value '2024.11.001' in " + propertiesFilePath,
             "Variable JAVA_VERSION is configured with empty value, please fix your configuration.");
   }
 

--- a/documentation/configuration.adoc
+++ b/documentation/configuration.adoc
@@ -7,7 +7,7 @@ toc::[]
 The configuration of the link:cli.adoc[ide] command and environment variables takes place via `ide.properties` files.
 The following list shows these configuration folders in the order they are loaded so files can override configurations:
 
-1. build in defaults (for `MAVEN_ARGS`, `IDE_TOOLS`, etc.)
+1. built-in defaults (for `MAVEN_ARGS`, `IDE_TOOLS`, etc.)
 2. `~/.ide/` - user specific global defaults (on Windows in `%USERPROFILE%/.ide/`)
 3. `https://github.com/devonfw/ide-settings/blob/main/[settings/]` - project specific configurations from link:settings.adoc[settings].
 4. `workspaces/${WORKSPACE}/` - optional workspace specific configurations.

--- a/documentation/variables.adoc
+++ b/documentation/variables.adoc
@@ -16,7 +16,7 @@ Please note that we are trying to minimize any potential side-effect from `IDEas
 |`IDE_ROOT`|e.g. `~/projects/` or `C:\projects`|The installation root directory of `IDEasy` - see link:structure.adoc[structure] for details.
 |`IDE_HOME`|e.g. `/projects/my-project`|The top level directory of your `IDEasy` project.
 |`IDE_OPTIONS`| |General options that will be applied to each call of `IDEasy`. Should typically be used for JVM options like link:proxy-support.adoc[proxy-support].
-|`PATH`|`$IDE_HOME/software/«tool»:...:$PATH`|You system path is adjusted by `ide` link:cli.adoc[command].
+|`PATH`|`$IDE_HOME/software/«tool»:...:$PATH`|Your system path is adjusted by `ide` link:cli.adoc[command].
 |`IDE_TOOLS`|`(java mvn node npm)`|List of tools that should be installed by default on project creation.
 |`CREATE_START_SCRIPTS`| |List of IDEs that shall be used by developers in the project and therefore start-scripts are created on setup. E.g. `(eclipse intellij vscode)`
 |*`WORKSPACE`*|`main`|The link:workspaces.adoc[workspace] you are currently in. Defaults to `main` if you are not inside a link:workspaces.adoc[workspace]. Never set this variable in any `ide.properties` file.
@@ -30,9 +30,10 @@ Please note that we are trying to minimize any potential side-effect from `IDEas
 |*`IDE_VARIABLE_SYNTAX_LEGACY_SUPPORT_ENABLED`*|`true`|Enable/disable legacy support for devonfw-ide link:configurator.adoc[configuration templates] in IDE workspace folders.
 |`ECLIPSE_VMARGS`|`-Xms128M -Xmx768M -XX:MaxPermSize=256M`|JVM options for Eclipse
 |`PREFERRED_GIT_PROTOCOL`| |Allows to enforce a specific protocol for git. Options are `ssh` (for SSH) and `https`. If set any git URL will automatically be converted to the preferred protocol before IDEasy clones it. This option should only be set for individual users in `$IDE_HOME/conf/ide.properties` or `~/.ide/ide.properties` (and not in shared `settings`).
-|`FAIL_ON_AMBIGOUS_MERGE`| |If set to `true` the link:configurator.adoc#element-identification[merge:id] is ambiguous and the resulting XPath expression matches multiple elements. Typically the link:usage.adoc#admin[IDE admin] did something wrong in the workspace template configuration. However, we decided to log a warning if that happens and use the first match by default to prevent our users from being blocked or annoyed in case of such configuration error. With this property you can enforce that this is handled as error aborting the merge. If that happens the user sees the stacktrace of the error and gets asked if he want to continue in order to launch his IDE (IntelliJ, Eclipse, VSCode, etc.).
+|`FAIL_ON_AMBIGOUS_MERGE`| |If set to `true` the link:configurator.adoc#element-identification[merge:id] is ambiguous and the resulting XPath expression matches multiple elements. Typically, the link:usage.adoc#admin[IDE admin] did something wrong in the workspace template configuration. However, we decided to log a warning if that happens and use the first match by default to prevent our users from being blocked or annoyed in case of such configuration error. With this property you can enforce that this is handled as error aborting the merge. If that happens the user sees the stacktrace of the error and gets asked if they want to continue in order to launch his IDE (IntelliJ, Eclipse, VSCode, etc.).
 |`«TOOL»_EDITION`|`«tool»`|The edition of the tool `«TOOL»` to install and use (e.g. `ECLIPSE_EDITION`, `INTELLIJ_EDITION` or `DOCKER_EDITION`). Default of `DOCKER_EDITION` is `rancher`.
 |`«TOOL»_VERSION`|`*`|The version of the tool `«TOOL»` to install and use (e.g. `ECLIPSE_VERSION` or `MVN_VERSION`).
 |`«TOOL»_BUILD_OPTS`| |The arguments provided to the build-tool `«TOOL»` in order to run a build. E.g.`clean install`
 |`«TOOL»_RELEASE_OPTS`| |The arguments provided to the build-tool `«TOOL»` in order to perform a release build. E.g.`clean deploy -Dchangelist= -Pdeploy`
+|`IDE_MIN_VERSION`| | The minimum version of IDEasy that should be installed. Causes `ide create` to fail if violated, otherwise renders a warning
 |=======================


### PR DESCRIPTION
IDE_MIN_VERSION no longer falls back to DEVON_IDE_MIN_VERSION. ide create now fails if version is smaller than minimum, a warning is rendered otherwise. Documentation is updated to reflect change.