### PR TITLE
#1633: fix CVE check to only suggest unstable versions if requested version was unstable

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionIdentifier.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionIdentifier.java
@@ -133,6 +133,16 @@ public final class VersionIdentifier implements VersionObject<VersionIdentifier>
     return false;
   }
 
+
+  /**
+   * @return {@code true} if this is a stable version, {@code false} otherwise.
+   * @see VersionLetters#isStable()
+   */
+  public boolean isStable() {
+
+    return this.developmentPhase.isStable();
+  }
+
   /**
    * @return the {@link VersionLetters#isDevelopmentPhase() development phase} of this {@link VersionIdentifier}. Will be {@link VersionLetters#EMPTY} if no
    *     development phase is specified in any {@link VersionSegment} and will be {@link VersionLetters#UNDEFINED} if more than one

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionLetters.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionLetters.java
@@ -13,6 +13,9 @@ public final class VersionLetters implements AbstractVersionPhase, VersionObject
   /** The empty {@link VersionLetters} instance. */
   public static final VersionLetters EMPTY = new VersionLetters("");
 
+  /** The unstable {@link VersionLetters} instance - see {@link VersionSegment#PATTERN_MATCH_ANY_VERSION}. */
+  public static final VersionLetters UNSTABLE = new VersionLetters(VersionPhase.UNSTABLE);
+
   /** The undefined {@link VersionLetters} instance. */
   public static final VersionLetters UNDEFINED = new VersionLetters("undefined");
 
@@ -48,14 +51,23 @@ public final class VersionLetters implements AbstractVersionPhase, VersionObject
     this.phase = VersionPhase.of(phaseLetters);
   }
 
+  private VersionLetters(VersionPhase phase) {
+
+    super();
+    this.letters = "";
+    this.lettersLowerCase = "";
+    this.prePhase = false;
+    this.phase = phase;
+  }
+
   /**
    * @return the letters or the empty {@link String} ("") for none. In canonical {@link VersionIdentifier}s letters indicate the development phase (e.g. "pre",
-   * "rc", "alpha", "beta", "milestone", "test", "dev", "SNAPSHOT", etc.). However, letters are technically any
-   * {@link Character#isLetter(char) letter characters} and may also be something like a code-name (e.g. "Cupcake", "Donut", "Eclair", "Froyo", "Gingerbread",
-   * "Honeycomb", "Ice Cream Sandwich", "Jelly Bean" in case of Android internals). Please note that in such case it is impossible to properly decide which
-   * version is greater than another versions. To avoid mistakes, the comparison supports a strict mode that will let the comparison fail in such case. However,
-   * by default (e.g. for {@link Comparable#compareTo(Object)}) the default {@link String#compareTo(String) string comparison} (lexicographical) is used to
-   * ensure a natural order.
+   *     "rc", "alpha", "beta", "milestone", "test", "dev", "SNAPSHOT", etc.). However, letters are technically any
+   *     {@link Character#isLetter(char) letter characters} and may also be something like a code-name (e.g. "Cupcake", "Donut", "Eclair", "Froyo",
+   *     "Gingerbread", "Honeycomb", "Ice Cream Sandwich", "Jelly Bean" in case of Android internals). Please note that in such case it is impossible to
+   *     properly decide which version is greater than another versions. To avoid mistakes, the comparison supports a strict mode that will let the comparison
+   *     fail in such case. However, by default (e.g. for {@link Comparable#compareTo(Object)}) the default {@link String#compareTo(String) string comparison}
+   *     (lexicographical) is used to ensure a natural order.
    * @see #getPhase()
    */
   public String getLetters() {
@@ -75,7 +87,7 @@ public final class VersionLetters implements AbstractVersionPhase, VersionObject
 
   /**
    * @return {@code true} if the {@link #getLetters() letters} and a potential {@link #getPhase() phase} are prefixed with "pre" (e.g. in "pre-alpha"),
-   * {@code false} otherwise.
+   *     {@code false} otherwise.
    */
   public boolean isPrePhase() {
 

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionPhase.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionPhase.java
@@ -11,6 +11,9 @@ public enum VersionPhase implements AbstractVersionPhase {
   /** A revision number (actually not a development phase like {@link #UNDEFINED}). */
   REVISION(Boolean.TRUE, "revision", "rev"),
 
+  /** Unstable marker - see {@link VersionSegment#PATTERN_MATCH_ANY_VERSION}. */
+  UNSTABLE(Boolean.FALSE, "!"),
+
   /** A snapshot version from development (e.g. "-SNAPSHOT" suffix in maven). */
   SNAPSHOT(Boolean.FALSE, "beta-snapshot", "snapshot", "dev"),
 

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionSegment.java
@@ -51,9 +51,14 @@ public class VersionSegment implements VersionObject<VersionSegment> {
 
     super();
     this.separator = separator;
-    this.letters = VersionLetters.of(letters);
-    if (!pattern.isEmpty() && !PATTERN_MATCH_ANY_STABLE_VERSION.equals(pattern)
-        && !PATTERN_MATCH_ANY_VERSION.equals(pattern)) {
+    boolean isAnyPattern = PATTERN_MATCH_ANY_VERSION.equals(pattern);
+    if (isAnyPattern && letters.isEmpty()) {
+      this.letters = VersionLetters.UNSTABLE;
+    } else {
+      this.letters = VersionLetters.of(letters);
+    }
+    if (!pattern.isEmpty() && !isAnyPattern
+        && !PATTERN_MATCH_ANY_STABLE_VERSION.equals(pattern)) {
       throw new IllegalArgumentException("Invalid pattern: " + pattern);
     }
     this.pattern = pattern;

--- a/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
@@ -341,4 +341,15 @@ public class VersionIdentifierTest extends Assertions {
     assertThat(incremented).hasToString(expectedVersion);
   }
 
+  /** Test of {@link VersionIdentifier#isStable()}. */
+  @Test
+  public void testIsStable() {
+
+    assertThat(VersionIdentifier.of("2025.01.002").isStable()).isTrue();
+    assertThat(VersionIdentifier.of("1.0-rc1").isStable()).isFalse();
+    assertThat(VersionIdentifier.of("1.0-alpha1.rc2").isStable()).isFalse();
+    assertThat(VersionIdentifier.LATEST.isStable()).isTrue();
+    assertThat(VersionIdentifier.LATEST_UNSTABLE.isStable()).isFalse();
+  }
+
 }


### PR DESCRIPTION
### This PR fixes #1633

### Implemented changes:

* change `ToolCommandlet.cveCheck` to ignore unstable versions for suggestions if the requested version was stable
* added `VersionIdentifier.isStable()`
* changed `VersionSegment` to be unstable for `*!`
* extended JUnit

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`