### PR TITLE
#1309: Fixed ide.bat splitting IDE_OPTIONS

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,14 @@
 
 This file documents all notable changes to https://github.com/devonfw/IDEasy[IDEasy].
 
+== 2025.06.002
+
+Release with new features and bugfixes:
+
+* https://github.com/devonfw/IDEasy/issues/1309[#1309]: ide.bat splitting short options
+
+The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/29?closed=1[milestone 2025.06.002].
+
 == 2025.06.001
 
 Release with new features and bugfixes:
@@ -15,7 +23,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1332[#1332]: cannot launch eclipse due to failling plugin
 * https://github.com/devonfw/IDEasy/issues/716[#716]: Show progress of vscode extension installation
 
-The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/28?closed=1[milestone 2025.05.002].
+The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/28?closed=1[milestone 2025.06.001].
 
 == 2025.05.001
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,12 +6,9 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
-<<<<<<< 1309-ide-bat-splitting-ide-options
 * https://github.com/devonfw/IDEasy/issues/1309[#1309]: ide.bat splitting short options
-=======
 * https://github.com/devonfw/IDEasy/issues/1361[#1361]: ide create does not install intellij plugins properly
 * https://github.com/devonfw/IDEasy/issues/1340[#1340]: IDEasy does not warn user if IDE_ROOT is not sane
->>>>>>> main
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/29?closed=1[milestone 2025.06.002].
 

--- a/cli/src/main/package/bin/ide.bat
+++ b/cli/src/main/package/bin/ide.bat
@@ -34,7 +34,7 @@ if %ERRORLEVEL% NEQ 0 (
 :skipIdeasy
 
 REM https://stackoverflow.com/questions/61888625/what-is-f-in-the-for-loop-command
-for /f "tokens=*" %%i in ('ideasy %IDE_OPTIONS% env') do (
+for /f "tokens=*" %%i in ('"ideasy %IDE_OPTIONS% env"') do (
   call set %%i
 )
 


### PR DESCRIPTION
### This PR fixes #1309

### Implemented changes:

* Added quotes to the ideasy call inside the for loop in ide.bat

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
