### PR TITLE
#1361: fix IDE (IntelliJ) plugin installation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,14 @@
 
 This file documents all notable changes to https://github.com/devonfw/IDEasy[IDEasy].
 
+== 2025.06.002
+
+Release with new features and bugfixes:
+
+* https://github.com/devonfw/IDEasy/issues/1361[#1361]: ide create does not install intellij plugins properly
+
+The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/29?closed=1[milestone 2025.06.002].
+
 == 2025.06.001
 
 Release with new features and bugfixes:

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeToolCommandlet.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.io.FileAccess;
+import com.devonfw.tools.ide.process.ProcessContext;
 import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.step.Step;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
@@ -45,7 +46,6 @@ public abstract class IdeToolCommandlet extends PluginBasedCommandlet {
 
   @Override
   public final void run() {
-    configureWorkspace();
     super.run();
   }
 
@@ -55,8 +55,15 @@ public abstract class IdeToolCommandlet extends PluginBasedCommandlet {
     runTool(ProcessMode.BACKGROUND, null, args);
   }
 
+  @Override
+  public boolean install(boolean silent, ProcessContext processContext, Step step) {
+
+    configureWorkspace();
+    return super.install(silent, processContext, step);
+  }
+
   /**
-   * Configure the workspace for this IDE using the templates from the settings.
+   * Configure (initialize or update) the workspace for this IDE using the templates from the settings.
    */
   protected void configureWorkspace() {
 

--- a/cli/src/test/integration-tests/install-intellij.sh
+++ b/cli/src/test/integration-tests/install-intellij.sh
@@ -16,3 +16,4 @@ then
 fi
 
 assertThat "${IDE_ROOT}/${TEST_PROJECT_NAME}/software/intellij/${intellij_binary}" exists
+assertThat "${IDE_ROOT}/${TEST_PROJECT_NAME}/workspaces/main/idea.properties" exists

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
@@ -149,6 +149,7 @@ public class IntellijTest extends AbstractIdeContextTest {
   private void checkInstallation(IdeTestContext context) {
 
     assertThat(context.getSoftwarePath().resolve("intellij/.ide.software.version")).exists().hasContent("2023.3.3");
+    assertThat(context.getWorkspacePath().resolve("idea.properties")).exists();
     assertThat(context).logAtSuccess().hasEntries("Successfully installed java in version 17.0.10_7",
         "Successfully installed intellij in version 2023.3.3");
     assertThat(context).logAtDebug().hasEntries("Omitting installation of inactive plugin InactivePlugin (inactivePlugin).");


### PR DESCRIPTION
### This PR fixes #1361

### Implemented changes:

* configureWorkspace on install of IDE so that IJ properties file is created before plugin installation

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`