### PR TITLE
added VersionRange math and VersionIdentifier improvements

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionIdentifier.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionIdentifier.java
@@ -201,22 +201,22 @@ public final class VersionIdentifier implements VersionObject<VersionIdentifier>
   /**
    * Increment the specified segment. For examples see {@code VersionIdentifierTest.testIncrement()}.
    *
-   * @param segmentNumber the index of the {@link VersionSegment} to increment. All segments before will remain untouched and all following segments will be
+   * @param digitNumber the index of the {@link VersionSegment} to increment. All segments before will remain untouched and all following segments will be
    *     set to zero.
    * @param keepLetters {@code true} to keep {@link VersionSegment#getLetters() letters} from modified segments, {@code false} to drop them.
    * @return the incremented {@link VersionIdentifier}.
    */
-  public VersionIdentifier incrementSegment(int segmentNumber, boolean keepLetters) {
+  public VersionIdentifier incrementSegment(int digitNumber, boolean keepLetters) {
 
     if (isPattern()) {
       throw new IllegalStateException("Cannot increment version pattern: " + toString());
     }
-    VersionSegment newStart = this.start.increment(segmentNumber, keepLetters);
+    VersionSegment newStart = this.start.increment(digitNumber, keepLetters);
     return new VersionIdentifier(newStart);
   }
 
   /**
-   * Increment the first segment (major version).
+   * Increment the first digit (major version).
    *
    * @param keepLetters {@code true} to keep {@link VersionSegment#getLetters() letters} from modified segments, {@code false} to drop them.
    * @return the incremented {@link VersionIdentifier}.
@@ -227,7 +227,7 @@ public final class VersionIdentifier implements VersionObject<VersionIdentifier>
   }
 
   /**
-   * Increment the second segment (minor version).
+   * Increment the second digit (minor version).
    *
    * @param keepLetters {@code true} to keep {@link VersionSegment#getLetters() letters} from modified segments, {@code false} to drop them.
    * @return the incremented {@link VersionIdentifier}.
@@ -238,7 +238,7 @@ public final class VersionIdentifier implements VersionObject<VersionIdentifier>
   }
 
   /**
-   * Increment the third segment (patch or micro version).
+   * Increment the third digit (patch or micro version).
    *
    * @param keepLetters {@code true} to keep {@link VersionSegment#getLetters() letters} from modified segments, {@code false} to drop them.
    * @return the incremented {@link VersionIdentifier}.
@@ -246,6 +246,18 @@ public final class VersionIdentifier implements VersionObject<VersionIdentifier>
    */
   public VersionIdentifier incrementPatch(boolean keepLetters) {
     return incrementSegment(2, keepLetters);
+  }
+
+  /**
+   * Increment the last segment.
+   *
+   * @param keepLetters {@code true} to keep {@link VersionSegment#getLetters() letters} from modified segments, {@code false} to drop them.
+   * @return the incremented {@link VersionIdentifier}.
+   * @see #incrementSegment(int, boolean)
+   */
+  public VersionIdentifier incrementLastDigit(boolean keepLetters) {
+
+    return incrementSegment(this.start.countDigits() - 1, keepLetters);
   }
 
   @Override
@@ -320,6 +332,30 @@ public final class VersionIdentifier implements VersionObject<VersionIdentifier>
       return null;
     }
     return new VersionIdentifier(startSegment);
