### PR TITLE
#1615: prevent to ask CVE questions if tool already installed

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
@@ -137,7 +137,7 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
     }
     String edition = toolEdition.edition();
     ToolRepository toolRepository = this.context.getDefaultToolRepository();
-    resolvedVersion = cveCheck(request, false);
+    resolvedVersion = cveCheck(request);
     // download and install the global tool
     FileAccess fileAccess = this.context.getFileAccess();
     Path target = toolRepository.download(this.tool, edition, resolvedVersion, this);

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -95,7 +95,7 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
 
     // check if we already have this version installed (linked) locally in IDE_HOME/software
     VersionIdentifier resolvedVersion = installation.resolvedVersion();
-    if (request.isAlreadyInstalled(this.context.isSkipUpdatesMode())) {
+    if (request.isAlreadyInstalled()) {
       return installation;
     }
     FileAccess fileAccess = this.context.getFileAccess();
@@ -155,22 +155,16 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
     ToolEdition toolEdition = requested.getEdition();
     assert (toolEdition.tool().equals(this.tool)) : "Mismatch " + this.tool + " != " + toolEdition.tool();
     String edition = toolEdition.edition();
-    boolean skipSuggestions = false;
-    VersionIdentifier resolvedVersion;
-    if (this.context.isSkipUpdatesMode() && request.isAlreadyInstalled(true)) {
-      requested.setResolvedVersion(request.getInstalled().getResolvedVersion());
-      skipSuggestions = true;
-    }
-    resolvedVersion = cveCheck(request, skipSuggestions);
-    ProcessContext processContext = request.getProcessContext();
+    VersionIdentifier resolvedVersion = cveCheck(request);
     installToolDependencies(request);
 
     // cveCheck might have changed resolvedVersion so let us re-check...
-    if (request.isAlreadyInstalled(this.context.isSkipUpdatesMode())) {
+    if (request.isAlreadyInstalled()) {
       return toolAlreadyInstalled(request);
     }
     Path installationPath = getInstallationPath(edition, resolvedVersion);
 
+    ProcessContext processContext = request.getProcessContext();
     boolean additionalInstallation = request.isAdditionalInstallation();
     boolean ignoreSoftwareRepo = isIgnoreSoftwareRepo();
     Path toolVersionFile = installationPath.resolve(IdeContext.FILE_SOFTWARE_VERSION);

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolInstallRequest.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolInstallRequest.java
@@ -175,11 +175,9 @@ public final class ToolInstallRequest {
   }
 
   /**
-   * @param skipUpdate {@code true} for {@link com.devonfw.tools.ide.context.IdeStartContext#isSkipUpdatesMode() skip update mode}, {@code false}
-   *     otherwise.
    * @return {@code true} if the {@link #getRequested() requested edition and version} matches the {@link #getInstalled() installed edition and version}
    */
-  public boolean isAlreadyInstalled(boolean skipUpdate) {
+  public boolean isAlreadyInstalled() {
 
     if (this.installed == null) {
       return false;
@@ -195,12 +193,7 @@ public final class ToolInstallRequest {
     if (!this.requested.getEdition().equals(installedEdition)) {
       return false;
     }
-    VersionIdentifier resolvedVersion = this.requested.getResolvedVersion();
-    if ((resolvedVersion == null) || skipUpdate) {
-      GenericVersionRange requestedVersion = this.requested.getVersion();
-      return requestedVersion.contains(installedVersion);
-    }
-    return resolvedVersion.equals(installedVersion);
+    return installedVersion.equals(this.requested.getResolvedVersion());
   }
 
   /**


### PR DESCRIPTION
### This PR fixes #1615

### Implemented changes:

* improve `cveCheck` to check if already installed, handle direct and force mode, removed `skipSuggestions` parameter and handle everything properly directly in this method.
* since `complete(ToolInstallRequest)` already handles `--skip-update` mode I simplified redundant handling in `isAlreadyInstalled` method.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`