### PR TITLE
#1616: fixed postInstall problems

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -112,7 +112,7 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
     if (installation.binDir() != null) {
       this.context.getPath().setPath(this.tool, installation.binDir());
     }
-    postInstall(true, request.getProcessContext());
+    postInstall(request);
     ToolEditionAndVersion installed = request.getInstalled();
     GenericVersionRange installedVersion = null;
     if (installed != null) {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
@@ -187,8 +187,21 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
       request.setRequested(new ToolEditionAndVersion(toolVersion));
     }
     request.setProcessContext(pc);
+    return runTool(request, processMode, args);
+  }
+
+  /**
+   * Ensures the tool is installed and then runs this tool with the given arguments.
+   *
+   * @param request the {@link ToolInstallRequest}.
+   * @param processMode the {@link ProcessMode}. Should typically be {@link ProcessMode#DEFAULT} or {@link ProcessMode#BACKGROUND}.
+   * @param args the command-line arguments to run the tool.
+   * @return the {@link ProcessResult result}.
+   */
+  public ProcessResult runTool(ToolInstallRequest request, ProcessMode processMode, String... args) {
+
     install(request);
-    return runTool(pc, processMode, args);
+    return runTool(request.getProcessContext(), processMode, args);
   }
 
   /**
@@ -344,21 +357,21 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
   /**
    * This method is called after a tool was requested to be installed or updated.
    *
-   * @param newlyInstalled {@code true} if the tool was installed or updated (at least link to software folder was created/updated), {@code false} otherwise
-   *     (configured version was already installed and nothing changed).
-   * @param pc the {@link ProcessContext} to use.
+   * @param request {@code true} the {@link ToolInstallRequest}.
    */
