### PR TITLE
#1340: proper fix if IDE_ROOT is not sane

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1293[#1293]: make sure core.longpaths is true in windows git config
 * https://github.com/devonfw/IDEasy/issues/1307[#1307]: Link to settings documentation is broken
 * https://github.com/devonfw/IDEasy/issues/351[#351]: Avoid inheriting environment variables from other IDEasy project if switched in the same shell session
+* https://github.com/devonfw/IDEasy/issues/1340[#1340]: IDEasy does not warn user if IDE_ROOT is not sane
 * https://github.com/devonfw/IDEasy/issues/1332[#1332]: cannot launch eclipse due to failling plugin
 * https://github.com/devonfw/IDEasy/issues/716[#716]: Show progress of vscode extension installation
 

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -210,8 +210,11 @@ public abstract class AbstractIdeContext implements IdeContext {
       Path ideRootPathFromEnv = getIdeRootPathFromEnv(true);
       ideRootPath = ideHomePath.getParent();
       if ((ideRootPathFromEnv != null) && !ideRootPath.toString().equals(ideRootPathFromEnv.toString())) {
-        warning("Variable IDE_ROOT is set to '{}' but for your project '{}' the path '{}' would have been expected.", ideRootPathFromEnv,
-            ideRootPath, ideHomePath.getFileName());
+        warning(
+            "Variable IDE_ROOT is set to '{}' but for your project '{}' the path '{}' would have been expected.\n"
+                + "Please check your 'user.dir' or working directory setting and make sure that it matches your IDE_ROOT variable.",
+            ideRootPathFromEnv,
+            ideHomePath.getFileName(), ideRootPath);
       }
 
     } else if (!isTest()) {

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -158,7 +158,7 @@ public abstract class AbstractIdeContext implements IdeContext {
     if (workingDirectory == null) {
       workingDirectory = Path.of(System.getProperty("user.dir"));
     }
-    workingDirectory = workingDirectory.toAbsolutePath();
+    workingDirectory = this.fileAccess.toCanonicalPath(workingDirectory);
     this.cwd = workingDirectory;
     // detect IDE_HOME and WORKSPACE
     Path currentDir = workingDirectory;

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -158,7 +158,12 @@ public abstract class AbstractIdeContext implements IdeContext {
     if (workingDirectory == null) {
       workingDirectory = Path.of(System.getProperty("user.dir"));
     }
-    workingDirectory = this.fileAccess.toCanonicalPath(workingDirectory);
+    workingDirectory = workingDirectory.toAbsolutePath();
+    if (Files.isDirectory(workingDirectory)) {
+      workingDirectory = this.fileAccess.toCanonicalPath(workingDirectory);
+    } else {
+      warning("Current working directory does not exist: {}", workingDirectory);
+    }
     this.cwd = workingDirectory;
     // detect IDE_HOME and WORKSPACE
     Path currentDir = workingDirectory;

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -157,15 +157,14 @@ public abstract class AbstractIdeContext implements IdeContext {
     String workspace = WORKSPACE_MAIN;
     if (workingDirectory == null) {
       workingDirectory = Path.of(System.getProperty("user.dir"));
-    } else {
-      workingDirectory = workingDirectory.toAbsolutePath();
     }
+    workingDirectory = workingDirectory.toAbsolutePath();
     this.cwd = workingDirectory;
     // detect IDE_HOME and WORKSPACE
     Path currentDir = workingDirectory;
     String name1 = "";
     String name2 = "";
-    Path ideRootPath = getIdeRootPathFromEnv();
+    Path ideRootPath = getIdeRootPathFromEnv(false);
     while (currentDir != null) {
       trace("Looking for IDE_HOME in {}", currentDir);
       if (isIdeHome(currentDir)) {
@@ -208,9 +207,15 @@ public abstract class AbstractIdeContext implements IdeContext {
 
     Path ideRootPath = null;
     if (ideHomePath != null) {
+      Path ideRootPathFromEnv = getIdeRootPathFromEnv(true);
       ideRootPath = ideHomePath.getParent();
+      if (!ideRootPath.toString().equals(ideRootPathFromEnv.toString())) {
+        warning("Variable IDE_ROOT is set to '{}' but for your project '{}' the path '{}' would have been expected.", ideRootPathFromEnv,
+            ideHomePath.getFileName(), ideRootPath);
+      }
+
     } else if (!isTest()) {
-      ideRootPath = getIdeRootPathFromEnv();
+      ideRootPath = getIdeRootPathFromEnv(true);
     }
     return ideRootPath;
   }
@@ -218,13 +223,34 @@ public abstract class AbstractIdeContext implements IdeContext {
   /**
    * @return the {@link #getIdeRoot() IDE_ROOT} from the system environment.
    */
-  protected Path getIdeRootPathFromEnv() {
+  protected Path getIdeRootPathFromEnv(boolean withSanityCheck) {
 
     String root = getSystem().getEnv(IdeVariables.IDE_ROOT.getName());
     if (root != null) {
       Path rootPath = Path.of(root);
       if (Files.isDirectory(rootPath)) {
-        return rootPath;
+        Path absoluteRootPath = getFileAccess().toCanonicalPath(rootPath);
+        if (withSanityCheck) {
+          int nameCount = rootPath.getNameCount();
+          int absoluteNameCount = absoluteRootPath.getNameCount();
+          int delta = absoluteNameCount - nameCount;
+          if (delta >= 0) {
+            for (int nameIndex = 0; nameIndex < nameCount; nameIndex++) {
+              String rootName = rootPath.getName(nameIndex).toString();
+              String absoluteRootName = absoluteRootPath.getName(nameIndex + delta).toString();
+              if (!rootName.equals(absoluteRootName)) {
+                warning("IDE_ROOT is set to {} but was expanded to absolute path {} and does not match for segment {} and {} - fix your IDEasy installation!",
+                    rootPath, absoluteRootPath, rootName, absoluteRootName);
+                break;
+              }
+            }
+          } else {
+            warning("IDE_ROOT is set to {} but was expanded to a shorter absolute path {}", rootPath, absoluteRootPath);
+          }
+        }
+        return absoluteRootPath;
+      } else if (withSanityCheck) {
+        warning("IDE_ROOT is set to {} that is not an existing directory - fix your IDEasy installation!", rootPath);
       }
     }
     return null;
@@ -961,7 +987,6 @@ public abstract class AbstractIdeContext implements IdeContext {
           this.startContext.activateLogging();
         } else {
           this.startContext.activateLogging();
-          verifyIdeRoot();
           if (cmd.isIdeHomeRequired()) {
             debug(getMessageIdeHomeFound());
           }
@@ -1056,21 +1081,6 @@ public abstract class AbstractIdeContext implements IdeContext {
       this.startContext.setLogLevel(IdeLogLevel.INTERACTION, false);
     }
     return true;
-  }
-
-  private void verifyIdeRoot() {
-
-    if (!isTest()) {
-      if (this.ideRoot == null) {
-        warning("Variable IDE_ROOT is undefined. Please check your installation or run setup script again.");
-      } else if (this.ideHome != null) {
-        Path ideRootPath = getIdeRootPathFromEnv();
-        if (!this.ideRoot.equals(ideRootPath)) {
-          warning("Variable IDE_ROOT is set to '{}' but for your project '{}' the path '{}' would have been expected.", ideRootPath,
-              this.ideHome.getFileName(), this.ideRoot);
-        }
-      }
-    }
   }
 
   @Override

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -209,7 +209,7 @@ public abstract class AbstractIdeContext implements IdeContext {
     if (ideHomePath != null) {
       Path ideRootPathFromEnv = getIdeRootPathFromEnv(true);
       ideRootPath = ideHomePath.getParent();
-      if (!ideRootPath.toString().equals(ideRootPathFromEnv.toString())) {
+      if ((ideRootPathFromEnv != null) && !ideRootPath.toString().equals(ideRootPathFromEnv.toString())) {
         warning("Variable IDE_ROOT is set to '{}' but for your project '{}' the path '{}' would have been expected.", ideRootPathFromEnv,
             ideHomePath.getFileName(), ideRootPath);
       }

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -211,7 +211,7 @@ public abstract class AbstractIdeContext implements IdeContext {
       ideRootPath = ideHomePath.getParent();
       if ((ideRootPathFromEnv != null) && !ideRootPath.toString().equals(ideRootPathFromEnv.toString())) {
         warning("Variable IDE_ROOT is set to '{}' but for your project '{}' the path '{}' would have been expected.", ideRootPathFromEnv,
-            ideHomePath.getFileName(), ideRootPath);
+            ideRootPath, ideHomePath.getFileName());
       }
 
     } else if (!isTest()) {

--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccess.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccess.java
@@ -216,6 +216,12 @@ public interface FileAccess {
   Path toRealPath(Path path);
 
   /**
+   * @param path the {@link Path} to convert.
+   * @return the absolute and physical {@link Path}.
+   */
+  Path toCanonicalPath(Path path);
+
+  /**
    * Deletes the given {@link Path} idempotent and recursive.
    * <p>
    * ATTENTION: In most cases we want to use {@link #backup(Path)} instead to prevent the user from data loss.

--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -513,8 +513,24 @@ public class FileAccessImpl implements FileAccess {
   @Override
   public Path toRealPath(Path path) {
 
+    return toRealPath(path, true);
+  }
+
+  @Override
+  public Path toCanonicalPath(Path path) {
+
+    return toRealPath(path, false);
+  }
+
+  private Path toRealPath(Path path, boolean resolveLinks) {
+
     try {
-      Path realPath = path.toRealPath();
+      Path realPath;
+      if (resolveLinks) {
+        realPath = path.toRealPath();
+      } else {
+        realPath = path.toRealPath(LinkOption.NOFOLLOW_LINKS);
+      }
       if (!realPath.equals(path)) {
         this.context.trace("Resolved path {} to {}", path, realPath);
       }

--- a/cli/src/test/java/com/devonfw/tools/ide/context/AbstractIdeTestContext.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/AbstractIdeTestContext.java
@@ -316,7 +316,7 @@ public class AbstractIdeTestContext extends AbstractIdeContext {
   }
 
   @Override
-  protected Path getIdeRootPathFromEnv() {
+  protected Path getIdeRootPathFromEnv(boolean withSanityCheck) {
 
     Path workingDirectory = getCwd();
     Path root = Path.of("").toAbsolutePath();


### PR DESCRIPTION
### This PR fixes #1340.

### Implemented changes:

* Log warning if IDE_ROOT is not sane (undefined, wrong case, not matching parent of IDE_HOME)
* Auto-repair IDE_ROOT if not sane to prevent follow up errors.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`