### PR TITLE
#1221: Disable windows terminal integration feature and move to next release

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,7 +8,6 @@ Release with new features and bugfixes:
 
 * https://github.com/devonfw/IDEasy/issues/1384[#1384]: Python support not working at all
 * https://github.com/devonfw/IDEasy/issues/1443[#1443]: Tool version is being added to settings even though it does not exist
-* https://github.com/devonfw/IDEasy/issues/1221[#1221]: Improve installation on Windows
 * https://github.com/devonfw/IDEasy/issues/1451[#1451]: XmlMerger requires merge:id for single attribute
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/33?closed=1[milestone 2025.08.001].

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/InstallCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/InstallCommandlet.java
@@ -67,7 +67,8 @@ public class InstallCommandlet extends Commandlet {
             + "The current command will install IDEasy on your computer. Are you sure?");
       }
       ideasy.installIdeasy(cwd);
-      ideasy.setupWindowsTerminal();
+      // TODO https://github.com/devonfw/IDEasy/issues/1221
+      //ideasy.setupWindowsTerminal();
       return;
     }
     ToolCommandlet commandlet = this.tool.getValue();


### PR DESCRIPTION
### This PR disables feature #1221 that is broken and not working.

We want to unblock the release and fix it in the next release.

### Implemented changes:

* Disable windows terminal integration feature
* Removed from CHANGELOG

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [ ] When running `mvn clean test` locally all tests pass and build is successful
- [ ] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [ ] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [ ] PR and issue(s) have suitable labels
- [ ] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [ ] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [ ] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
