### PR TITLE
#901: Add mvn wrapper detection

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/Mvn.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/Mvn.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 
@@ -41,6 +42,12 @@ public class Mvn extends PluginBasedCommandlet {
   /** The name of the settings-security.xml */
   public static final String SETTINGS_SECURITY_FILE = "settings-security.xml";
 
+  /** The mvn wrapper file name. */
+  public static final String MVN_WRAPPER_FILENAME = "mvnw";
+
+  /** The pom.xml file name. */
+  public static final String POM_XML = "pom.xml";
+
   /**
    * The name of the settings.xml
    */
@@ -64,6 +71,34 @@ public class Mvn extends PluginBasedCommandlet {
   public Mvn(IdeContext context) {
 
     super(context, "mvn", Set.of(Tag.JAVA, Tag.BUILD));
+  }
+
+  @Override
+  protected void configureToolBinary(ProcessContext pc, ProcessMode processMode, ProcessErrorHandling errorHandling) {
+    Path mvn = Path.of(getBinaryName());
+    Path wrapper = findWrapper();
+    pc.executable(Objects.requireNonNullElse(wrapper, mvn));
+  }
+
+  /**
+   * Searches for a wrapper file in valid mvn projects (containing a pom.xml) and returns its path.
+   *
+   * @return Path of the wrapper file or {@code null} if none was found.
+   */
+  protected Path findWrapper() {
+    Path dir = context.getCwd();
+    // traverse the cwd containing a pom.xml up till a maven wrapper file was found
+    while (Files.exists(dir.resolve(POM_XML)) &&
+        !Files.exists(dir.resolve(MVN_WRAPPER_FILENAME)) &&
+        dir.getParent() != null) {
+      dir = dir.getParent();
+    }
+    if (Files.exists(dir.resolve("mvnw"))) {
+      context.debug("Using mvn wrapper file at: {}", dir);
+      return dir.resolve(MVN_WRAPPER_FILENAME);
+    }
+
+    return null;
   }
 
   @Override

--- a/cli/src/test/resources/ide-projects/mvn/repository/mvn/mvn/default/bin/mvnw
+++ b/cli/src/test/resources/ide-projects/mvn/repository/mvn/mvn/default/bin/mvnw
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$1" == "--encrypt-master-password" ]; then
+    echo "masterPassword"
+elif [ "$1" == "--encrypt-password" ]; then
+    echo "$2"
+else
+    echo "mvnw $*"
+fi


### PR DESCRIPTION
### This PR fixes #901.

### Implemented changes:

* added mvn wrapper file detection
* added test for wrapper file detection
* added mvnw file to test resources

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [ ] When running `mvn clean test` locally all tests pass and build is successful
- [ ] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [ ] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [ ] PR and issue(s) have suitable labels
- [ ] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [ ] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [ ] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue
