### PR TITLE
#1160: IDEasy version gets printed when using ide status offline

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,14 @@
 
 This file documents all notable changes to https://github.com/devonfw/IDEasy[IDEasy].
 
+== 2025.06.002
+
+Release with new features and bugfixes:
+
+* https://github.com/devonfw/IDEasy/issues/1160[#1160]: Print IDEasy version in ide status when offline
+
+The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/29?closed=1[milestone 2025.06.002].
+
 == 2025.06.001
 
 Release with new features and bugfixes:

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/StatusCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/StatusCommandlet.java
@@ -54,10 +54,6 @@ public class StatusCommandlet extends Commandlet {
   }
 
   private void checkForUpdate() {
-    if (!this.context.isOnline()) {
-      this.context.warning("Check for newer version of IDEasy is skipped due to no network connectivity.");
-      return;
-    }
     new IdeasyCommandlet(this.context, null).checkIfUpdateIsAvailable();
     logSystemInfo();
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/IdeasyCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/IdeasyCommandlet.java
@@ -133,6 +133,11 @@ public class IdeasyCommandlet extends MvnBasedLocalToolCommandlet {
    */
   public boolean checkIfUpdateIsAvailable() {
     VersionIdentifier installedVersion = getInstalledVersion();
+    if (!this.context.isOnline()) {
+      this.context.success("Your version of IDEasy is {}.", installedVersion);
+      this.context.warning("Skipping check for newer version of IDEasy due to lack of network connectivity.");
+      return false;
+    }
     VersionIdentifier latestVersion = getLatestVersion();
     if (installedVersion.equals(latestVersion)) {
       this.context.success("Your version of IDEasy is {} which is the latest released version.", installedVersion);

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/StatusCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/StatusCommandletTest.java
@@ -40,6 +40,6 @@ public class StatusCommandletTest extends AbstractIdeContextTest {
     status.run();
 
     // assert
-    assertThat(context).logAtWarning().hasMessage("Check for newer version of IDEasy is skipped due to no network connectivity.");
+    assertThat(context).logAtWarning().hasMessage("Skipping check for newer version of IDEasy due to lack of network connectivity.");
   }
 }


### PR DESCRIPTION
### This PR fixes #1160 .

### Implemented changes:

* the current version of IDEasy will be printed even when offline
* also print the operating system when offline

Before:
```
Skipping git fetch on C:\Users\<user>\projects\IDEasy\settings because we are offline.
IDE_ROOT is set to C:\Users\<user>\projects
IDE_HOME is set to C:\Users\<user>\projects\IDEasy
You are offline. Check your internet connection and potential proxy settings.
Your settings are up-to-date.
Check for newer version of IDEasy is skipped due to no network connectivity.
Successfully completed ide (status)
```

After:
```
Skipping git fetch on C:\Users\<user>\projects\Test\settings because we are offline.
IDE_ROOT is set to C:\Users\<user>\projects
IDE_HOME is set to C:\Users\<user>\projects\IDEasy
You are offline. Check your internet connection and potential proxy settings.
Your settings are up-to-date.
Your version of IDEasy is 2025.06.001.
Skipping check for newer version of IDEasy due to lack of network connectivity.
Your operating system is windows(10.0)@x64 [Windows 11@amd64]
Successfully completed ide (status)
```

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`