### PR TITLE
#1490: fix linking folders as junction with absolute path on Windows as fallback

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccess.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccess.java
@@ -407,7 +407,7 @@ public interface FileAccess {
 
   /**
    * @param file the {@link Path} to the file to read.
-   * @return the content of the specified file (in UTF-8 encoding), or null if the file doesn't exist
+   * @return the content of the specified file (in UTF-8 encoding), or {@code null} if the file doesn't exist.
    * @see java.nio.file.Files#readString(Path)
    */
   String readFileContent(Path file);

--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -495,7 +495,14 @@ public class FileAccessImpl implements FileAccess {
   private void mklinkOnWindows(Path target, Path link, PathLinkType type) {
 
     this.context.trace("Creating a Windows link at {} pointing to {}", link, target);
-    ProcessResult result = this.context.newProcess().executable("cmd").addArgs("/c", "mklink", type.getMklinkOption(), link.toString(), target.toString())
+    ProcessContext pc = this.context.newProcess().executable("cmd")
+        .addArgs("/c", "mklink", type.getMklinkOption());
+    if (type == PathLinkType.SYMBOLIC_LINK && Files.isDirectory(target)) {
+      pc.addArg("/j");
+      target = target.toAbsolutePath();
+    }
+    pc = pc.addArgs(link.toString(), target.toString());
+    ProcessResult result = pc
         .run(ProcessMode.DEFAULT);
     result.failOnError();
   }


### PR DESCRIPTION
### This PR fixes #1490.

### Implemented changes:

* fix linking folders as junction with absolute path on Windows as fallback

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`