### PR TITLE
#1387: throw CliException when tool version not supported for OS

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,14 @@
 
 This file documents all notable changes to https://github.com/devonfw/IDEasy[IDEasy].
 
+== 2025.08.001
+
+Release with new features and bugfixes:
+
+* https://github.com/devonfw/IDEasy/issues/1387[#1387]: Hide exception from user when a tool version is not supported
+
+The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/31?closed=1[milestone 2025.08.001].
+
 == 2025.07.001
 
 Release with new features and bugfixes:

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/UrlMetadata.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/UrlMetadata.java
@@ -87,7 +87,7 @@ public class UrlMetadata implements AbstractUrlMetadata {
       try {
         urlVersion.getMatchingUrls(sys.getOs(), sys.getArchitecture());
         list.add(versionIdentifier);
-      } catch (IllegalStateException e) {
+      } catch (CliException e) {
         // ignore, but do not add versionIdentifier as there is no download available for the current system
       }
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/folder/UrlVersion.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/folder/UrlVersion.java
@@ -110,8 +110,7 @@ public class UrlVersion extends AbstractUrlFolderWithParent<UrlEdition, UrlFile<
             urls = getUrls(os, SystemArchitecture.X64);
           }
           if (urls == null) {
-            Path path = getPath();
-            throw new CliException("No download was found for OS " + os + "@" + arch + " in " + path);
+            throw new CliException("No download was found for OS " + os + "@" + arch + " in " + getPath());
           }
         }
       }

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/folder/UrlVersion.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/folder/UrlVersion.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import com.devonfw.tools.ide.cli.CliException;
 import com.devonfw.tools.ide.os.OperatingSystem;
 import com.devonfw.tools.ide.os.SystemArchitecture;
 import com.devonfw.tools.ide.url.model.AbstractUrlFolderWithParent;
@@ -109,7 +110,8 @@ public class UrlVersion extends AbstractUrlFolderWithParent<UrlEdition, UrlFile<
             urls = getUrls(os, SystemArchitecture.X64);
           }
           if (urls == null) {
-            throw new IllegalStateException("No download was found for OS " + os + "@" + arch + " in " + getPath());
+            Path path = getPath();
+            throw new CliException("No download was found for OS " + os + "@" + arch + " in " + path);
           }
         }
       }


### PR DESCRIPTION
### This PR fixes #1387.

### Implemented changes:

* throw CliException instead of IllegalStateException when tool version is not supported on current OS

Can betested on Windows by running:
`ide install vscode 1.12.0`
Can be tested on Linux by running:
`ide install az 2.52.0`

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
