### PR TITLE
#1340: Added error message if CWD and IDE_ROOT cases differ

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,20 +2,28 @@
 
 This file documents all notable changes to https://github.com/devonfw/IDEasy[IDEasy].
 
+== 2025.06.002
+
+Release with new features and bugfixes:
+
+* https://github.com/devonfw/IDEasy/issues/1340[#1340]: IDEasy does not warn user if IDE_ROOT case was overwritten by user.dir
+
+The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/29?closed=1[milestone 2025.06.002].
+
 == 2025.06.001
 
 Release with new features and bugfixes:
 
 * https://github.com/devonfw/IDEasy/issues/809[#809]: make uninstall with --force also remove from software repo
 * https://github.com/devonfw/IDEasy/issues/1038[#1038]: XML merger fails in native-image on custom XPath with MissingResourceException
-* https://github.com/devonfw/IDEasy/issues/1108[#1108]: Fix git authentification in terminal
+* https://github.com/devonfw/IDEasy/issues/1108[#1108]: git fails if not authenticated, request for login/password not visible to the user
 * https://github.com/devonfw/IDEasy/issues/1293[#1293]: make sure core.longpaths is true in windows git config
 * https://github.com/devonfw/IDEasy/issues/1307[#1307]: Link to settings documentation is broken
 * https://github.com/devonfw/IDEasy/issues/351[#351]: Avoid inheriting environment variables from other IDEasy project if switched in the same shell session
-* https://github.com/devonfw/IDEasy/issues/1332[#1332]: cannot launch eclipse due to failling plugin
+* https://github.com/devonfw/IDEasy/issues/1332[#1332]: cannot launch eclipse due to failing plugin
 * https://github.com/devonfw/IDEasy/issues/716[#716]: Show progress of vscode extension installation
 
-The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/28?closed=1[milestone 2025.05.002].
+The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/28?closed=1[milestone 2025.06.001].
 
 == 2025.05.001
 

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/StatusCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/StatusCommandlet.java
@@ -59,22 +59,20 @@ public class StatusCommandlet extends Commandlet {
   }
 
   private void checkCwdAndRootPathCases() {
-    Path cwd = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize();
+
+    // make sure to run this check only within a project
+    if (this.context.getIdeHome() == null) {
+      return;
+    }
+
+    Path cwd = this.context.getCwd().toAbsolutePath().normalize();
     Path root = Path.of(this.context.getSystem().getEnv(IdeVariables.IDE_ROOT.getName()))
         .toAbsolutePath().normalize();
 
     boolean isCaseSensitive;
     isCaseSensitive = !this.context.getSystemInfo().isLinux();
 
-    boolean pathsMatch;
-
-    if (isCaseSensitive) {
-      pathsMatch = cwd.toString().startsWith(root.toString());
-    } else {
-      pathsMatch = cwd.toString().equalsIgnoreCase(root.toString());
-    }
-
-    if (!pathsMatch) {
+    if (!cwd.toString().startsWith(root.toString()) && isCaseSensitive) {
       this.context.error(
           "Your CWD path: '{}' and your IDE_ROOT path: '{}' cases do not match!\n" +
               "Please check your 'user.dir' or starting directory and make sure that it matches your IDE_ROOT path.",

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/StatusCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/StatusCommandletTest.java
@@ -1,16 +1,21 @@
 package com.devonfw.tools.ide.commandlet;
 
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeTestContext;
+import com.devonfw.tools.ide.os.SystemInfo;
+import com.devonfw.tools.ide.os.SystemInfoMock;
 
 /**
  * Test of {@link StatusCommandlet}.
  */
 public class StatusCommandletTest extends AbstractIdeContextTest {
-
-  private static final String PROJECT_BASIC = "basic";
 
   @Test
   public void testStatusOutsideOfHome() {
@@ -41,5 +46,89 @@ public class StatusCommandletTest extends AbstractIdeContextTest {
 
     // assert
     assertThat(context).logAtWarning().hasMessage("Check for newer version of IDEasy is skipped due to no network connectivity.");
+  }
+
+  /**
+   * Tests that if {@link StatusCommandlet} is run outside a project and the cases of IDE_ROOT and CWD differ, no error message about the wrong CWD path will be
+   * shown.
+   *
+   * @param tempDir temporary directory to use.
+   */
+  @Test
+  public void testStatusWhenUsingWrongCaseOutsideOfProjectShowsNoError(@TempDir Path tempDir) {
+
+    // arrange
+    IdeTestContext context = new IdeTestContext();
+    Path ideRootLowercase = tempDir.resolve("projects");
+    Path ideRootUppercase = tempDir.resolve("Projects");
+    context.setIdeRoot(ideRootLowercase);
+    context.getSystem().setEnv("IDE_ROOT", ideRootLowercase.toString());
+    context.setCwd(ideRootUppercase.getParent(), "", null);
+    StatusCommandlet status = context.getCommandletManager().getCommandlet(StatusCommandlet.class);
+
+    // act
+    status.run();
+
+    // assert
+    assertThat(context).logAtWarning()
+        .hasNoMessageContaining("Your CWD path");
+  }
+
+  /**
+   * Tests the output if {@link StatusCommandlet} is run within a project and the IDE_ROOT and CWD cases did not match.
+   *
+   * @param os String of the OS to use.
+   * @param tempDir temporary directory to use.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = { "windows", "mac" })
+  public void testStatusWhenUsingWrongCaseInProjectShowsError(String os, @TempDir() Path tempDir) {
+
+    // arrange
+    IdeTestContext context = new IdeTestContext();
+    SystemInfo systemInfo = SystemInfoMock.of(os);
+    context.setSystemInfo(systemInfo);
+    Path ideRootLowercase = tempDir.resolve("projects");
+    Path ideRootUppercase = tempDir.resolve("Projects");
+    context.setIdeRoot(ideRootLowercase);
+    context.getSystem().setEnv("IDE_ROOT", ideRootLowercase.toString());
+    context.setCwd(ideRootUppercase, "", Path.of("non-existing-project"));
+    StatusCommandlet status = context.getCommandletManager().getCommandlet(StatusCommandlet.class);
+
+    // act
+    status.run();
+
+    // assert
+    assertThat(context).logAtError()
+        .hasMessage("Your CWD path: '" + ideRootUppercase + "' and your IDE_ROOT path: '" + ideRootLowercase + "' cases do not match!\n"
+            + "Please check your 'user.dir' or starting directory and make sure that it matches your IDE_ROOT path.");
+  }
+
+  /**
+   * Tests the output if {@link StatusCommandlet} is run within a project and the IDE_ROOT and CWD cases did not match on a linux system no error message will
+   * be shown.
+   *
+   * @param tempDir temporary directory to use.
+   */
+  @Test
+  public void testStatusWhenUsingWrongCaseInProjectShowsNoErrorOnLinux(@TempDir() Path tempDir) {
+
+    // arrange
+    IdeTestContext context = new IdeTestContext();
+    SystemInfo systemInfo = SystemInfoMock.of("linux");
+    context.setSystemInfo(systemInfo);
+    Path ideRootLowercase = tempDir.resolve("projects");
+    Path ideRootUppercase = tempDir.resolve("Projects");
+    context.setIdeRoot(ideRootLowercase);
+    context.getSystem().setEnv("IDE_ROOT", ideRootLowercase.toString());
+    context.setCwd(ideRootUppercase, "", Path.of("non-existing-project"));
+    StatusCommandlet status = context.getCommandletManager().getCommandlet(StatusCommandlet.class);
+
+    // act
+    status.run();
+
+    // assert
+    assertThat(context).logAtWarning()
+        .hasNoMessageContaining("Your CWD path");
   }
 }


### PR DESCRIPTION
### This PR fixes #1340 .

### Implemented changes:

*  added error message for Windows and Mac to `status` commandlet if `CWD` and `IDE_ROOT` path cases were not 
matching
* added tests for new error message on various os
* adjusted changelog (fixed wrong titles)

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`