+  }
+
+  /**
+   * @param v1 the first {@link VersionIdentifier}.
+   * @param v2 the second {@link VersionIdentifier}.
+   * @param treatNullAsNegativeInfinity {@code true} to treat {@code null} as negative infinity, {@code false} otherwise (positive infinity).
+   * @return the null-safe {@link #compareVersion(VersionIdentifier) comparison} of the two {@link VersionIdentifier}s.
+   */
+  public static VersionComparisonResult compareVersion(VersionIdentifier v1, VersionIdentifier v2, boolean treatNullAsNegativeInfinity) {
+
+    if (v1 == null) {
+      if (v2 == null) {
+        return VersionComparisonResult.EQUAL;
+      } else if (treatNullAsNegativeInfinity) {
+        return VersionComparisonResult.LESS;
+      }
+      return VersionComparisonResult.GREATER;
+    } else if (v2 == null) {
+      if (treatNullAsNegativeInfinity) {
+        return VersionComparisonResult.GREATER;
+      }
+      return VersionComparisonResult.LESS;
+    }
+    return v1.compareVersion(v2);
   }
 
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionRangeCombination.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionRangeCombination.java
@@ -1,0 +1,131 @@
+package com.devonfw.tools.ide.version;
+
+class VersionRangeCombination {
+
+  private final VersionComparisonResult minComparison;
+
+  private final VersionIdentifier minMin;
+
+  private final boolean minMinExclusive;
+
+  private final VersionIdentifier maxMin;
+
+  private final boolean maxMinExclusive;
+
+  private final VersionComparisonResult maxComparison;
+
+  private final VersionIdentifier minMax;
+
+  private final boolean minMaxExclusive;
+
+  private final VersionIdentifier maxMax;
+
+  private final boolean maxMaxExclusive;
+
+  private final VersionRangeRelation relation;
+
+  VersionRangeCombination(VersionRange range1, VersionRange range2) {
+    super();
+    // minimums
+    VersionIdentifier myMinMin = null;
+    VersionIdentifier myMaxMin = null;
+    boolean myMinMinExclusive = true;
+    boolean myMaxMinExclusive = true;
+    if ((range1.min == null) && (range2.min == null)) {
+      this.minComparison = VersionComparisonResult.EQUAL;
+    } else {
+      this.minComparison = VersionIdentifier.compareVersion(range1.min, range2.min, true);
+      if (this.minComparison.isLess()) {
+        myMinMin = range1.min;
+        myMinMinExclusive = range1.boundaryType.isLeftExclusive();
+        myMaxMin = range2.min;
+        myMaxMinExclusive = range2.boundaryType.isLeftExclusive();
+      } else {
+        myMinMin = range2.min;
+        myMinMinExclusive = range2.boundaryType.isLeftExclusive();
+        myMaxMin = range1.min;
+        myMaxMinExclusive = range1.boundaryType.isLeftExclusive();
+      }
+    }
+    this.minMin = myMinMin;
+    this.minMinExclusive = myMinMinExclusive;
+    this.maxMin = myMaxMin;
+    this.maxMinExclusive = myMaxMinExclusive;
+    // maximums
+    VersionIdentifier myMaxMax = null;
+    VersionIdentifier myMinMax = null;
+    boolean myMaxMaxExclusive = true;
+    boolean myMinMaxExclusive = true;
+    if ((range1.max == null) && (range2.max == null)) {
+      this.maxComparison = VersionComparisonResult.EQUAL;
+    } else {
+      this.maxComparison = VersionIdentifier.compareVersion(range1.max, range2.max, false);
+      if (maxComparison.isGreater()) {
+        myMaxMax = range1.max;
+        myMaxMaxExclusive = range1.boundaryType.isRightExclusive();
+        myMinMax = range2.max;
+        myMinMaxExclusive = range2.boundaryType.isRightExclusive();
+      } else {
+        myMaxMax = range2.max;
+        myMaxMaxExclusive = range2.boundaryType.isRightExclusive();
+        myMinMax = range1.max;
+        myMinMaxExclusive = range1.boundaryType.isRightExclusive();
+      }
+    }
+    this.maxMax = myMaxMax;
+    this.maxMaxExclusive = myMaxMaxExclusive;
+    this.minMax = myMinMax;
+    this.minMaxExclusive = myMinMaxExclusive;
+    this.relation = VersionRangeRelation.of(this.maxMin, this.maxMinExclusive, this.minMax, this.minMaxExclusive);
+  }
+
+  VersionRange union(VersionRangeRelation minRelation) {
+
+    if (minRelation.ordinal() <= relation.ordinal()) {
+      boolean leftExclusive = this.minMinExclusive;
+      boolean rightExclusive = this.maxMaxExclusive;
+      if (this.minComparison.isEqual()) {
+        leftExclusive = this.minMinExclusive && this.maxMinExclusive;
+      }
+      if (this.maxComparison.isEqual()) {
+        rightExclusive = this.maxMaxExclusive && this.minMaxExclusive;
+      }
+      return VersionRange.of(this.minMin, this.maxMax, BoundaryType.of(leftExclusive, rightExclusive));
+    }
+    return null;
+  }
+
+  VersionRange intersection() {
+
+    VersionComparisonResult comparison;
+    if (this.minMax == null) {
+      if (this.maxMin == null) {
+        assert this.minMaxExclusive && this.maxMinExclusive;
+        return VersionRange.UNBOUNDED;
+      } else {
+        comparison = VersionComparisonResult.LESS;
+      }
+    } else {
+      comparison = this.minMax.compareVersion(this.maxMin);
+    }
+    boolean leftInclusive = this.maxMinExclusive && this.minMinExclusive;
+    boolean rightInclusive = this.minMaxExclusive && this.maxMaxExclusive;
+    if (comparison.isLess()) {
+      return null;
+    } else if (comparison.isEqual()) {
+      if (this.minMaxExclusive || this.maxMinExclusive) {
+        return null;
+      }
+      //leftInclusive = !this.minMinExclusive;
+      //rightInclusive = !this.maxMaxExclusive;
+    }
+    if (this.minComparison.isEqual()) {
+      leftInclusive = this.minMinExclusive || this.maxMinExclusive;
+    }
+    if (this.maxComparison.isEqual()) {
+      rightInclusive = this.maxMinExclusive || this.minMaxExclusive;
+    }
+    return VersionRange.of(this.maxMin, this.minMax, BoundaryType.of(leftInclusive, rightInclusive));
+  }
+
+}

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionRangeRelation.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionRangeRelation.java
@@ -1,0 +1,114 @@
+package com.devonfw.tools.ide.version;
+
+/**
+ * {@link Enum} with the available types how {@link VersionRange}s can relate to each other. Examples are given by the following table:
+ * <table border="1">
+ *   <tr>
+ *     <th>range1</th>
+ *     <th>range2</th>
+ *     <th>relation</th>
+ *   </tr>
+ *   <tr>
+ *     <td>[2.0,5.0)</td>
+ *     <td>(3.0,5.0]</td>
+ *     <td>{@link #OVERLAPPING}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>[2.0,3.0]</td>
+ *     <td>[3.0,5.0]</td>
+ *     <td>{@link #OVERLAPPING}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>[2.0,3.0)</td>
+ *     <td>[3.0,5.0]</td>
+ *     <td>{@link #CONNECTED}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>[2.0,3.0]</td>
+ *     <td>(3.0,5.0]</td>
+ *     <td>{@link #CONNECTED}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>[2.0,2.2]</td>
+ *     <td>[2.3,5.0]</td>
+ *     <td>{@link #CONNECTED_LOOSELY}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>[2.0,3.0]</td>
+ *     <td>[4.0,5.0]</td>
+ *     <td>{@link #DISJUNCT}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>[2.0,2.2)</td>
+ *     <td>(2.2,5.0]</td>
+ *     <td>{@link #DISJUNCT}</td>
+ *   </tr>
+ * </table>
+ * For readability, we sorted the {@link VersionRange}s in the examples from the table above but there is no order in the {@link VersionRange}s to be considered.
+ * Further, the last example seems to raise some question: Why is a gap of "(2.2, 2.3)" accepted as {@link #CONNECTED_LOOSELY} while a gap of only exactly "[2.2, 2.2]" is not?
+ * From a strictly mathematical point of view this seems confusing. However, in the last example version "2.2" is considered to be known and is explicitly not included in both ranges.
+ * In contrast, the example for {@link #CONNECTED_LOOSELY} explicitly includes versions "2.2" and "2.3" and if we assume a strict versioning schema, then
+ * "2.3" is the {@link VersionIdentifier#incrementSegment(int, boolean) next version build by incrementing only the last digit}. Even though in math there are infinite numbers in "(2.2, 2.3)" but from a pragmatical view
+ * of a product versioning scheme we could assume that "(2.2, 2.3)" is actually empty.
+ *
+ * @see VersionRange#union(VersionRange, VersionRangeRelation)
+ */
+public enum VersionRangeRelation {
+
+  /** The {@link VersionRange}s are disjunct so there is no value contained in all of them. */
+  DISJUNCT,
+
+  /**
+   * The {@link VersionRange}s are connected loosely so the maximum of the {@link VersionRange#getMin() minimums} is equal to the minimum of the *
+   * {@link VersionRange#getMax() maximums} and that value is {@link VersionRange#contains(VersionIdentifier) contained} in only one of them.
+   */
+  CONNECTED_LOOSELY,
+
+  /**
+   * The {@link VersionRange}s are connected so the maximum of the {@link VersionRange#getMin() minimums} is equal to the minimum of the
+   * {@link VersionRange#getMax() maximums} and that value is {@link VersionRange#contains(VersionIdentifier) contained} in only one of them.
+   */
+  CONNECTED,
+
+  /**
+   * The {@link VersionRange}s overlap so the maximum of the {@link VersionRange#getMin() minimums} is {@link VersionIdentifier#isLessOrEqual less or equal} to
+   * the minimum of the {@link VersionRange#getMax() maximums} and if they are equal that value must be
+   * {@link VersionRange#contains(VersionIdentifier) contained} in the {@link VersionRange}s.
+   */
+  OVERLAPPING;
+
+  /**
+   * @param maxMin the maximum of the {@link VersionRange#getMin() minimums}.
+   * @param maxMinExclusive {@code true} if {@code maxMin} is exclusive, {@code false} otherwise.
+   * @param minMax the minimum of the {@link VersionRange#getMax() maximums}.
+   * @param minMaxExclusive {@code true} if {@code minMax} is exclusive, {@code false} otherwise.
+   * @return the {@link VersionRangeRelation} for the given situation.
+   */
+  static VersionRangeRelation of(VersionIdentifier maxMin, boolean maxMinExclusive, VersionIdentifier minMax, boolean minMaxExclusive) {
+
+    if ((minMax == null) || (maxMin == null)) {
+      // "(,1]" and "(,10)" overlaps also "(1,)" and "(2,)" as well as "(,)" and "(,)" do
+      assert (minMax != null) || minMaxExclusive;
+      assert (maxMin != null) || maxMinExclusive;
+      return OVERLAPPING;
+    }
+    VersionComparisonResult comparison = minMax.compareVersion(maxMin);
+    if (comparison.isGreater()) {
+      return OVERLAPPING; // "[1.0,2.1)" and "(2.0,3.0]" overlap
+    } else if (comparison.isEqual()) {
+      if (!maxMinExclusive && !minMaxExclusive) {
+        return OVERLAPPING;
+      } else if (maxMinExclusive && minMaxExclusive) {
+        return DISJUNCT;
+      } else {
+        return CONNECTED;
+      }
+    } else { // less than
+      VersionIdentifier minMaxNext = minMax.incrementLastDigit(true);
+      if (minMaxNext.isGreaterOrEqual(maxMin)) {
+        return CONNECTED_LOOSELY;
+      }
+    }
+    return DISJUNCT;
+  }
+}

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
@@ -327,28 +327,28 @@ public class VersionSegment implements VersionObject<VersionSegment> {
   /**
    * {@link VersionIdentifier#incrementSegment(int, boolean)}  Increments a version} recursively per {@link VersionSegment}.
    *
-   * @param segmentKeepCount the number of leading {@link VersionSegment}s to keep untouched. Will be {@code 0} for the segment to increment and negative
-   *     for the segments to set to zero.
+   * @param digitKeepCount the number of leading {@link VersionSegment}s with {@link VersionSegment#getDigits() digits} to keep untouched. Will be {@code 0}
+   *     for the segment to increment and negative for the segments to set to zero.
    * @param keepLetters {@code true} to keep {@link VersionSegment#getLetters() letters} from modified segments, {@code false} to drop them.
    * @return the new {@link VersionSegment}.
    */
-  VersionSegment increment(int segmentKeepCount, boolean keepLetters) {
+  VersionSegment increment(int digitKeepCount, boolean keepLetters) {
 
     String separator = this.separator;
     VersionLetters letters = this.letters;
     String digits = this.digits;
     int number = this.number;
     String pattern = this.pattern;
-    int nextSegmentKeepCount = segmentKeepCount;
+    int nextSegmentKeepCount = digitKeepCount;
     if (this.number >= 0) {
       nextSegmentKeepCount--;
     }
-    if ((segmentKeepCount < 0) || ((segmentKeepCount == 0) && (this.number >= 0))) {
+    if ((digitKeepCount < 0) || ((digitKeepCount == 0) && (this.number >= 0))) {
       if (!keepLetters) {
         letters = VersionLetters.EMPTY;
       }
       if (number >= 0) {
-        if (segmentKeepCount == 0) {
+        if (digitKeepCount == 0) {
           number++;
         } else {
           number = 0;
@@ -376,6 +376,21 @@ public class VersionSegment implements VersionObject<VersionSegment> {
       nextSegment = this.next.increment(nextSegmentKeepCount, keepLetters);
     }
     return new VersionSegment(nextSegment, separator, letters, digits, number, pattern);
+  }
+
+  /**
+   * @return the number of {@link VersionSegment}s with {@link VersionSegment#getDigits() digits}.
+   */
+  int countDigits() {
+
+    int count = 0;
+    if (this.number >= 0) {
+      count = 1;
+    }
+    if (this.next != null) {
+      count = count + this.next.countDigits();
+    }
+    return count;
   }
 
   @Override

--- a/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
@@ -284,6 +284,7 @@ public class VersionIdentifierTest extends Assertions {
     assertThat(snapshot_star.matches(VersionIdentifier.of("2025.03.001-SNAPSHOT"))).isFalse();
   }
 
+  /** Test of {@link VersionIdentifier#incrementSegment(int, boolean)} and related methods. */
   @Test
   public void testIncrement() {
 
@@ -306,13 +307,37 @@ public class VersionIdentifierTest extends Assertions {
     assertThat(versionIdentifier.incrementMajor(false)).hasToString("2026.00.000");
     assertThat(versionIdentifier.incrementMinor(false)).hasToString("2025.02.000");
     assertThat(versionIdentifier.incrementPatch(false)).hasToString("2025.01.003");
-
   }
 
-  private static void assertIncrement(String version, int segment, boolean keepLetters, String expectedVersion) {
+  private static void assertIncrement(String version, int digit, boolean keepLetters, String expectedVersion) {
 
     VersionIdentifier identifier = VersionIdentifier.of(version);
-    VersionIdentifier incremented = identifier.incrementSegment(segment, keepLetters);
+    VersionIdentifier incremented =
+        switch (digit) {
+          case 0 -> identifier.incrementMajor(keepLetters);
+          case 1 -> identifier.incrementMinor(keepLetters);
+          case 2 -> identifier.incrementPatch(keepLetters);
+          default -> identifier.incrementSegment(digit, keepLetters);
+        };
+    assertThat(incremented).hasToString(expectedVersion);
+  }
+
+  /** Test of {@link VersionIdentifier#incrementLastDigit(boolean)}. */
+  @Test
+  public void testIncrementLastDigit() {
+
+    assertIncrementLastDigit("1-beta", false, "2");
+    assertIncrementLastDigit("1-beta", true, "2-beta");
+    assertIncrementLastDigit("1.0-beta", false, "1.1");
+    assertIncrementLastDigit("1.0-alpha", true, "1.1-alpha");
+    assertIncrementLastDigit("3.2.1_rc-SNAPSHOT", false, "3.2.2");
+    assertIncrementLastDigit("3.2.1_rc-SNAPSHOT", true, "3.2.2_rc-SNAPSHOT");
+  }
+
+  private static void assertIncrementLastDigit(String version, boolean keepLetters, String expectedVersion) {
+
+    VersionIdentifier identifier = VersionIdentifier.of(version);
+    VersionIdentifier incremented = identifier.incrementLastDigit(keepLetters);
     assertThat(incremented).hasToString(expectedVersion);
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/version/VersionRangeTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/version/VersionRangeTest.java
@@ -181,4 +181,73 @@ public class VersionRangeTest extends Assertions {
       assertThat(e.getMessage()).isEqualTo(range);
     }
   }
+
+  /** Test of {@link VersionRange#union(VersionRange, VersionRangeRelation)}. */
+  @Test
+  public void testUnion() {
+
+    VersionRange union = VersionRange.of("[2.0,5.0]");
+    assertThat(union("[2.0,5.0)", "(3.0,5.0]")).isEqualTo(union);
+    assertThat(union("[2.0,3.0]", "[3.0,5.0]")).isEqualTo(union);
+    assertThat(union("[2.0,3.0)", "[3.0,5.0]")).isEqualTo(union);
+    assertThat(union("[2.0,3.0)", "[3.0,5.0]", VersionRangeRelation.OVERLAPPING)).isNull();
+    assertThat(union("[2.0,3.0]", "(3.0,5.0]")).isEqualTo(union);
+    assertThat(union("[2.0,3.0]", "(3.0,5.0]", VersionRangeRelation.CONNECTED)).isEqualTo(union);
+    assertThat(union("[2.0,2.2]", "[2.3,5.0]")).isNull();
+    assertThat(union("[2.0,2.2]", "[2.3,5.0]", VersionRangeRelation.CONNECTED_LOOSELY)).isEqualTo(union);
+    assertThat(union("[2.0,3.0]", "[4.0,5.0]", VersionRangeRelation.CONNECTED_LOOSELY)).isNull();
+    assertThat(union("[2.0,3.0]", "[4.0,5.0]", VersionRangeRelation.DISJUNCT)).isEqualTo(union);
+    assertThat(union("[2.0,2.2)", "(2.2,5.0]", VersionRangeRelation.CONNECTED_LOOSELY)).isNull();
+    assertThat(union("[2.0,2.2)", "(2.2,5.0]", VersionRangeRelation.DISJUNCT)).isEqualTo(union);
+    assertThat(union("(,)", "[1.0,1.0]")).isSameAs(VersionRange.UNBOUNDED);
+    assertThat(union("(,1.0)", "[1.0,1.0]")).isEqualTo(VersionRange.of("(,1.0]"));
+    assertThat(union("(1.0,)", "[1.0,1.0]")).isEqualTo(VersionRange.of("[1.0,)"));
+    assertThat(union("(,2.0]", "[1.0,2.0)")).isEqualTo(VersionRange.of("(,2.0]"));
+    assertThat(union("[2.0,)", "(2.0,3.0]")).isEqualTo(VersionRange.of("[2.0,)"));
+  }
+
+  private VersionRange union(String range1, String range2) {
+
+    return union(range1, range2, null);
+  }
+
+  private VersionRange union(String range1, String range2, VersionRangeRelation minRelation) {
+
+    VersionRange r1 = VersionRange.of(range1);
+    VersionRange r2 = VersionRange.of(range2);
+    VersionRange union;
+    VersionRange reverseUnion;
+    if (minRelation == null) {
+      union = r1.union(r2);
+      reverseUnion = r2.union(r1);
+    } else {
+      union = r1.union(r2, minRelation);
+      reverseUnion = r2.union(r1, minRelation);
+    }
+    assertThat(union).as("Union of " + range1 + " and " + range2 + " is symmetric").isEqualTo(reverseUnion);
+    return union;
+  }
+
+
+  /** Test of {@link VersionRange#intersect(VersionRange)}. */
+  @Test
+  public void testIntersection() {
+
+    assertThat(intersection("(,)", "[1.0,5.0]")).isEqualTo(VersionRange.of("[1.0,5.0]"));
+    assertThat(intersection("(2.0,5.0]", "[2.0,5.0)")).isEqualTo(VersionRange.of("(2.0,5.0)"));
+    assertThat(intersection("[2.0,5.0)", "(2.0,5.0]")).isEqualTo(VersionRange.of("(2.0,5.0)"));
+    assertThat(intersection("(2.0,4.0]", "[3.0,5.0]")).isEqualTo(VersionRange.of("[3.0,4.0]"));
+    assertThat(intersection("(2.0,3.0]", "[3.0,5.0]")).isEqualTo(VersionRange.of("[3.0,3.0]"));
+    assertThat(intersection("(2.0,3.0)", "[3.0,5.0]")).isNull();
+  }
+
+  private VersionRange intersection(String range1, String range2) {
+    VersionRange r1 = VersionRange.of(range1);
+    VersionRange r2 = VersionRange.of(range2);
+    VersionRange intersection = r1.intersect(r2);
+    VersionRange reverseIntersection = r2.intersect(r1);
+    assertThat(intersection).as("Intersection of " + range1 + " and " + range2 + " is symmetric").isEqualTo(reverseIntersection);
+    return intersection;
+  }
+
 }


### PR DESCRIPTION
### This PR adds new version related features

### Implemented changes:

* added `VersionIdentifier.incrementLastDigit` method.
* added null-safe `VersionIdentifier.compareVersion` method.
* added `VersionRangeRelation` and `VersionRangeCombination`.
* added `union` and `intersection` method to `VersionRange` based on the two new classes above.
* added/extended tests to cover new functionality.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`