### PR TITLE
#1267: avoid CI failure on coveralls error

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,3 +16,5 @@ jobs:
         run: mvn -B -ntp -Dstyle.color=always install
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2.2.3
+        with:
+          fail-on-error: false


### PR DESCRIPTION
Implements #1267 by passing an argument to the coveralls action on pr-builds that tells it to not fail the CI pipeline when coveralls returns an error.