### PR TITLE
#1314: add IdeContext.runWithoutLogging to temporary disable logging

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -924,6 +924,14 @@ public abstract class AbstractIdeContext implements IdeContext {
     }
   }
 
+  @Override
+  public void runWithoutLogging(Runnable lambda, IdeLogLevel threshold) {
+
+    this.startContext.deactivateLogging(threshold);
+    lambda.run();
+    this.startContext.activateLogging();
+  }
+
   /**
    * @param cmd the potential {@link Commandlet} to {@link #apply(CliArguments, Commandlet) apply} and {@link Commandlet#run() run}.
    * @return {@code true} if the given {@link Commandlet} matched and did {@link Commandlet#run() run} successfully, {@code false} otherwise (the
@@ -1065,15 +1073,17 @@ public abstract class AbstractIdeContext implements IdeContext {
     }
   }
 
+  @Override
   public void verifyIdeMinVersion(boolean throwException) {
-    if (IDE_MIN_VERSION.get(this) == null) {
+    VersionIdentifier minVersion = IDE_MIN_VERSION.get(this);
+    if (minVersion == null) {
       return;
     }
-    if (IdeVersion.getVersionIdentifier().compareVersion(IDE_MIN_VERSION.get(this)).isLess()) {
+    if (IdeVersion.getVersionIdentifier().compareVersion(minVersion).isLess()) {
       String message = String.format("Your version of IDEasy is currently %s\n"
           + "However, this is too old as your project requires at latest version %s\n"
           + "Please run the following command to update to the latest version of IDEasy and fix the problem:\n"
-          + "ide upgrade", IdeVersion.getVersionIdentifier().toString(), IDE_MIN_VERSION.get(this).toString());
+          + "ide upgrade", IdeVersion.getVersionIdentifier().toString(), minVersion.toString());
       if (throwException) {
         throw new CliException(message);
       } else {

--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
@@ -15,6 +15,7 @@ import com.devonfw.tools.ide.git.GitContext;
 import com.devonfw.tools.ide.io.FileAccess;
 import com.devonfw.tools.ide.io.IdeProgressBar;
 import com.devonfw.tools.ide.io.IdeProgressBarNone;
+import com.devonfw.tools.ide.log.IdeLogLevel;
 import com.devonfw.tools.ide.merge.DirectoryMerger;
 import com.devonfw.tools.ide.os.SystemInfo;
 import com.devonfw.tools.ide.os.WindowsPathSyntax;
@@ -26,6 +27,7 @@ import com.devonfw.tools.ide.tool.repository.MavenRepository;
 import com.devonfw.tools.ide.tool.repository.ToolRepository;
 import com.devonfw.tools.ide.url.model.UrlMetadata;
 import com.devonfw.tools.ide.variable.IdeVariables;
+import com.devonfw.tools.ide.version.IdeVersion;
 import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
@@ -665,6 +667,24 @@ public interface IdeContext extends IdeStartContext {
   Step newStep(boolean silent, String name, Object... parameters);
 
   /**
+   * @param lambda the {@link Runnable} to {@link Runnable#run() run} while the {@link com.devonfw.tools.ide.log.IdeLogger logging} is entirely disabled.
+   *     After this the logging will be enabled again. Collected log messages will then be logged at the end.
+   */
+  default void runWithoutLogging(Runnable lambda) {
+
+    runWithoutLogging(lambda, IdeLogLevel.TRACE);
+  }
+
+  /**
+   * @param lambda the {@link Runnable} to {@link Runnable#run() run} while the {@link com.devonfw.tools.ide.log.IdeLogger logging} is entirely disabled.
+   *     After this the logging will be enabled again. Collected log messages will then be logged at the end.
+   * @param threshold the {@link IdeLogLevel} to use as threshold for filtering logs while logging is disabled and log messages are collected. Use
+   *     {@link IdeLogLevel#TRACE} to collect all logs and ensure nothing gets lost (will still not log anything that is generally not active in regular
+   *     logging) and e.g. use {@link IdeLogLevel#ERROR} to discard all logs except errors.
+   */
+  void runWithoutLogging(Runnable lambda, IdeLogLevel threshold);
+
+  /**
    * Updates the current working directory (CWD) and configures the environment paths according to the specified parameters. This method is central to changing
    * the IDE's notion of where it operates, affecting where configurations, workspaces, settings, and other resources are located or loaded from.
    *
@@ -726,9 +746,9 @@ public interface IdeContext extends IdeStartContext {
   void writeVersionFile(VersionIdentifier version, Path installationPath);
 
   /**
-   * checks if the ide version is at least IDE_MIN_VERSION
+   * Verifies that current {@link IdeVersion} satisfies {@link IdeVariables#IDE_MIN_VERSION}.
    *
-   * @param throwException whether to throw a CliException or just log a warning
+   * @param throwException whether to throw a {@link CliException} or just log a warning.
    */
   void verifyIdeMinVersion(boolean throwException);
 

--- a/cli/src/main/java/com/devonfw/tools/ide/log/IdeLogListenerCollector.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/log/IdeLogListenerCollector.java
@@ -8,7 +8,9 @@ import java.util.List;
  */
 public class IdeLogListenerCollector implements IdeLogListener {
 
-  protected List<IdeLogEntry> entries;
+  protected final List<IdeLogEntry> entries;
+
+  protected IdeLogLevel threshold;
 
   /**
    * The constructor.
@@ -16,6 +18,7 @@ public class IdeLogListenerCollector implements IdeLogListener {
   public IdeLogListenerCollector() {
     super();
     this.entries = new ArrayList<>(512);
+    this.threshold = IdeLogLevel.TRACE;
   }
 
   /**
@@ -28,9 +31,16 @@ public class IdeLogListenerCollector implements IdeLogListener {
 
   @Override
   public boolean onLog(IdeLogLevel level, String message, String rawMessage, Object[] args, Throwable error) {
-    if (this.entries != null) {
+    if (level.ordinal() >= threshold.ordinal()) {
       this.entries.add(new IdeLogEntry(level, message, rawMessage, args, error));
     }
+    return true;
+  }
+
+  /**
+   * @return {@code true} if this collector is active and collects all logs, {@code false} otherwise (disabled and no filtering of logs so regular logging).
+   */
+  protected boolean isActive() {
     return true;
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/log/IdeLoggerImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/log/IdeLoggerImpl.java
@@ -82,4 +82,19 @@ public class IdeLoggerImpl implements IdeLogger {
     }
   }
 
+  /**
+   * Disables the logging system (temporary).
+   *
+   * @param threshold the {@link IdeLogLevel} acting as threshold.
+   * @see com.devonfw.tools.ide.context.IdeContext#runWithoutLogging(Runnable, IdeLogLevel)
+   */
+  public void deactivateLogging(IdeLogLevel threshold) {
+
+    if (this.listener instanceof IdeLogListenerBuffer buffer) {
+      buffer.enable(threshold);
+    } else {
+      throw new IllegalStateException();
+    }
+  }
+
 }


### PR DESCRIPTION
fixes #1314.

### Implemented changes:

* add IdeContext.runWithoutLogging to temporary disable logging

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [ ] When running `mvn clean test` locally all tests pass and build is successful
- [ ] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [ ] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [ ] PR and issue(s) have suitable labels
- [ ] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [ ] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [ ] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue
