### PR TITLE
#1384: Add python installation logic via uv

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/CommandletManagerImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/CommandletManagerImpl.java
@@ -45,6 +45,7 @@ import com.devonfw.tools.ide.tool.quarkus.Quarkus;
 import com.devonfw.tools.ide.tool.sonar.Sonar;
 import com.devonfw.tools.ide.tool.terraform.Terraform;
 import com.devonfw.tools.ide.tool.tomcat.Tomcat;
+import com.devonfw.tools.ide.tool.uv.Uv;
 import com.devonfw.tools.ide.tool.vscode.Vscode;
 
 /**
@@ -128,6 +129,7 @@ public class CommandletManagerImpl implements CommandletManager {
     add(new LazyDocker(context));
     add(new Python(context));
     add(new Pycharm(context));
+    add(new Uv(context));
   }
 
   /**

--- a/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
@@ -128,6 +128,12 @@ public class SystemPath {
           String tool = child.getFileName().toString();
           if (!"extra".equals(tool) && Files.isDirectory(child)) {
             Path toolPath = child;
+            if (tool.equals("python")) {
+              Path venvScripts = child.resolve(".venv").resolve("Scripts");
+              if (Files.isDirectory(venvScripts)) {
+                toolPath = venvScripts;
+              }
+            }
             Path bin = child.resolve("bin");
             if (Files.isDirectory(bin)) {
               toolPath = bin;

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -214,6 +214,27 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
         }
       }
     }
+    performToolInstallation(toolRepository, resolvedVersion, installationPath, fileAccess, edition, processContext);
+    return createToolInstallation(installationPath, resolvedVersion, toolVersionFile, true, processContext, extraInstallation);
+  }
+
+  /**
+   * Performs the actual installation of the {@link #getName() tool} by downloading its binary, optionally extracting it, backing up any existing installation,
+   * and writing the version file.
+   * <p>
+   * This method assumes that the version has already been resolved and dependencies installed. It handles the final steps of placing the tool into the
+   * appropriate installation directory.
+   *
+   * @param toolRepository the {@link ToolRepository} used to locate and download the tool.
+   * @param resolvedVersion the resolved {@link VersionIdentifier} of the {@link #getName() tool} to install.
+   * @param installationPath the target {@link Path} where the {@link #getName() tool} should be installed.
+   * @param fileAccess the {@link FileAccess} utility for file operations such as backup, extraction, and directory creation.
+   * @param edition the specific edition of the tool to install.
+   * @param processContext the {@link ProcessContext} used to manage the installation process.
+   */
+  protected void performToolInstallation(ToolRepository toolRepository, VersionIdentifier resolvedVersion, Path installationPath, FileAccess fileAccess,
+      String edition, ProcessContext processContext) {
+
     Path downloadedToolFile = downloadTool(edition, toolRepository, resolvedVersion);
     boolean extract = isExtract();
     if (!extract) {
@@ -226,7 +247,6 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
     fileAccess.extract(downloadedToolFile, installationPath, this::postExtract, extract);
     this.context.writeVersionFile(resolvedVersion, installationPath);
     this.context.debug("Installed {} in version {} at {}", this.tool, resolvedVersion, installationPath);
-    return createToolInstallation(installationPath, resolvedVersion, toolVersionFile, true, processContext, extraInstallation);
   }
 
   /**
@@ -268,7 +288,7 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
     return toolInstallation.newInstallation();
   }
 
-  private void installToolDependencies(VersionIdentifier version, String edition, ProcessContext processContext) {
+  protected void installToolDependencies(VersionIdentifier version, String edition, ProcessContext processContext) {
     Collection<ToolDependency> dependencies = getToolRepository().findDependencies(this.tool, edition, version);
     String toolWithEdition = getToolWithEdition(this.tool, edition);
     int size = dependencies.size();
@@ -471,7 +491,7 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
   }
 
 
-  private ToolInstallation createToolInstallation(Path rootDir, VersionIdentifier resolvedVersion, Path toolVersionFile,
+  protected ToolInstallation createToolInstallation(Path rootDir, VersionIdentifier resolvedVersion, Path toolVersionFile,
       boolean newInstallation, EnvironmentContext environmentContext, boolean extraInstallation) {
 
     Path linkDir = getMacOsHelper().findLinkDir(rootDir, getBinaryName());

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/python/Python.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/python/Python.java
@@ -1,12 +1,20 @@
 package com.devonfw.tools.ide.tool.python;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Set;
 
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
-import com.devonfw.tools.ide.nls.NlsBundle;
+import com.devonfw.tools.ide.io.FileAccess;
+import com.devonfw.tools.ide.process.EnvironmentContext;
+import com.devonfw.tools.ide.process.ProcessContext;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
+import com.devonfw.tools.ide.tool.ToolInstallation;
+import com.devonfw.tools.ide.tool.repository.ToolRepository;
+import com.devonfw.tools.ide.tool.uv.Uv;
+import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
  * {@link ToolCommandlet} for <a href="https://www.python.org/">python</a>.
@@ -21,6 +29,39 @@ public class Python extends LocalToolCommandlet {
   public Python(IdeContext context) {
 
     super(context, "python", Set.of(Tag.PYTHON));
+  }
+
+  /**
+   * Installs {@code python} using the {@link Uv#installPython(Path, VersionIdentifier, ProcessContext)} method.
+   * <p>
+   * Unlike the base implementation, this method requires the {@link ProcessContext} to perform the installation logic specific to {@code python}.
+   *
+   * @param toolRepository the {@link ToolRepository}, unused in this implementation.
+   * @param resolvedVersion the {@link VersionIdentifier} of the {@code python} tool to install.
+   * @param installationPath the target {@link Path} where the tool should be installed.
+   * @param fileAccess the {@link FileAccess} utility for file operations.
+   * @param edition the edition of the tool to install, unused in this implementation.
+   * @param processContext the {@link ProcessContext} required to install the Python environment.
+   */
+  @Override
+  protected void performToolInstallation(ToolRepository toolRepository, VersionIdentifier resolvedVersion, Path installationPath, FileAccess fileAccess,
+      String edition, ProcessContext processContext) {
+
+    if (Files.exists(installationPath)) {
+      fileAccess.backup(installationPath);
+    }
+    fileAccess.mkdirs(installationPath);
+    Uv uv = this.context.getCommandletManager().getCommandlet(Uv.class);
+    uv.installPython(installationPath, resolvedVersion, processContext);
+    this.context.writeVersionFile(resolvedVersion, installationPath);
+    this.context.debug("Installed {} in version {} at {}", this.tool, resolvedVersion, installationPath);
+  }
+
+  @Override
+  public void setEnvironment(EnvironmentContext environmentContext, ToolInstallation toolInstallation, boolean extraInstallation) {
+
+    super.setEnvironment(environmentContext, toolInstallation, extraInstallation);
+    environmentContext.withEnvVar("VIRTUAL_ENV", toolInstallation.rootDir().resolve(".venv").toString());
   }
 
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/uv/Uv.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/uv/Uv.java
@@ -1,0 +1,48 @@
+package com.devonfw.tools.ide.tool.uv;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.devonfw.tools.ide.common.Tag;
+import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.process.ProcessContext;
+import com.devonfw.tools.ide.process.ProcessErrorHandling;
+import com.devonfw.tools.ide.process.ProcessMode;
+import com.devonfw.tools.ide.process.ProcessResult;
+import com.devonfw.tools.ide.tool.LocalToolCommandlet;
+import com.devonfw.tools.ide.version.VersionIdentifier;
+
+public class Uv extends LocalToolCommandlet {
+
+
+  /**
+   * The constructor.
+   *
+   * @param context the {@link IdeContext}.
+   */
+  public Uv(IdeContext context) {
+
+    super(context, "uv", Set.of(Tag.PYTHON));
+  }
+
+  public void installPython(Path installationPath, VersionIdentifier resolvedVersion, ProcessContext processContext) {
+
+    processContext.directory(installationPath);
+
+    List<String> uvInstallCommands = new ArrayList<>();
+    uvInstallCommands.add("venv");
+    uvInstallCommands.add("--python");
+    uvInstallCommands.add(resolvedVersion.toString());
+
+    ProcessResult result = runTool(ProcessMode.DEFAULT_CAPTURE, ProcessErrorHandling.THROW_ERR, processContext, uvInstallCommands.toArray(String[]::new));
+
+    if (result.isSuccessful()) {
+      this.context.success("Successfully installed and created virtual environment for Python version: {}", resolvedVersion);
+    } else {
+      this.context.warning("Failed to install and create virtual environment for Python version: {}", resolvedVersion);
+    }
+  }
+
+}


### PR DESCRIPTION
### This PR fixes #1384 .

### Implemented changes:

* Add python installation logic via uv
* Add a uv commandlet
* Adjust installation logic so it can be overridden for special python handeling without too much redundancy

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [ ] When running `mvn clean test` locally all tests pass and build is successful
- [ ] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [ ] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [ ] PR and issue(s) have suitable labels
- [ ] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [ ] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [ ] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue
