### PR TITLE
#351: prevent environment variables from other project causing side-effects

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/809[#809]: make uninstall with --force also remove from software repo
 * https://github.com/devonfw/IDEasy/issues/1038[#1038]: XML merger fails in native-image on custom XPath with MissingResourceException
 * https://github.com/devonfw/IDEasy/issues/1108[#1108]: Fix git authentification in terminal
+* https://github.com/devonfw/IDEasy/issues/351[#351]: Avoid inheriting environment variables from other IDEasy project if switched in the same shell session
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/28?closed=1[milestone 2025.05.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesSystem.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/environment/EnvironmentVariablesSystem.java
@@ -3,6 +3,8 @@ package com.devonfw.tools.ide.environment;
 import java.util.Map;
 
 import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.variable.IdeVariables;
+import com.devonfw.tools.ide.variable.VariableDefinition;
 
 /**
  * Implementation of {@link EnvironmentVariables} using {@link System#getenv()}.
@@ -11,9 +13,17 @@ import com.devonfw.tools.ide.context.IdeContext;
  */
 public final class EnvironmentVariablesSystem extends EnvironmentVariablesMap {
 
+  private final Map<String, String> variables;
+
   private EnvironmentVariablesSystem(IdeContext context) {
 
+    this(context, context.getSystem().getEnv());
+  }
+
+  private EnvironmentVariablesSystem(IdeContext context, Map<String, String> variables) {
+
     super(null, context);
+    this.variables = variables;
   }
 
   @Override
@@ -25,7 +35,21 @@ public final class EnvironmentVariablesSystem extends EnvironmentVariablesMap {
   @Override
   public Map<String, String> getVariables() {
 
-    return this.context.getSystem().getEnv();
+    return this.variables;
+  }
+
+  @Override
+  public String getFlat(String name) {
+
+    for (VariableDefinition<?> variable : IdeVariables.VARIABLES) {
+      if ((variable != IdeVariables.PATH) && (variable != IdeVariables.IDE_ROOT) && (variable != IdeVariables.HOME) && name.equals(variable.getName())) {
+        return null;
+      }
+    }
+    if (name.endsWith("_VERSION") || name.endsWith("_EDITION") || name.endsWith("_HOME")) {
+      return null;
+    }
+    return super.getFlat(name);
   }
 
   /**
@@ -35,5 +59,16 @@ public final class EnvironmentVariablesSystem extends EnvironmentVariablesMap {
   static EnvironmentVariablesSystem of(IdeContext context) {
 
     return new EnvironmentVariablesSystem(context);
+  }
+
+
+  /**
+   * @param context the {@link IdeContext}.
+   * @param variables the mocked environment variables.
+   * @return the {@link EnvironmentVariablesSystem} instance.
+   */
+  public static EnvironmentVariablesSystem of(IdeContext context, Map<String, String> variables) {
+
+    return new EnvironmentVariablesSystem(context, variables);
   }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandletTest.java
@@ -76,6 +76,7 @@ public class EnvironmentCommandletTest extends AbstractIdeContextTest {
         IdeLogEntry.ofProcessable("HOME=\"" + normalize(context.getUserHome()) + "\""), //
         IdeLogEntry.ofProcessable("IDE_HOME=\"" + normalize(context.getIdeHome()) + "\""), //
         IdeLogEntry.ofProcessable("export M2_REPO=\"" + context.getUserHome() + "/.m2/repository\""), //
+        new IdeLogEntry(IdeLogLevel.PROCESSABLE, "export MAVEN_ARGS=\"-s ", true), //
         new IdeLogEntry(IdeLogLevel.PROCESSABLE, "export PATH=", true), //
         IdeLogEntry.ofProcessable("WORKSPACE=\"foo-test\""), //
         IdeLogEntry.ofProcessable("WORKSPACE_PATH=\"" + normalize(context.getWorkspacePath()) + "\""), //
@@ -118,7 +119,8 @@ public class EnvironmentCommandletTest extends AbstractIdeContextTest {
             "export JAVA_HOME=\"" + context.getSoftwarePath() + FileSystems.getDefault().getSeparator() + "java\""), //
         IdeLogEntry.ofProcessable("JAVA_VERSION=\"17*\""), //
         IdeLogEntry.ofProcessable("export M2_REPO=\"" + context.getUserHome() + "/.m2/repository\""), //
-        IdeLogEntry.ofProcessable("export MVN_HOME=\"" + softwarePath + FileSystems.getDefault().getSeparator() + "mvn\""),
+        new IdeLogEntry(IdeLogLevel.PROCESSABLE, "export MAVEN_ARGS=\"-s ", true), //
+        IdeLogEntry.ofProcessable("export MVN_HOME=\"" + softwarePath.resolve("mvn") + "\""),
         IdeLogEntry.ofProcessable("MVN_VERSION=\"3.9.1\""), //
         IdeLogEntry.ofProcessable("export NPM_HOME=\"" + softwarePath + FileSystems.getDefault().getSeparator() + "npm\""), //
         new IdeLogEntry(IdeLogLevel.PROCESSABLE, "export PATH=", true), //

--- a/cli/src/test/java/com/devonfw/tools/ide/context/AbstractIdeTestContext.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/AbstractIdeTestContext.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import com.devonfw.tools.ide.commandlet.Commandlet;
 import com.devonfw.tools.ide.commandlet.CommandletManager;
@@ -11,7 +12,7 @@ import com.devonfw.tools.ide.commandlet.TestCommandletManager;
 import com.devonfw.tools.ide.common.SystemPath;
 import com.devonfw.tools.ide.environment.AbstractEnvironmentVariables;
 import com.devonfw.tools.ide.environment.EnvironmentVariables;
-import com.devonfw.tools.ide.environment.EnvironmentVariablesPropertiesFile;
+import com.devonfw.tools.ide.environment.EnvironmentVariablesSystem;
 import com.devonfw.tools.ide.environment.EnvironmentVariablesType;
 import com.devonfw.tools.ide.environment.IdeSystem;
 import com.devonfw.tools.ide.environment.IdeSystemTestImpl;
@@ -131,14 +132,16 @@ public class AbstractIdeTestContext extends AbstractIdeContext {
     return progressBar;
   }
 
+  @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
   protected AbstractEnvironmentVariables createSystemVariables() {
 
     Path home = getUserHome();
     if (home != null) {
-      Path systemPropertiesFile = home.resolve("environment.properties");
-      if (Files.exists(systemPropertiesFile)) {
-        return new EnvironmentVariablesPropertiesFile(null, EnvironmentVariablesType.SYSTEM, systemPropertiesFile, this);
+      Path environmentPropertiesFile = home.resolve("environment.properties");
+      if (Files.exists(environmentPropertiesFile)) {
+        Properties environmentProperties = getFileAccess().readProperties(environmentPropertiesFile);
+        return EnvironmentVariablesSystem.of(this, (Map) environmentProperties);
       }
     }
     return super.createSystemVariables();

--- a/cli/src/test/resources/ide-projects/environment/project/conf/mvn/settings.xml
+++ b/cli/src/test/resources/ide-projects/environment/project/conf/mvn/settings.xml
@@ -1,0 +1,1 @@
+<settings></settings>

--- a/cli/src/test/resources/ide-projects/environment/project/home/environment.properties
+++ b/cli/src/test/resources/ide-projects/environment/project/home/environment.properties
@@ -1,2 +1,7 @@
 # if this file is present, it will replace and mock System.getenv in the text context
 PATH=${IDE_ROOT}/_ide/bin
+MAVEN_ARGS=-s ~/projects/other-project/conf/mvn/settings.xml
+M2_REPO=~/projects/other-project/conf/mvn/repository
+NPM_VERSION=value-from-other-project
+JAVA_HOME=/usr/share/java
+OTHER_VARIABLE=other value


### PR DESCRIPTION
### This PR fixes #351.

### Implemented changes:

* implemented #351
* ignore all environment properties relevant to IDEasy except for PATH, HOME, and IDE_ROOT
* added test
* improved test-infrastructure to behave more realistic using `EnvironmentVariablesSystem` that was otherwise mocked by a different class.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