-  protected void postInstall(boolean newlyInstalled, ProcessContext pc) {
+  protected void postInstall(ToolInstallRequest request) {
 
-    if (newlyInstalled) {
-      postInstall();
+    if (!request.isAlreadyInstalled()) {
+      postInstallOnNewInstallation(request);
     }
   }
 
   /**
-   * This method is called after the tool has been newly installed or updated to a new version.
+   * This method is called after a tool was requested to be installed or updated and a new installation was performed.
+   *
+   * @param request {@code true} the {@link ToolInstallRequest}.
    */
-  protected void postInstall() {
+  protected void postInstallOnNewInstallation(ToolInstallRequest request) {
 
     // nothing to do by default
   }
@@ -455,7 +468,7 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
 
     logToolAlreadyInstalled(request);
     cveCheck(request);
-    postInstall(false, request.getProcessContext());
+    postInstall(request);
     return createExistingToolInstallation(request);
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/aws/Aws.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/aws/Aws.java
@@ -11,6 +11,7 @@ import com.devonfw.tools.ide.nls.NlsBundle;
 import com.devonfw.tools.ide.process.EnvironmentContext;
 import com.devonfw.tools.ide.process.ProcessContext;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
+import com.devonfw.tools.ide.tool.ToolInstallRequest;
 import com.devonfw.tools.ide.tool.ToolInstallation;
 
 /**
@@ -29,9 +30,9 @@ public class Aws extends LocalToolCommandlet {
   }
 
   @Override
-  public void postInstall() {
+  protected void postInstallOnNewInstallation(ToolInstallRequest request) {
 
-    super.postInstall();
+    super.postInstallOnNewInstallation(request);
     Path awsConfigDir = this.context.getConfPath().resolve("aws");
     this.context.getFileAccess().mkdirs(awsConfigDir);
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/az/Azure.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/az/Azure.java
@@ -1,5 +1,6 @@
 package com.devonfw.tools.ide.tool.az;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 
@@ -27,10 +28,17 @@ public class Azure extends LocalToolCommandlet {
   }
 
   @Override
-  public void postInstall() {
+  protected void postExtract(Path extractedDir) {
 
-    super.postInstall();
-    this.context.getFileAccess().symlink(Path.of("wbin"), getToolPath().resolve("bin"));
+    super.postExtract(extractedDir);
+    Path bin = extractedDir.resolve("bin");
+    if (Files.isDirectory(bin)) {
+      return;
+    }
+    Path wbin = extractedDir.resolve("wbin");
+    if (Files.isDirectory(wbin)) {
+      this.context.getFileAccess().symlink(wbin, bin);
+    }
   }
 
   @Override

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
@@ -37,24 +37,21 @@ public class Jmc extends LocalToolCommandlet {
   }
 
   @Override
-  public void postInstall() {
+  protected void postExtract(Path extractedDir) {
 
-    super.postInstall();
-
+    super.postExtract(extractedDir);
     if (this.context.getSystemInfo().isWindows() || this.context.getSystemInfo().isLinux()) {
-      Path toolPath = getToolPath();
-      Path oldBinaryPath = toolPath.resolve("JDK Mission Control");
+      Path oldBinaryPath = extractedDir.resolve("JDK Mission Control");
       if (Files.isDirectory(oldBinaryPath)) {
         FileAccess fileAccess = this.context.getFileAccess();
-        moveFilesAndDirs(oldBinaryPath, toolPath);
+        moveFilesAndDirs(oldBinaryPath, extractedDir);
         fileAccess.delete(oldBinaryPath);
       } else {
-        this.context.info(
+        this.context.debug(
             "JMC binary folder not found at {} - ignoring as this legacy problem may be resolved in newer versions.",
             oldBinaryPath);
       }
     }
-
   }
 
   private void moveFilesAndDirs(Path sourceFolder, Path targetFolder) {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/Mvn.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/Mvn.java
@@ -19,6 +19,7 @@ import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.step.Step;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
+import com.devonfw.tools.ide.tool.ToolInstallRequest;
 import com.devonfw.tools.ide.variable.IdeVariables;
 import com.devonfw.tools.ide.variable.VariableSyntax;
 
@@ -79,8 +80,9 @@ public class Mvn extends LocalToolCommandlet {
   }
 
   @Override
-  public void postInstall() {
+  protected void postInstallOnNewInstallation(ToolInstallRequest request) {
 
+    super.postInstallOnNewInstallation(request);
     // locate templates...
     Path templatesConfMvnFolder = getMavenTemplatesFolder();
     if (templatesConfMvnFolder == null) {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/node/Node.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/node/Node.java
@@ -8,6 +8,7 @@ import com.devonfw.tools.ide.nls.NlsBundle;
 import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
+import com.devonfw.tools.ide.tool.ToolInstallRequest;
 import com.devonfw.tools.ide.tool.npm.Npm;
 
 /**
@@ -26,8 +27,9 @@ public class Node extends LocalToolCommandlet {
   }
 
   @Override
-  protected void postInstall() {
-    super.postInstall();
+  protected void postInstallOnNewInstallation(ToolInstallRequest request) {
+
+    super.postInstallOnNewInstallation(request);
     Npm npm = this.context.getCommandletManager().getCommandlet(Npm.class);
     ProcessResult result = npm.runPackageManager("config", "set", "prefix", getToolPath().toString());
     if (result.isSuccessful()) {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/plugin/PluginBasedCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/plugin/PluginBasedCommandlet.java
@@ -99,12 +99,12 @@ public abstract class PluginBasedCommandlet extends LocalToolCommandlet {
   }
 
   @Override
-  protected void postInstall(boolean newlyInstalled, ProcessContext pc) {
+  protected void postInstall(ToolInstallRequest request) {
 
-    super.postInstall(newlyInstalled, pc);
+    super.postInstall(request);
     Path pluginsInstallationPath = getPluginsInstallationPath();
     FileAccess fileAccess = this.context.getFileAccess();
-    if (newlyInstalled) {
+    if (!request.isAlreadyInstalled()) {
       fileAccess.delete(pluginsInstallationPath);
       List<Path> markerFiles = fileAccess.listChildren(this.context.getIdeHome().resolve(IdeContext.FOLDER_DOT_IDE), Files::isRegularFile);
       for (Path path : markerFiles) {
@@ -115,7 +115,7 @@ public abstract class PluginBasedCommandlet extends LocalToolCommandlet {
       }
     }
     fileAccess.mkdirs(pluginsInstallationPath);
-    installPlugins(pc);
+    installPlugins(request.getProcessContext());
   }
 
   private void installPlugins(ProcessContext pc) {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/terraform/Terraform.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/terraform/Terraform.java
@@ -7,6 +7,7 @@ import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
+import com.devonfw.tools.ide.tool.ToolInstallRequest;
 
 /**
  * {@link ToolCommandlet} for terraform CLI (terraform).
@@ -24,10 +25,10 @@ public class Terraform extends LocalToolCommandlet {
   }
 
   @Override
-  protected void postInstall() {
+  protected void postInstallOnNewInstallation(ToolInstallRequest request) {
 
-    super.postInstall();
-    runTool(ProcessMode.DEFAULT, null, "-install-autocomplete");
+    super.postInstallOnNewInstallation(request);
+    runTool(request, ProcessMode.DEFAULT, "-install-autocomplete");
   }
 
   @Override

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/ide/IdeToolDummyCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/ide/IdeToolDummyCommandletTest.java
@@ -20,6 +20,7 @@ import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.process.ProcessResultImpl;
 import com.devonfw.tools.ide.step.Step;
+import com.devonfw.tools.ide.tool.ToolInstallRequest;
 import com.devonfw.tools.ide.tool.plugin.ToolPluginDescriptor;
 import com.devonfw.tools.ide.version.GenericVersionRange;
 
@@ -77,7 +78,7 @@ public class IdeToolDummyCommandletTest extends AbstractIdeContextTest {
 
       // skip installation but trigger postInstall to test mocked plugin installation
       ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.THROW_CLI);
-      postInstall(true, pc);
+      postInstall(new ToolInstallRequest(true));
       return new ProcessResultImpl(this.tool, this.tool, 0, List.of());
     }
 


### PR DESCRIPTION
### This PR fixes #1616

### Implemented changes:

* refactored `postInstall` to use `ToolInstallRequest` as parameter.
* added `postInstallOnNewInstallation` for simplicity.
* extracted `runTool` method that takes `ToolInstallRequest` as parameter.
* In `Azure` changed `postInstall` to `postExtract` and made the code more robust (actually a bugfix).
* Also in `Jmc` changed `postInstall` to `postExtract` since this was incorrect before.
* In `Terraform` pass the `ToolInstallRequest` from `postInstall` to `runTool` (actual bugfix).

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`