### PR TITLE
fix tests on Windows so bash scripts can be executed since bash.exe n…

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.os.SystemInfoImpl;
 import com.devonfw.tools.ide.os.WindowsPathSyntax;
 import com.devonfw.tools.ide.variable.IdeVariables;
 
@@ -171,7 +172,7 @@ public class SystemPath {
   private Path findBinaryInOrder(Path path, String tool) {
 
     List<String> extensionPriority = List.of("");
-    if (this.context.getSystemInfo().isWindows()) {
+    if (this.context.getSystemInfo().isWindows() || SystemInfoImpl.INSTANCE.isWindows()) {
       extensionPriority = EXTENSION_PRIORITY;
     }
     for (String extension : extensionPriority) {

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -1397,7 +1397,7 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
     Path bashPath = findBashOnBashPath();
     if (bashPath == null) {
       bashPath = findBashInPath();
-      if (bashPath == null && getSystemInfo().isWindows()) {
+      if (bashPath == null && (getSystemInfo().isWindows() || SystemInfoImpl.INSTANCE.isWindows())) {
         bashPath = findBashOnWindowsDefaultGitPath();
         if (bashPath == null) {
           bashPath = findBashInWindowsRegistry();


### PR DESCRIPTION

### This PR fixes a bug from PR #1577 that caused the tests fail on some Windows systems.

fix tests on Windows so bash scripts can be executed since bash.exe needs to be found on path

```
No bash executable could be found on your system.
Running command 'D:\projects\IDEasy\workspaces\main\IDEasy\cli\target\ide-projects\build\project\software\node\bin\npm' using bash with arguments 'config' 'set' 'prefix' 'D:\projects\IDEasy\workspaces\main\IDEasy\cli\target\ide-projects\build\project\software\node' ...
Running command 'D:\projects\IDEasy\workspaces\main\IDEasy\cli\target\ide-projects\build\project\software\node\bin\npm' using bash with arguments 'config' 'set' 'prefix' 'D:\projects\IDEasy\workspaces\main\IDEasy\cli\target\ide-projects\build\project\software\node'
failed with exit code 1!
10:46:34.464 [main] - ERROR - c.d.tools.ide.log.IdeSubLoggerSlf4j - <3>WSL (9) ERROR: CreateProcessEntryCommon:502: execvpe /bin/bash failed 2
10:46:34.464 [main] - ERROR - c.d.tools.ide.log.IdeSubLoggerSlf4j - <3>WSL (9) ERROR: CreateProcessEntryCommon:505: Create process not expected to return

com.devonfw.tools.ide.cli.CliProcessException: Running command 'D:\projects\IDEasy\workspaces\main\IDEasy\cli\target\ide-projects\build\project\software\node\bin\npm' using bash with arguments 'config' 'set' 'prefix' 'D:\projects\IDEasy\workspaces\main\IDEasy\cli\target\ide-projects\build\project\software\node'
failed with exit code 1!
```

The problem is this setup (from Windows CMD):
```
where bash
C:\Windows\System32\bash.exe
C:\Users\hohwille\AppData\Local\Microsoft\WindowsApps\bash.exe
C:\Program Files\Git\usr\bin\bash.exe
```

### Implemented changes:

* do windows specific quirks to find bash always on physical Windows even if another OS is currently mocked.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`