### PR TITLE
add FileAccess getBin[Parent]Path() methods

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccess.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccess.java
@@ -2,6 +2,7 @@ package com.devonfw.tools.ide.io;
 
 import java.io.OutputStream;
 import java.io.Reader;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
@@ -13,6 +14,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.io.ini.IniFile;
 import com.devonfw.tools.ide.io.ini.IniFileImpl;
 
@@ -557,4 +559,31 @@ public interface FileAccess {
    *     {@link Duration}), {@code false} otherwise.
    */
   boolean isFileAgeRecent(Path path, Duration cacheDuration);
+
+  /**
+   * @param path the tool {@link Path}.
+   * @return a potential "bin" sub-folder or the given {@link Path} itself, if no such sub-folder was found.
+   */
+  default Path getBinPath(Path path) {
+
+    Path binPath = path.resolve(IdeContext.FOLDER_BIN);
+    if (Files.exists(binPath)) {
+      return binPath;
+    }
+    return path;
+  }
+
+  /**
+   * Reverse operation of {@link #getBinPath(Path)}.
+   *
+   * @param binPath the {@link Path} to a potential "bin" sub-folder of a tool {@link Path}.
+   * @return the tool {@link Path} containing the "bin" sub-folder.
+   */
+  default Path getBinParentPath(Path binPath) {
+
+    if (binPath.getFileName().toString().equals(IdeContext.FOLDER_BIN)) {
+      return binPath.getParent();
+    }
+    return binPath;
+  }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/io/FileAccessImplTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/io/FileAccessImplTest.java
@@ -792,4 +792,27 @@ public class FileAccessImplTest extends AbstractIdeContextTest {
     }
   }
 
+  /**
+   * Test of {@link FileAccess#getBinPath(Path)} and {@link FileAccess#getBinParentPath(Path)}.
+   */
+  @Test
+  public void testBinPath() {
+
+    // arrage
+    FileAccess fileAccess = IdeTestContextMock.get().getFileAccess();
+    Path projects = Path.of("src/test/resources/ide-projects");
+    Path rootPath = projects.resolve("basic/project/software/java");
+    Path binPath = rootPath.resolve("bin");
+
+    // act
+    Path testBinPath = fileAccess.getBinPath(rootPath);
+    Path testRootPath = fileAccess.getBinParentPath(binPath);
+
+    // assert
+    assertThat(testBinPath).isEqualTo(binPath);
+    assertThat(testRootPath).isEqualTo(rootPath);
+    assertThat(fileAccess.getBinPath(projects)).isSameAs(projects);
+    assertThat(fileAccess.getBinParentPath(projects)).isSameAs(projects);
+  }
+
 }


### PR DESCRIPTION
### This PR add bin path support to FileAccess

This feature is added to avoid redundancies and complexity in PR #1593

### Implemented changes:

* Added `FileAccess.getBinPath(Path)`
* Added `FileAccess.getBinParentPath(Path)`
* Added `FileAccessImplTest.testBinPath()` to test the new feature

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`