### PR TITLE
#1593: #1144: #1145: fix json parsing in graalvm

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/json/JsonMapping.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/json/JsonMapping.java
@@ -6,7 +6,11 @@ import com.devonfw.tools.ide.tool.repository.CustomToolJsonSerializer;
 import com.devonfw.tools.ide.tool.repository.CustomToolsJson;
 import com.devonfw.tools.ide.tool.repository.CustomToolsJsonDeserializer;
 import com.devonfw.tools.ide.tool.repository.CustomToolsJsonSerializer;
+import com.devonfw.tools.ide.url.model.file.json.Cve;
+import com.devonfw.tools.ide.url.model.file.json.CveJsonDeserializer;
 import com.devonfw.tools.ide.url.model.file.json.ToolDependency;
+import com.devonfw.tools.ide.url.model.file.json.ToolSecurity;
+import com.devonfw.tools.ide.url.model.file.json.ToolSecurityJsonDeserializer;
 import com.devonfw.tools.ide.version.VersionIdentifier;
 import com.devonfw.tools.ide.version.VersionRange;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -35,13 +39,17 @@ public class JsonMapping {
     SimpleModule customModule = new SimpleModule();
     customModule.addDeserializer(VersionIdentifier.class, new VersionIdentifierDeserializer());
     customModule.addDeserializer(VersionRange.class, new VersionRangeDeserializer());
-    customModule.addDeserializer(ToolDependency.class, new ToolDependencyDeserializer());
-    customModule.addDeserializer(CustomToolJson.class, new CustomToolJsonDeserializer());
-    customModule.addDeserializer(CustomToolsJson.class, new CustomToolsJsonDeserializer());
-    customModule.addSerializer(CustomToolJson.class, new CustomToolJsonSerializer());
-    customModule.addSerializer(CustomToolsJson.class, new CustomToolsJsonSerializer());
-    customModule.addKeyDeserializer(VersionRange.class, new VersionRangeKeyDeserializer());
     customModule.addSerializer(VersionRange.class, new VersionRangeSerializer());
+    customModule.addKeyDeserializer(VersionRange.class, new VersionRangeKeyDeserializer());
+
+    customModule.addDeserializer(ToolDependency.class, new ToolDependencyDeserializer());
+    customModule.addDeserializer(ToolSecurity.class, new ToolSecurityJsonDeserializer());
+    customModule.addDeserializer(Cve.class, new CveJsonDeserializer());
+
+    customModule.addDeserializer(CustomToolJson.class, new CustomToolJsonDeserializer());
+    customModule.addSerializer(CustomToolJson.class, new CustomToolJsonSerializer());
+    customModule.addDeserializer(CustomToolsJson.class, new CustomToolsJsonDeserializer());
+    customModule.addSerializer(CustomToolsJson.class, new CustomToolsJsonSerializer());
     mapper = mapper.registerModule(customModule);
     return mapper;
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/Cve.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/Cve.java
@@ -16,6 +16,12 @@ import com.devonfw.tools.ide.version.VersionRange;
  */
 public record Cve(String id, double severity, List<VersionRange> versions) {
 
+  static final String PROPERTY_ID = "id";
+
+  static final String PROPERTY_SEVERITY = "severity";
+
+  static final String PROPERTY_VERSIONS = "versions";
+
   /**
    * @param cves the {@link Cve}s to summarize.
    * @return the sum of {@link Cve#severity()}.

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/CveJsonDeserializer.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/CveJsonDeserializer.java
@@ -1,0 +1,87 @@
+package com.devonfw.tools.ide.url.model.file.json;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.devonfw.tools.ide.version.VersionRange;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+/**
+ * {@link JsonDeserializer} for {@link Cve}.
+ */
+public class CveJsonDeserializer extends JsonDeserializer<Cve> {
+
+  // private static final Logger LOG = LoggerFactory.getLogger(ToolSecurityJsonDeserializer.class);
+
+  @Override
+  public Cve deserialize(JsonParser p, DeserializationContext deserializationContext) throws IOException {
+
+    JsonToken token = p.getCurrentToken();
+    if (token == JsonToken.START_OBJECT) {
+      String id = null;
+      double severity = 0;
+      List<VersionRange> versions = null;
+      token = p.nextToken();
+      while (token == JsonToken.FIELD_NAME) {
+        String property = p.currentName();
+        switch (property) {
+          case Cve.PROPERTY_ID -> {
+            token = p.nextToken();
+            assert token == JsonToken.VALUE_STRING;
+            assert id == null;
+            id = p.getValueAsString();
+            token = p.nextToken();
+          }
+          case Cve.PROPERTY_SEVERITY -> {
+            token = p.nextToken();
+            assert token.isNumeric();
+            assert severity == 0;
+            severity = p.getValueAsDouble();
+            token = p.nextToken();
+          }
+          case Cve.PROPERTY_VERSIONS -> {
+            assert versions == null;
+            versions = parseVersions(p);
+            token = p.nextToken();
+          }
+          default -> {
+            // currently cannot log here due to https://github.com/devonfw/IDEasy/issues/404
+            //LOG.debug("Ignoring unexpected property {}", property);
+            p.skipChildren();
+            token = p.nextToken();
+          }
+        }
+      }
+      assert id != null;
+      assert severity != 0;
+      assert versions != null;
+      return new Cve(id, severity, versions);
+    } else if (token == JsonToken.VALUE_NULL) {
+      return null;
+    } else {
+      throw new IllegalStateException("Unexpected token " + token);
+    }
+  }
+
+  private static List<VersionRange> parseVersions(JsonParser p) throws IOException {
+    JsonToken token = p.nextToken();
+    if (token == JsonToken.START_ARRAY) {
+      List<VersionRange> versions = new ArrayList<>();
+      token = p.nextToken();
+      while (token != JsonToken.END_ARRAY) {
+        VersionRange versionRange = p.readValueAs(VersionRange.class);
+        versions.add(versionRange);
+        token = p.nextToken();
+      }
+      return versions;
+    } else if (token == JsonToken.VALUE_NULL) {
+      return null;
+    } else {
+      throw new IllegalStateException("Unexpected token " + token);
+    }
+  }
+}

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/ToolSecurity.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/ToolSecurity.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class ToolSecurity {
 
+  static final String PROPERTY_ISSUES = "issues";
+
   private static final ObjectMapper MAPPER = JsonMapping.create();
 
   private static final ToolSecurity EMPTY = new ToolSecurity(Collections.emptyList());

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/ToolSecurityJsonDeserializer.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/ToolSecurityJsonDeserializer.java
@@ -1,0 +1,66 @@
+package com.devonfw.tools.ide.url.model.file.json;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+/**
+ * {@link JsonDeserializer} for {@link ToolSecurity}.
+ */
+public class ToolSecurityJsonDeserializer extends JsonDeserializer<ToolSecurity> {
+
+  // private static final Logger LOG = LoggerFactory.getLogger(ToolSecurityJsonDeserializer.class);
+
+  @Override
+  public ToolSecurity deserialize(JsonParser p, DeserializationContext deserializationContext) throws IOException {
+
+    JsonToken token = p.getCurrentToken();
+    if (token == JsonToken.START_OBJECT) {
+      List<Cve> issues = null;
+      token = p.nextToken();
+      while (token == JsonToken.FIELD_NAME) {
+        String property = p.currentName();
+        if (property.equals(ToolSecurity.PROPERTY_ISSUES)) {
+          assert (issues == null);
+          issues = parseIssues(p);
+          token = p.nextToken();
+        } else {
+          // currently cannot log here due to https://github.com/devonfw/IDEasy/issues/404
+          //LOG.debug("Ignoring unexpected property {}", property);
+          p.skipChildren();
+          token = p.nextToken();
+        }
+      }
+      assert (issues != null);
+      return new ToolSecurity(Collections.unmodifiableList(issues));
+    } else if (token == JsonToken.VALUE_NULL) {
+      return null;
+    } else {
+      throw new IllegalStateException("Unexpected token " + token);
+    }
+  }
+
+  private static List<Cve> parseIssues(JsonParser p) throws IOException {
+    JsonToken token = p.nextToken();
+    if (token == JsonToken.START_ARRAY) {
+      List<Cve> issues = new ArrayList<>();
+      token = p.nextToken();
+      while (token != JsonToken.END_ARRAY) {
+        Cve cve = p.readValueAs(Cve.class);
+        issues.add(cve);
+        token = p.nextToken();
+      }
+      return issues;
+    } else if (token == JsonToken.VALUE_NULL) {
+      return null;
+    } else {
+      throw new IllegalStateException("Unexpected token " + token);
+    }
+  }
+}


### PR DESCRIPTION
### This PR fixes a bug from PR #1593

### Implemented changes:

* fix json parsing in graalvm

Error was:
```
java.lang.IllegalStateException: Failed to load D:\projects\_ide\urls\mvn\mvn\security.json
        at com.devonfw.tools.ide.url.model.file.json.ToolSecurity.of(ToolSecurity.java:108)
        at com.devonfw.tools.ide.url.model.file.UrlSecurityFile.doLoad(UrlSecurityFile.java:64)
        at com.devonfw.tools.ide.url.model.file.AbstractUrlFile.load(AbstractUrlFile.java:41)
        at com.devonfw.tools.ide.url.model.folder.AbstractUrlToolOrEdition.getSecurityFile(AbstractUrlToolOrEdition.java:46)
        at com.devonfw.tools.ide.tool.repository.AbstractToolRepository.findSecurity(AbstractToolRepository.java:309)
        at com.devonfw.tools.ide.tool.ToolCommandlet.cveCheck(ToolCommandlet.java:488)
        at com.devonfw.tools.ide.tool.LocalToolCommandlet.installTool(LocalToolCommandlet.java:188)
        at com.devonfw.tools.ide.tool.LocalToolCommandlet.doInstallStep(LocalToolCommandlet.java:99)
        at com.devonfw.tools.ide.tool.LocalToolCommandlet.install(LocalToolCommandlet.java:86)
        at com.devonfw.tools.ide.tool.ToolCommandlet.install(ToolCommandlet.java:270)
        at com.devonfw.tools.ide.tool.ToolCommandlet.install(ToolCommandlet.java:259)
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.devonfw.tools.ide.url.model.file.json.ToolSecurity`: cannot deserialize from Object value (no delegate- or property-based Creator): this appears to be a native image, in which case you may need to configure reflection for the class that is to be deserialized
at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 2, column: 3]
        at com.fasterxml.jackson.databind.DeserializationContext.reportBadDefinition(DeserializationContext.java:1888)
        at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:414)
        at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1370)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1509)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:348)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185)
        at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4931)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3881)
        at com.devonfw.tools.ide.url.model.file.json.ToolSecurity.of(ToolSecurity.java:106)
        ... 26 more
```

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`