### PR TITLE
#1560: enable trace logging in setup scripts

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1169[#1169]: mklink fails if link already exists
 * https://github.com/devonfw/IDEasy/issues/1553[#1553]: IDEasy is slow since 2025.09.001
 * https://github.com/devonfw/IDEasy/issues/1555[#1555]: Handle npm_config_prefix environment variable
+* https://github.com/devonfw/IDEasy/issues/1560[#1560]: Enable trace logging in IDEasy setup script
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/37?closed=1[milestone 2025.11.001].
 

--- a/cli/src/main/package/setup
+++ b/cli/src/main/package/setup
@@ -1,3 +1,13 @@
 #!/bin/bash
 cd "$(dirname "${BASH_SOURCE:-$0}")" || exit 255
-./bin/ideasy -f install
+
+# Create logs directory if it doesn't exist
+LOGS_DIR="${HOME}/.ide/logs"
+mkdir -p "${LOGS_DIR}"
+
+# Generate timestamp for log file
+TIMESTAMP=$(date +"%Y-%m-%d_%H_%M_%S")
+LOG_FILE="${LOGS_DIR}/install-${TIMESTAMP}.log"
+
+# Run ideasy with trace logging and tee output to log file
+./bin/ideasy -ft install 2>&1 | tee "${LOG_FILE}"

--- a/windows-installer/Package.wxs
+++ b/windows-installer/Package.wxs
@@ -35,7 +35,7 @@
 		<!-- Execution of install command-->
 		<SetProperty
 			Id="RunInstallAction"
-			Value='"[%SystemFolder]cmd.exe" /c "cd /d [INSTALLFOLDER] &amp;&amp; bin\ideasy.exe -ftb --no-colors install > install.log 2>&amp;1"'
+			Value='"[%SystemFolder]cmd.exe" /c "cd /d [INSTALLFOLDER] &amp;&amp; if not exist [%USERPROFILE%]\.ide\logs mkdir [%USERPROFILE%]\.ide\logs &amp;&amp; for /f "tokens=1-4 delims=/ " %%a in ("%date%") do (for /f "tokens=1-3 delims=:." %%m in ("%time: =0%") do (bin\ideasy.exe -ftb --no-colors install > [%USERPROFILE%]\.ide\logs\install-%%c-%%b-%%a_%%m_%%n_%%o.log 2>&amp;1))"'
 			Before="RunInstallAction"
 			Sequence="execute"
 			/>

--- a/windows-installer/README.adoc
+++ b/windows-installer/README.adoc
@@ -56,7 +56,7 @@ Here you define the script that will be executed after installation:
 
       <SetProperty
             Id="RunSetupAction"
-            Value="&quot;[INSTALLFOLDER]bin\ideasy.exe&quot; -f install"
+            Value="&quot;[INSTALLFOLDER]bin\ideasy.exe&quot; -ft install"
             Before="RunSetupAction"
             Sequence="execute"
             />


### PR DESCRIPTION
### This PR fixes #1560

### Implemented changes:

* Added `-t` flag to enable trace logging in bash setup script (`cli/src/main/package/setup`)
* Implemented log file creation with timestamp in `~/.ide/logs/install-YYYY-MM-DD_HH_mm_ss.log`
* Used `tee` command to capture output to log file while still displaying to console (bash)
* Updated Windows MSI installer to save logs with timestamp in `%USERPROFILE%\.ide\logs\install-YYYY-MM-DD_HH_mm_ss.log`
* Updated `windows-installer/README.adoc` to reflect the `-ft` flag
* Added issue to `CHANGELOG.adoc` for release 2025.11.001

Fixes #1560

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
