### PR TITLE
#716 Add VSCode extension installation visualization

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
@@ -573,6 +573,14 @@ public interface IdeContext extends IdeStartContext {
   }
 
   /**
+   * @param size the {@link IdeProgressBar#getMaxSize() expected maximum} plugin count.
+   * @return the new {@link IdeProgressBar} to use.
+   */
+  default IdeProgressBar newProgressBarForPlugins(long size) {
+    return newProgressBar(IdeProgressBar.TITLE_INSTALL_PLUGIN, size, IdeProgressBar.UNIT_NAME_PLUGIN, IdeProgressBar.UNIT_SIZE_PLUGIN);
+  }
+
+  /**
    * @return the {@link DirectoryMerger} used to configure and merge the workspace for an {@link com.devonfw.tools.ide.tool.ide.IdeToolCommandlet IDE}.
    */
   DirectoryMerger getWorkspaceMerger();

--- a/cli/src/main/java/com/devonfw/tools/ide/io/IdeProgressBar.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/IdeProgressBar.java
@@ -14,11 +14,20 @@ public interface IdeProgressBar extends AutoCloseable {
   /** The {@link #getTitle() title} for copying. */
   String TITLE_COPYING = "Copying";
 
+  /** The {@link #getTitle() title} for installing plugins. */
+  String TITLE_INSTALL_PLUGIN = "Installing Plugins";
+
   /** {@link #getUnitName() Unit name} for Megabytes. */
   String UNIT_NAME_MB = "MiB";
-  
+
   /** {@link #getUnitSize() Unit size} for Megabytes. */
   int UNIT_SIZE_MB = 1048576;
+
+  /** {@link #getUnitName() Unit name} for plugins. */
+  String UNIT_NAME_PLUGIN = "Plugins";
+
+  /** {@link #getUnitSize() Unit size} for plugins. */
+  int UNIT_SIZE_PLUGIN = 1;
 
   /**
    * @return the title (task name or activity) to display in the progress bar.

--- a/cli/src/main/java/com/devonfw/tools/ide/process/OutputListener.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/OutputListener.java
@@ -1,0 +1,20 @@
+package com.devonfw.tools.ide.process;
+
+/**
+ * Interface to listen for output.
+ */
+@FunctionalInterface
+public interface OutputListener {
+
+  /**
+   * An empty {@link OutputListener} instance doing nothing.
+   */
+  OutputListener NONE = (m, e) -> {
+  };
+
+  /**
+   * @param message the output message
+   * @param error {@code true} in case of an error, {@code false} otherwise.
+   */
+  void onOutput(String message, boolean error);
+}

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
@@ -183,4 +183,6 @@ public interface ProcessContext extends EnvironmentContext {
    */
   ProcessResult run(ProcessMode processMode);
 
+  void setOutputListener(OutputListener listener);
+
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContextImpl.java
@@ -48,6 +48,8 @@ public class ProcessContextImpl implements ProcessContext {
 
   private ProcessErrorHandling errorHandling;
 
+  private OutputListener outputListener;
+
   /**
    * The constructor.
    *
@@ -128,6 +130,11 @@ public class ProcessContextImpl implements ProcessContext {
   }
 
   @Override
+  public void setOutputListener(OutputListener listener) {
+    this.outputListener = listener;
+  }
+
+  @Override
   public ProcessResult run(ProcessMode processMode) {
 
     if (processMode == ProcessMode.DEFAULT) {
@@ -179,6 +186,12 @@ public class ProcessContextImpl implements ProcessContext {
           CompletableFuture<Void> errFut = readInputStream(process.getErrorStream(), true, output);
           outFut.get();
           errFut.get();
+
+          if (this.outputListener != null) {
+            for (OutputMessage msg : output) {
+              this.outputListener.onOutput(msg.message(), msg.error());
+            }
+          }
         }
 
         int exitCode;


### PR DESCRIPTION
### This PR fixes; #716 

### Implemented changes:

* progress bar when installing vscode extensions

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [ ] When running `mvn clean test` locally all tests pass and build is successful
- [ ] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [ ] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [ ] PR and issue(s) have suitable labels
- [ ] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [ ] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [ ] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue
