### PR TITLE
1393: download of tools first tries http version 2 - if this fails download will be retried with 1.1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,8 @@
 
 This file documents all notable changes to https://github.com/devonfw/IDEasy[IDEasy].
 
+* https://github.com/devonfw/IDEasy/issues/1393[#1393]: Download of java fails in ZScaler VPN due to invalid TLS certificate
+
 == 2025.07.001
 
 Release with new features and bugfixes:

--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -110,40 +110,37 @@ public class FileAccessImpl implements FileAccess {
 
     this.context.info("Trying to download {} from {}", target.getFileName(), url);
     mkdirs(target.getParent());
-    //try {
-      if (this.context.isOffline()) {
-        throw CliOfflineException.ofDownloadViaUrl(url);
-      }
-      if (url.startsWith("http")) {
 
-        HttpRequest request = HttpRequest.newBuilder()
-            .uri(URI.create(url))
-            .GET()
-            .version(httpClientVersion)
-            .build();
-        HttpClient client = createHttpClient(url);
-        HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
-        int statusCode = response.statusCode();
-        if (statusCode == 200) {
-          downloadFileWithProgressBar(url, target, response);
-        } else {
-          throw new IllegalStateException("Download failed with status code " + statusCode);
-        }
-      } else if (url.startsWith("ftp") || url.startsWith("sftp")) {
-        throw new IllegalArgumentException("Unsupported download URL: " + url);
+    if (this.context.isOffline()) {
+      throw CliOfflineException.ofDownloadViaUrl(url);
+    }
+    if (url.startsWith("http")) {
+
+      HttpRequest request = HttpRequest.newBuilder()
+          .uri(URI.create(url))
+          .GET()
+          .version(httpClientVersion)
+          .build();
+      HttpClient client = createHttpClient(url);
+      HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+      int statusCode = response.statusCode();
+      if (statusCode == 200) {
+        downloadFileWithProgressBar(url, target, response);
       } else {
-        Path source = Path.of(url);
-        if (isFile(source)) {
-          // network drive
-
-          copyFileWithProgressBar(source, target);
-        } else {
-          throw new IllegalArgumentException("Download path does not point to a downloadable file: " + url);
-        }
+        throw new IllegalStateException("Download failed with status code " + statusCode);
       }
-    //} catch (Exception e) {
-    //  throw new IllegalStateException("Failed to download file from URL " + url + " to " + target, e);
-    //}
+    } else if (url.startsWith("ftp") || url.startsWith("sftp")) {
+      throw new IllegalArgumentException("Unsupported download URL: " + url);
+    } else {
+      Path source = Path.of(url);
+      if (isFile(source)) {
+        // network drive
+
+        copyFileWithProgressBar(source, target);
+      } else {
+        throw new IllegalArgumentException("Download path does not point to a downloadable file: " + url);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION

### This PR fixes <1393>.

### Implemented changes:

* new method to download a tool: copied the former pulic method to a private method an give that private method a third parameter concerning the http version
* public download method tries to dowload with http version 2 - and if this fails, the download will be repeated with 1.1.
  If this also fail, an Exception will be thrown

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [ ] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue
