### PR TITLE
#1621: fix build security.json

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/file/UrlSecurityFile.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/file/UrlSecurityFile.java
@@ -2,7 +2,7 @@ package com.devonfw.tools.ide.url.model.file;
 
 import java.io.BufferedWriter;
 import java.nio.file.Files;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -89,10 +89,8 @@ public class UrlSecurityFile extends AbstractUrlFile<AbstractUrlToolOrEdition<?,
     if (this.security == null || this.security == ToolSecurity.getEmpty()) {
       this.security = new ToolSecurity();
     }
-
-    List<Cve> issues = this.security.getIssues();
-    if (!issues.contains(cve)) {
-      issues.add(cve);
+    boolean securityModified = this.security.addIssue(cve);
+    if (securityModified) {
       this.modified = true;
     }
   }
@@ -103,7 +101,7 @@ public class UrlSecurityFile extends AbstractUrlFile<AbstractUrlToolOrEdition<?,
    */
   public void clearSecurityWarnings() {
     if (this.security != null) {
-      this.security.setIssues(new ArrayList<>()); // avoid error on immutable list
+      this.security.clearIssues();
       this.modified = true;
     }
   }
@@ -128,7 +126,7 @@ public class UrlSecurityFile extends AbstractUrlFile<AbstractUrlToolOrEdition<?,
           edition.getName(), edition.getName(), null);
     }
 
