### PR TITLE
#1460: added --no-colors option to disable colored logging and fixed MSI logging

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1464[#1464]: IDEasy setup does not find bash
 * https://github.com/devonfw/IDEasy/issues/1476[#1476]: IDEasy does not create links on extraction
 * https://github.com/devonfw/IDEasy/issues/1477[#1477]: IDEasy cannot create link to file on Windows
+* https://github.com/devonfw/IDEasy/issues/1460[#1460]: Prevent strange ansi-codes in logs
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/34?closed=1[milestone 2025.09.001].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/ContextCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/ContextCommandlet.java
@@ -30,6 +30,8 @@ public class ContextCommandlet extends Commandlet {
 
   private final FlagProperty skipUpdates;
 
+  private final FlagProperty noColors;
+
   private final LocaleProperty locale;
 
   private IdeStartContextImpl startContext;
@@ -48,6 +50,7 @@ public class ContextCommandlet extends Commandlet {
     this.privacy = add(new FlagProperty("--privacy", false, "-p"));
     this.offline = add(new FlagProperty("--offline", false, "-o"));
     this.skipUpdates = add(new FlagProperty("--skip-updates", false));
+    this.noColors = add(new FlagProperty("--no-colors", false));
     this.locale = add(new LocaleProperty("--locale", false, null));
   }
 
@@ -81,6 +84,7 @@ public class ContextCommandlet extends Commandlet {
     this.startContext.setOfflineMode(this.offline.isTrue());
     this.startContext.setPrivacyMode(this.privacy.isTrue());
     this.startContext.setSkipUpdatesMode(this.skipUpdates.isTrue());
+    this.startContext.setNoColorsMode(this.noColors.isTrue());
     this.startContext.setLocale(this.locale.getValue());
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -710,6 +710,12 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
   }
 
   @Override
+  public boolean isNoColorsMode() {
+
+    return this.startContext.isNoColorsMode();
+  }
+
+  @Override
   public boolean isOnline() {
 
     if (this.online == null) {

--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeStartContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeStartContext.java
@@ -57,6 +57,11 @@ public interface IdeStartContext extends IdeLogger {
   boolean isSkipUpdatesMode();
 
   /**
+   * @return {@code true} if no-colours mode is activated (--no-colours), {@code false} otherwise.
+   */
+  boolean isNoColorsMode();
+
+  /**
    * @return the current {@link Locale}. Either configured via command-line option or {@link Locale#getDefault() default}.
    */
   Locale getLocale();

--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeStartContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeStartContextImpl.java
@@ -31,6 +31,8 @@ public class IdeStartContextImpl extends IdeLoggerImpl implements IdeStartContex
 
   private boolean privacyMode;
 
+  private boolean noColorsMode;
+
   private Locale locale;
 
   /**
@@ -172,7 +174,6 @@ public class IdeStartContextImpl extends IdeLoggerImpl implements IdeStartContex
     return this.locale;
   }
 
-
   /**
    * @param locale new value of {@link #getLocale()}.
    */
@@ -181,4 +182,18 @@ public class IdeStartContextImpl extends IdeLoggerImpl implements IdeStartContex
     this.locale = locale;
   }
 
+  @Override
+  public boolean isNoColorsMode() {
+
+    return this.noColorsMode;
+  }
+
+  /**
+   * @param noColoursMode new value of {@link #isNoColorsMode()}.
+   */
+  public void setNoColorsMode(boolean noColoursMode) {
+
+    this.noColorsMode = noColoursMode;
+    setLogColors(!noColoursMode);
+  }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/log/AbstractIdeSubLogger.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/log/AbstractIdeSubLogger.java
@@ -14,7 +14,7 @@ public abstract class AbstractIdeSubLogger implements IdeSubLogger {
 
   final IdeLogListener listener;
 
-  protected final boolean colored;
+  protected boolean colored;
 
   private boolean enabled;
 
@@ -58,6 +58,11 @@ public abstract class AbstractIdeSubLogger implements IdeSubLogger {
   void setEnabled(boolean enabled) {
 
     this.enabled = enabled;
+  }
+
+  void setColored(boolean colored) {
+    
+    this.colored = colored;
   }
 
   /**

--- a/cli/src/main/java/com/devonfw/tools/ide/log/IdeLoggerImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/log/IdeLoggerImpl.java
@@ -63,6 +63,16 @@ public class IdeLoggerImpl implements IdeLogger {
   }
 
   /**
+   * @param colored the new {@link AbstractIdeSubLogger#isColored() colored flag}.
+   */
+  protected void setLogColors(boolean colored) {
+
+    for (IdeLogLevel level : IdeLogLevel.values()) {
+      this.loggers[level.ordinal()].setColored(colored);
+    }
+  }
+
+  /**
    * @param logLevel the {@link IdeLogLevel} to modify.
    * @param enabled - {@code true} to enable, {@code false} to disable.
    */

--- a/cli/src/main/resources/nls/Help.properties
+++ b/cli/src/main/resources/nls/Help.properties
@@ -132,6 +132,7 @@ opt.--force-plugins=force plugin (re)installation.
 opt.--force-pull=force pull of settings even for code repository.
 opt.--force-repositories=force setup of repositories to even clone inactive and pull existing ones.
 opt.--locale=the locale (e.g. '--locale=de' for German language).
+opt.--no-colors=disable colored log messages.
 opt.--offline=enable offline mode (skip updates or git pull, fail downloads or git clone).
 opt.--privacy=enable GDPR-compliant console output.
 opt.--quiet=disable info logging (only log success, warning or error).

--- a/cli/src/main/resources/nls/Help_de.properties
+++ b/cli/src/main/resources/nls/Help_de.properties
@@ -132,6 +132,7 @@ opt.--force-plugins=Erzwingt die (Re)Installation von Plugins.
 opt.--force-pull=Erzwingt einen Pull der settings auch im Fall eines Code-Repositories.
 opt.--force-repositories=Erzwingt das Setup von Repositories um auch Inaktive zu clonen oder Existierende zu pullen.
 opt.--locale=Die Spracheinstellungen (z.B. '--locale=en' für Englisch).
+opt.--no-colors=Deaktiviert farbige Log-Meldungen.
 opt.--offline=Aktiviert den Offline-Modus (Überspringt Aktualisierungen oder git pull, schlägt fehl bei Downloads or git clone).
 opt.--privacy=Aktiviert DSGVO konforme Konsolenausgaben.
 opt.--quiet=Deaktiviert Info Logging ( nur success, warning und error).

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -35,7 +35,7 @@
 		<!-- Execution of install command-->
 		<SetProperty
 			Id="RunInstallAction"
-			Value='"[%SystemFolder]cmd.exe" /c "cd /d [INSTALLFOLDER] &amp;&amp; bin\ideasy.exe -fb install > install.log"'
+			Value='"[%SystemFolder]cmd.exe" /c "cd /d [INSTALLFOLDER] &amp;&amp; bin\ideasy.exe -ftb --no-colors install > install.log 2>&1"'
 			Before="RunInstallAction"
 			Sequence="execute"
 			/>
@@ -51,7 +51,7 @@
     <!-- Execution of uninstall command-->
     <SetProperty
       Id="RunUninstallAction"
-			Value='"[%SystemFolder]cmd.exe" /c "[%IDE_ROOT]\_ide\installation\bin\ideasy.exe -f uninstall > [%IDE_ROOT]\uninstall.log"'
+			Value='"[%SystemFolder]cmd.exe" /c "[%IDE_ROOT]\_ide\installation\bin\ideasy.exe -ft --no-colors uninstall > [%IDE_ROOT]\uninstall.log 2>&1"'
       Before="RunUninstallAction"
       Sequence="execute"
       />


### PR DESCRIPTION
### This PR fixes #1460.

### Implemented changes:

* added --no-colors option
* make --no-colors to disable colored logging
* use --no-colors option in Windows MSI installer/uninstaller to prevent ANSI mess in logs
* enable trace logging for Windows MSI installer/uninstaller
* include stderr in logging for Windows MSI installer/uninstaller that was lost before

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`