### PR TITLE
#1303: fix critical bug on early logging causing mess

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,7 +12,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1304[#1304]: Error when reinstalling vscode
 * https://github.com/devonfw/IDEasy/issues/1160[#1160]: Print IDEasy version in ide status when offline
 * https://github.com/devonfw/IDEasy/issues/901[#901]: Consider maven wrapper mvnw
-* https://github.com/devonfw/IDEasy/issues/1303[#1303]: Add option to show GDPR compliant console output
+* https://github.com/devonfw/IDEasy/issues/1303[#1303]: Add option to show GPDR compliant console output
 * https://github.com/devonfw/IDEasy/issues/1309[#1309]: ide.bat splitting short options
 * https://github.com/devonfw/IDEasy/issues/1361[#1361]: ide create does not install intellij plugins properly
 * https://github.com/devonfw/IDEasy/issues/1340[#1340]: IDEasy does not warn user if IDE_ROOT is not sane

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -303,7 +303,7 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
     }
     this.userHomeIde = this.userHome.resolve(FOLDER_DOT_IDE);
     this.downloadPath = this.userHome.resolve("Downloads/ide");
-
+    resetPrivacyMap();
     this.path = computeSystemPath();
   }
 
@@ -837,7 +837,10 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
     if (isPrivacyMode()) {
       if ((this.ideRoot != null) && this.privacyMap.isEmpty()) {
         initializePrivacyMap(this.userHome, "~");
-        this.privacyMap.put(getProjectName(), "project");
+        String projectName = getProjectName();
+        if (!projectName.isEmpty()) {
+          this.privacyMap.put(projectName, "project");
+        }
       }
       for (Entry<String, String> entry : this.privacyMap.entrySet()) {
         result = result.replace(entry.getKey(), entry.getValue());

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -835,7 +835,7 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
     }
     String result = argument.toString();
     if (isPrivacyMode()) {
-      if (this.privacyMap.isEmpty()) {
+      if ((this.ideRoot != null) && this.privacyMap.isEmpty()) {
         initializePrivacyMap(this.userHome, "~");
         this.privacyMap.put(getProjectName(), "project");
       }


### PR DESCRIPTION
### This PR fixes #1303.

### Implemented changes:

* on main privacy mode has a critical bug: in case of early logging (--trace) the `privacyMap` with the replacements is created before `ideRoot` and `ideHome` is set.
* I fixed it so regular usage is now working as expected
* still looking if edge-cases can still cause the problem...

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