-    List<Cve> issues = this.security != null ? this.security.getIssues() : List.of();
+    Collection<Cve> issues = this.security != null ? this.security.getIssues() : List.of();
 
     for (Cve cve : issues) {
       for (VersionRange versionRange : cve.versions()) {

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/Cve.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/Cve.java
@@ -1,17 +1,22 @@
 package com.devonfw.tools.ide.url.model.file.json;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
+import com.devonfw.tools.ide.version.VersionIdentifier;
 import com.devonfw.tools.ide.version.VersionRange;
+import com.devonfw.tools.ide.version.VersionRangeRelation;
 
 /**
  * Model to represent a CVE (common vulnerabilities and exposures) of a tool.
  *
  * @param id the unique identifier (e.g. "CVE-2021-44228").
  * @param severity the severity in the range from (0,10.0] where 10.0 is most critical.
- * @param versions the {@link VersionRange}s of the affected versions. Typically one entry but might also affect multiple ranges (e.g. "[1.0,1.2)" and
- *     "[2.0,2.2)"). Should never be {@code null} or {@link List#isEmpty() empty}.
+ * @param versions the {@link VersionRange}s of the affected versions. Typically one entry but might also affect multiple ranges. E.g. "[1.0,1.2)" and
+ *     "[2.0,2.2)". Should never be {@code null} or {@link List#isEmpty() empty}.
  * @see ToolSecurity
  */
 public record Cve(String id, double severity, List<VersionRange> versions) {
@@ -21,6 +26,12 @@ public record Cve(String id, double severity, List<VersionRange> versions) {
   static final String PROPERTY_SEVERITY = "severity";
 
   static final String PROPERTY_VERSIONS = "versions";
+
+  public Cve {
+    Objects.requireNonNull(id);
+    Objects.requireNonNull(versions);
+    assert !versions.isEmpty();
+  }
 
   /**
    * @param cves the {@link Cve}s to summarize.
@@ -32,5 +43,48 @@ public record Cve(String id, double severity, List<VersionRange> versions) {
       severitySum += cve.severity();
     }
     return severitySum;
+  }
+
+  /**
+   * @param issue the {@link Cve} to merge with. Has to have the same {@link #id()} and {@link #severity()}.
+   * @return the merged {@link Cve}.
+   */
+  public Cve merge(Cve issue) {
+
+    if (!this.id.equals(issue.id)) {
+      throw new IllegalArgumentException(this.id + " != " + issue.id);
+    }
+    if (this.severity != issue.severity) {
+      throw new IllegalArgumentException(this.severity + " != " + issue.severity + " - cannot merge " + this.id);
+    }
+    List<VersionRange> newVersions = new ArrayList<>(this.versions);
+    for (VersionRange versionRange : issue.versions) {
+      mergeVersionRage(newVersions, versionRange);
+    }
+    return new Cve(this.id, this.severity, newVersions);
+  }
+
+  private static void mergeVersionRage(List<VersionRange> newVersions, VersionRange versionRange) {
+
+    if (newVersions.isEmpty()) {
+      newVersions.add(versionRange);
+      return;
+    }
+    VersionIdentifier min = versionRange.getMin();
+    int insertIndex = 0;
+    boolean removed = false;
+    VersionRange current = versionRange;
+    Iterator<VersionRange> versionIterator = newVersions.iterator();
+    while (versionIterator.hasNext()) {
+      VersionRange range = versionIterator.next();
+      VersionRange merged = range.union(current, VersionRangeRelation.CONNECTED_LOOSELY);
+      if (merged != null) {
+        current = merged;
+        versionIterator.remove();
+      } else if (!removed && (min != null) && min.isGreater(range.getMin())) {
+        insertIndex++;
+      }
+    }
+    newVersions.add(insertIndex, current);
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/ToolSecurity.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/ToolSecurity.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Predicate;
 
 import com.devonfw.tools.ide.json.JsonMapping;
@@ -27,46 +29,74 @@ public class ToolSecurity {
 
   private static final ObjectMapper MAPPER = JsonMapping.create();
 
-  private static final ToolSecurity EMPTY = new ToolSecurity(Collections.emptyList());
+  private static final ToolSecurity EMPTY = new ToolSecurity(Map.of());
 
-  private List<Cve> issues;
+  private final Map<String, Cve> cveMap;
+
+  private final Collection<Cve> issues;
 
   /**
    * The constructor.
    */
   public ToolSecurity() {
-    this(new ArrayList<>());
+    this(new TreeMap<>());
   }
 
-  /**
-   * The constructor.
-   *
-   * @param issues the {@link List} of {@link Cve CVE}s.
-   */
-  public ToolSecurity(List<Cve> issues) {
-
+  private ToolSecurity(Map<String, Cve> cveMap) {
     super();
-    this.issues = issues;
+    this.cveMap = cveMap;
+    this.issues = Collections.unmodifiableCollection(this.cveMap.values());
   }
 
   /**
-   * @return the list of CVEs
+   * @return the {@link Collection} of {@link Cve}s.
    */
-  public List<Cve> getIssues() {
-    return issues;
+  public Collection<Cve> getIssues() {
+    return this.issues;
   }
 
   /**
    * @param issues the list of CVEs
    */
   public void setIssues(List<Cve> issues) {
-    this.issues = issues;
+
+    this.cveMap.clear();
+    for (Cve issue : issues) {
+      addIssue(issue);
+    }
+  }
+
+  /**
+   * @param issue the {@link Cve} to add.
+   * @return {@code true} if this {@link ToolSecurity} was modified (issue added or merged), {@code false} otherwise ({@link Cve} was already contained).
+   */
+  public boolean addIssue(Cve issue) {
+
+    Cve newIssue = issue;
+    String id = issue.id();
+    Cve existingIssue = this.cveMap.get(id);
+    if (existingIssue != null) {
+      newIssue = existingIssue.merge(issue);
+      if (newIssue.equals(existingIssue)) {
+        return false;
+      }
+    }
+    this.cveMap.put(id, newIssue);
+    return true;
+  }
+
+  /**
+   * Clears all issues.
+   */
+  public void clearIssues() {
+    this.cveMap.clear();
   }
 
   /**
    * Finds all {@link Cve}s for the given {@link VersionIdentifier} that also match the given {@link Predicate}.
    *
    * @param version the {@link VersionIdentifier} to check.
+   * @param logger the {@link IdeLogger}.
    * @param predicate the {@link Predicate} deciding which matching {@link Cve}s are {@link Predicate#test(Object) accepted}.
    * @return all {@link Cve}s for the given {@link VersionIdentifier}.
    */
@@ -90,6 +120,7 @@ public class ToolSecurity {
    * Finds all {@link Cve}s for the given {@link VersionIdentifier} and {@code minSeverity}.
    *
    * @param version the {@link VersionIdentifier} to check.
+   * @param logger the {@link IdeLogger}.
    * @param minSeverity the {@link IdeVariables#CVE_MIN_SEVERITY minimum severity}.
    * @return all {@link Cve}s for the given {@link VersionIdentifier}.
    */

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/ToolSecurityJsonDeserializer.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/file/json/ToolSecurityJsonDeserializer.java
@@ -2,7 +2,6 @@ package com.devonfw.tools.ide.url.model.file.json;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import com.devonfw.tools.ide.json.JsonMapping;
@@ -38,7 +37,9 @@ public class ToolSecurityJsonDeserializer extends JsonDeserializer<ToolSecurity>
         token = p.nextToken();
       }
       assert (issues != null);
-      return new ToolSecurity(Collections.unmodifiableList(issues));
+      ToolSecurity security = new ToolSecurity();
+      security.setIssues(issues);
+      return security;
     } else if (token == JsonToken.VALUE_NULL) {
       return null;
     } else {

--- a/cli/src/main/java/com/devonfw/tools/ide/url/model/folder/AbstractUrlFolder.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/url/model/folder/AbstractUrlFolder.java
@@ -139,6 +139,7 @@ public abstract class AbstractUrlFolder<C extends UrlArtifactWithParent<?>> exte
   public void load(boolean recursive) {
 
     if (!this.loaded) {
+      LOG.trace("Loading url folder {}", this);
       Path path = getPath();
       if (Files.isDirectory(path)) {
         try (Stream<Path> childStream = Files.list(path)) {

--- a/cli/src/test/java/com/devonfw/tools/ide/url/model/file/json/CveTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/url/model/file/json/CveTest.java
@@ -1,0 +1,34 @@
+package com.devonfw.tools.ide.url.model.file.json;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.devonfw.tools.ide.version.VersionRange;
+
+/**
+ * Test of {@link Cve}.
+ */
+public class CveTest extends Assertions {
+
+  @Test
+  public void testMerge() {
+
+    // arrange
+    Cve cve1 = new Cve("CVE-2012-0845", 5.0,
+        List.of(VersionRange.of("[2.0.0,2.0.1]"), VersionRange.of("[2.1.0,2.1.3]"), VersionRange.of("[2.2.0,2.2.3]"), VersionRange.of("[2.3.0,2.3.4]"),
+            VersionRange.of("[2.8.0,2.8.1]")));
+    Cve cve2 = new Cve("CVE-2012-0845", 5.0,
+        List.of(VersionRange.of("(,2.6.7]"), VersionRange.of("[2.0.2,2.0.2]"), VersionRange.of("[2.6.8,2.6.9]"), VersionRange.of("[2.8.2,2.8.3]")));
+
+    // act
+    Cve merged = cve1.merge(cve2);
+
+    // assert
+    assertThat(merged.id()).isEqualTo("CVE-2012-0845");
+    assertThat(merged.severity()).isEqualTo(5.0);
+    assertThat(merged.versions()).containsExactly(VersionRange.of("(,2.6.9]"), VersionRange.of("[2.8.0,2.8.3]"));
+  }
+
+}

--- a/security/src/main/java/com/devonfw/tools/IDEasy/dev/BuildSecurityJsonFiles.java
+++ b/security/src/main/java/com/devonfw/tools/IDEasy/dev/BuildSecurityJsonFiles.java
@@ -51,7 +51,6 @@ import com.devonfw.tools.ide.log.IdeLogLevel;
 import com.devonfw.tools.ide.url.model.UrlMetadata;
 import com.devonfw.tools.ide.url.model.file.UrlSecurityFile;
 import com.devonfw.tools.ide.url.model.file.json.Cve;
-import com.devonfw.tools.ide.url.model.folder.UrlRepository;
 import com.devonfw.tools.ide.url.model.folder.UrlVersion;
 import com.devonfw.tools.ide.url.model.report.UrlFinalReport;
 import com.devonfw.tools.ide.url.updater.AbstractUrlUpdater;
@@ -86,8 +85,6 @@ public class BuildSecurityJsonFiles implements Runnable {
 
   private final Path urlsPath;
 
-  private final UrlRepository urlRepository;
-
   private final UrlMetadata urlMetadata;
 
   private final UpdateManager updateManager;
@@ -96,10 +93,10 @@ public class BuildSecurityJsonFiles implements Runnable {
 
     super();
     this.urlsPath = urlsPath;
-    this.urlRepository = UrlRepository.load(urlsPath);
-    this.urlMetadata = new UrlMetadata(new IdeContextConsole(IdeLogLevel.INFO, null, false));
     UrlFinalReport report = new UrlFinalReport();
     this.updateManager = new UpdateManager(urlsPath, report, Instant.now());
+    IdeContextConsole context = new IdeContextConsole(IdeLogLevel.INFO, null, false);
+    this.urlMetadata = new UrlMetadata(context, this.updateManager.getUrlRepository());
   }
 
   @Override

--- a/security/src/main/java/com/devonfw/tools/IDEasy/dev/UrlAnalyzer.java
+++ b/security/src/main/java/com/devonfw/tools/IDEasy/dev/UrlAnalyzer.java
@@ -67,7 +67,7 @@ public class UrlAnalyzer extends AbstractFileTypeAnalyzer {
     evidence = new Evidence(ANALYZER_NAME, "CpeProduct", cpeProduct, Confidence.HIGH);
     dependency.addEvidence(EvidenceType.PRODUCT, evidence);
 
-    if (cpeEdition.isBlank()) {
+    if (!cpeEdition.isBlank()) {
 
       evidence = new Evidence(ANALYZER_NAME, "CpeEdition", cpeEdition, Confidence.HIGH);
       dependency.addEvidence(EvidenceType.PRODUCT, evidence);

--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/UpdateManager.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/updater/UpdateManager.java
@@ -85,7 +85,8 @@ public class UpdateManager extends AbstractProcessorWithTimeout {
    */
   public UpdateManager(Path pathToRepository, UrlFinalReport urlFinalReport, Instant expirationTime) {
 
-    this.urlRepository = UrlRepository.load(pathToRepository);
+    this.urlRepository = new UrlRepository(pathToRepository);
+    this.urlRepository.load(false);
     this.urlFinalReport = urlFinalReport;
     setExpirationTime(expirationTime);
   }


### PR DESCRIPTION
### This PR fixes #1621

### Implemented changes:

* avoid duplicate CVE ID entries by using Map
* use TreeMap to get deterministic/sorted CVEs and reduce diffs
* merge version-ranges of CVEs (the tricky part)
* prevent eager loading of `UrlRepository`
* prevent multiple redundant creations of `UrlRepository`
* fixed CPE edition bug
* added test

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`