### PR TITLE
#39: refactoring to extract package-manager logic out of node/npm

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessResult.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessResult.java
@@ -68,18 +68,24 @@ public interface ProcessResult {
   }
 
   /**
-   * @param logger the {@link IdeSubLogger logger} to use.
    * @return the first captured standard out. Will be {@code null} if not captured but redirected.
-   * @throws IllegalStateException if more than one output was captured and the {@link IdeSubLogger logger} was null.
    */
-  String getSingleOutput(IdeSubLogger logger) throws IllegalStateException;
+  default String getSingleOutput() {
+
+    return getSingleOutput(null);
+  }
 
   /**
    * @param logger the {@link IdeSubLogger logger} to use.
    * @return the first captured standard out. Will be {@code null} if not captured but redirected.
-   * @throws IllegalStateException if the {@link IdeSubLogger logger} was null.
    */
-  List<String> getOutput(IdeSubLogger logger) throws IllegalStateException;
+  String getSingleOutput(IdeSubLogger logger);
+
+  /**
+   * @param logger the {@link IdeSubLogger logger} to use.
+   * @return the first captured standard out. Will be {@code null} if not captured but redirected.
+   */
+  List<String> getOutput(IdeSubLogger logger);
 
   /**
    * @return the {@link List} with the lines captured on standard out. Will be {@code null} if not captured but redirected.

--- a/cli/src/main/java/com/devonfw/tools/ide/security/ToolVulnerabilities.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/security/ToolVulnerabilities.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.devonfw.tools.ide.tool.ToolEditionAndVersion;
 import com.devonfw.tools.ide.url.model.file.json.Cve;
+import com.devonfw.tools.ide.version.GenericVersionRange;
 
 /**
  * Container for {@link #getIssues() vulnerabilities} with internal scoring.
@@ -109,7 +110,11 @@ public class ToolVulnerabilities implements Comparable<ToolVulnerabilities> {
       separator = ':';
     }
     if (toolEditionAndVersion != null) {
-      sb.append(" for version ").append(toolEditionAndVersion.getVersion()).append(" of tool ").append(toolEditionAndVersion.getEdition());
+      GenericVersionRange version = toolEditionAndVersion.getResolvedVersion();
+      if (version == null) {
+        version = toolEditionAndVersion.getVersion();
+      }
+      sb.append(" for version ").append(version).append(" of tool ").append(toolEditionAndVersion.getEdition());
     }
     sb.append(separator);
     for (Cve issue : issues) {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
@@ -56,7 +56,7 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
   protected boolean runWithPackageManager(boolean silent, List<PackageManagerCommand> pmCommands) {
 
     for (PackageManagerCommand pmCommand : pmCommands) {
-      PackageManager packageManager = pmCommand.packageManager();
+      NativePackageManager packageManager = pmCommand.packageManager();
       Path packageManagerPath = this.context.getPath().findBinary(Path.of(packageManager.getBinaryName()));
       if (packageManagerPath == null || !Files.exists(packageManagerPath)) {
         this.context.debug("{} is not installed", packageManager.toString());

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/NativePackageManager.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/NativePackageManager.java
@@ -1,10 +1,20 @@
 package com.devonfw.tools.ide.tool;
 
 /**
- * Represents a package manager used for managing software packages.
+ * Represents an OS native package manager used for managing software packages.
  */
-public enum PackageManager {
-  APT, ZYPPER, YUM, DNF;
+public enum NativePackageManager {
+  /** Advanced Package Tool (APT) is the package manager of Debian based Linux distributions. */
+  APT,
+
+  /** Zypper is the package manager of SUSE based Linux distributions. */
+  ZYPPER,
+
+  /** Yellowdog Updater Modified (YUM) is the package manager of RPM package based Linux distributions like Fedora, Red Hat, or CentOS. */
+  YUM,
+
+  /** DaNdiFied yum (DNF) is the package manager of RPM package based Linux distributions like Fedora. It is the successor of {@link #YUM}. */
+  DNF;
 
   /**
    * Extracts the package manager from the provided command string.
@@ -13,7 +23,7 @@ public enum PackageManager {
    * @return The corresponding {@code PackageManager} based on the provided command string.
    * @throws IllegalArgumentException If the command string does not contain a recognized package manager.
    */
-  public static PackageManager extractPackageManager(String command) {
+  public static NativePackageManager extractPackageManager(String command) {
 
     if (command.contains("apt")) {
       return APT;

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/PackageManagerBasedLocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/PackageManagerBasedLocalToolCommandlet.java
@@ -1,0 +1,200 @@
+package com.devonfw.tools.ide.tool;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import com.devonfw.tools.ide.cache.CachedValue;
+import com.devonfw.tools.ide.common.Tag;
+import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.process.ProcessContext;
+import com.devonfw.tools.ide.process.ProcessErrorHandling;
+import com.devonfw.tools.ide.process.ProcessMode;
+import com.devonfw.tools.ide.process.ProcessResult;
+import com.devonfw.tools.ide.version.VersionIdentifier;
+
+/**
+ * {@link LocalToolCommandlet} for tools that have their own {@link #getToolRepository() repository} and do not follow standard installation mechanism.
+ *
+ * @param <P> type of the {@link ToolCommandlet} acting as {@link #getPackageManagerClass() package manager}.
+ */
+public abstract class PackageManagerBasedLocalToolCommandlet<P extends ToolCommandlet> extends LocalToolCommandlet {
+
+  private final CachedValue<VersionIdentifier> installedVersion;
+
+  /**
+   * The constructor.
+   *
+   * @param context the {@link IdeContext}.
+   * @param tool the {@link #getName() tool name}.
+   * @param tags the {@link #getTags() tags} classifying the tool. Should be created via {@link Set#of(Object) Set.of} method.
+   */
+  public PackageManagerBasedLocalToolCommandlet(IdeContext context, String tool, Set<Tag> tags) {
+
+    super(context, tool, tags);
+    this.installedVersion = new CachedValue<>(this::determineInstalledVersion);
+  }
+
+  @Override
+  protected boolean isIgnoreSoftwareRepo() {
+
+    // python/pip and node/npm/yarn are messy - see https://github.com/devonfw/IDEasy/issues/352
+    return true;
+  }
+
+  protected abstract Class<P> getPackageManagerClass();
+
+  /**
+   * @return the package name of this tool in the underlying repository (e.g. MVN repo, NPM registry, PyPI). Typically, this is the same as the
+   *     {@link #getName() tool name} but may be overridden in some special cases.
+   */
+  public String getPackageName() {
+
+    return this.tool;
+  }
+
+  /**
+   * @param request the {@link PackageManagerRequest}.
+   * @return the {@link ProcessResult}.
+   */
+  public ProcessResult runPackageManager(PackageManagerRequest request) {
+    return runPackageManager(request, false);
+  }
+
+  /**
+   * @param request the {@link PackageManagerRequest}.
+   * @param skipInstallation {@code true} if the caller can guarantee that this package manager tool is already installed, {@code false} otherwise (run
+   *     install method again to ensure the tool is installed).
+   * @return the {@link ProcessResult}.
+   */
+  public ProcessResult runPackageManager(PackageManagerRequest request, boolean skipInstallation) {
+
+    completeRequest(request);
+    ProcessContext pc = request.getProcessContext();
+    ToolCommandlet pm = request.getPackageManager();
+    if (skipInstallation) { // See Node.postInstallOnNewInstallation
+      return pm.runTool(pc, request.getProcessMode(), request.getArgs());
+    } else {
+      ToolInstallRequest installRequest = new ToolInstallRequest(true);
+      installRequest.setProcessContext(pc);
+      return pm.runTool(installRequest, request.getProcessMode(), request.getArgs());
+    }
+  }
+
+  protected void completeRequest(PackageManagerRequest request) {
+
+    if (request.getProcessContext() == null) {
+      request.setProcessContext(this.context.newProcess().errorHandling(ProcessErrorHandling.THROW_CLI));
+    }
+    if (request.getPackageManager() == null) {
+      request.setPackageManager(this.context.getCommandletManager().getCommandlet(getPackageManagerClass()));
+    }
+    if (request.getProcessMode() == null) {
+      request.setProcessMode(ProcessMode.DEFAULT);
+    }
+    if (request.getArgs().isEmpty()) {
+      completeRequestArgs(request);
+    }
+  }
+
+  /**
+   * @param request the {@link PackageManagerRequest} with currently {@link List#isEmpty() empty} {@link PackageManagerRequest#getArgs() args}.
+   */
+  protected void completeRequestArgs(PackageManagerRequest request) {
+
+    String toolWithVersion = request.getTool();
+    VersionIdentifier version = request.getVersion();
+    if (version != null) {
+      toolWithVersion = appendVersion(toolWithVersion, version);
+    }
+    request.addArg(request.getType());
+    String option = completeRequestOption(request);
+    if (option != null) {
+      request.addArg(option);
+    }
+    request.addArg(toolWithVersion);
+  }
+
+  /**
+   * @param request the {@link PackageManagerRequest}.
+   * @return the option to {@link PackageManagerRequest#addArg(String) add as argument} to the package manager sub-command (e.g. "-gf") or {@code null} for no
+   *     option.
+   */
+  protected String completeRequestOption(PackageManagerRequest request) {
+    return null;
+  }
+
+  /**
+   * @param tool the {@link PackageManagerRequest#getTool() tool} to manage (e.g. install).
+   * @param version the {@link PackageManagerRequest#getVersion() version} to append.
+   * @return the combination of {@code tool} and {@code version} in the syntax of the package manager.
+   */
+  protected String appendVersion(String tool, VersionIdentifier version) {
+    return tool + '@' + version;
+  }
+
+  @Override
+  protected boolean isIgnoreMissingSoftwareVersionFile() {
+
+    return true;
+  }
+
+  private VersionIdentifier determineInstalledVersion() {
+
+    try {
+      return computeInstalledVersion();
+    } catch (Exception e) {
+      this.context.debug().log(e, "Failed to compute installed version of {}", this.tool);
+      return null;
+    }
+  }
+
+  /**
+   * @return the computed value of the {@link #getInstalledVersion() installed version}.
+   */
+  protected abstract VersionIdentifier computeInstalledVersion();
+
+  @Override
+  public VersionIdentifier getInstalledVersion() {
+
+    return this.installedVersion.get();
+  }
+
+  @Override
+  protected final void performToolInstallation(ToolInstallRequest request, Path installationPath) {
+
+    PackageManagerRequest packageManagerRequest = new PackageManagerRequest(PackageManagerRequest.TYPE_INSTALL, getPackageName())
+        .setProcessContext(request.getProcessContext()).setVersion(request.getRequested().getResolvedVersion());
+    runPackageManager(packageManagerRequest, true).failOnError();
+    this.installedVersion.invalidate();
+  }
+
+  /**
+   * @return {@code true} if the tool can be uninstalled, {@code false} if not.
+   */
+  protected boolean canBeUninstalled() {
+    return true;
+  }
+
+  @Override
+  protected final void performUninstall(Path toolPath) {
+    if (canBeUninstalled()) {
+      PackageManagerRequest request = new PackageManagerRequest(PackageManagerRequest.TYPE_UNINSTALL, getPackageName());
+      runPackageManager(request).failOnError();
+      this.installedVersion.invalidate();
+    } else {
+      this.context.info("IDEasy does not support uninstalling the tool {} since this will break your installation.\n"
+          + "If you really want to uninstall it, please uninstall its parent tool via:\n"
+          + "ide uninstall {}", this.tool, getParentTool().getName());
+    }
+  }
+
+  protected abstract LocalToolCommandlet getParentTool();
+
+  @Override
+  public Path getToolPath() {
+
+    return getParentTool().getToolPath();
+  }
+
+}

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/PackageManagerCommand.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/PackageManagerCommand.java
@@ -3,24 +3,24 @@ package com.devonfw.tools.ide.tool;
 import java.util.List;
 
 /**
- * Represents a command to be executed by a package manager. Each command consists of a {@link PackageManager} and a list of commands to be executed by that
- * package manager.
+ * Represents a command to be executed by a package manager. Each command consists of a {@link NativePackageManager} and a list of commands to be executed by
+ * that package manager.
  *
  * @param packageManager The package manager associated with this command.
  * @param commands The list of commands to be executed by the package manager.
  */
-public record PackageManagerCommand(PackageManager packageManager, List<String> commands) {
+public record PackageManagerCommand(NativePackageManager packageManager, List<String> commands) {
 
   /**
    * Constructs a {@code PackageManagerCommand} based on the provided command string. The package manager is retrieved from the command string using
-   * {@link PackageManager#extractPackageManager(String)}.
+   * {@link NativePackageManager#extractPackageManager(String)}.
    *
    * @param command The command string.
    * @return A {@code PackageManagerCommand} based on the provided command string.
    */
   public static PackageManagerCommand of(String command) {
 
-    PackageManager pm = PackageManager.extractPackageManager(command);
+    NativePackageManager pm = NativePackageManager.extractPackageManager(command);
     return new PackageManagerCommand(pm, List.of(command));
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/PackageManagerRequest.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/PackageManagerRequest.java
@@ -1,0 +1,169 @@
+package com.devonfw.tools.ide.tool;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.devonfw.tools.ide.process.ProcessContext;
+import com.devonfw.tools.ide.process.ProcessMode;
+import com.devonfw.tools.ide.version.VersionIdentifier;
+
+/**
+ * Container for the data related to a package manager request.
+ */
+public final class PackageManagerRequest {
+
+  /** {@link #getType() Type} of request to install a tool. */
+  public static final String TYPE_INSTALL = "install";
+
+  /** {@link #getType() Type} of request to uninstall a tool. */
+  public static final String TYPE_UNINSTALL = "uninstall";
+
+  private final String type;
+
+  private final String tool;
+
+  private final List<String> args;
+
+  private VersionIdentifier version;
+
+  private ToolCommandlet packageManager;
+
+  private ProcessContext processContext;
+
+  private ProcessMode processMode;
+
+  /**
+   * The constructor.
+   *
+   * @param type the {@link #getType() type}.
+   * @param tool the {@link #getTool() tool}.
+   */
+  public PackageManagerRequest(String type, String tool) {
+    super();
+    this.type = type;
+    this.tool = tool;
+    this.args = new ArrayList<>();
+  }
+
+  /**
+   * @return the type of this request (the sub-command of the package manager).
+   * @see #TYPE_INSTALL
+   * @see #TYPE_UNINSTALL
+   */
+  public String getType() {
+
+    return this.type;
+  }
+
+  /**
+   * @return the CLI args used to {@link ToolCommandlet#runTool(List) run} the {@link #getPackageManager() package manager}. E.g.
+   *     <code>List.of("install", "-gf", "@angular/cli")</code>.
+   */
+  public List<String> getArgs() {
+
+    return this.args;
+  }
+
+  /**
+   * @param arg the argument to append to the {@link #getArgs() args}.
+   * @return this {@link PackageManagerRequest} for fluent API calls.
+   */
+  public PackageManagerRequest addArg(String arg) {
+    this.args.add(arg);
+    return this;
+  }
+
+  /**
+   * @return the tool to manage (e.g. install) via this request. Will be in the syntax and terminology of the package-manager that can differ from
+   *     {@link ToolCommandlet#getName() tool names} in IDEasy.
+   * @see PackageManagerBasedLocalToolCommandlet#getPackageName()
+   */
+  public String getTool() {
+
+    return this.tool;
+  }
+
+  /**
+   * @return the optional {@link VersionIdentifier} of the {@link #getTool() tool} (e.g. to install exactly this version).
+   */
+  public VersionIdentifier getVersion() {
+
+    return this.version;
+  }
+
+  /**
+   * @param version new value of {@link #getVersion()}.
+   * @return this {@link PackageManagerRequest} for fluent API calls.
+   */
+  public PackageManagerRequest setVersion(VersionIdentifier version) {
+    if (this.version != null) {
+      throw new IllegalStateException();
+    }
+    this.version = version;
+    return this;
+  }
+
+  /**
+   * @return the {@link ToolCommandlet} acting as package manager.
+   */
+  public ToolCommandlet getPackageManager() {
+
+    return packageManager;
+  }
+
+  /**
+   * @param packageManager new value of {@link #getPackageManager()}.
+   * @return this {@link PackageManagerRequest} for fluent API calls.
+   */
+  public PackageManagerRequest setPackageManager(ToolCommandlet packageManager) {
+
+    if (this.packageManager != null) {
+      throw new IllegalStateException();
+    }
+    this.packageManager = packageManager;
+    return this;
+  }
+
+  /**
+   * @return the {@link ProcessContext}.
+   */
+  public ProcessContext getProcessContext() {
+
+    return this.processContext;
+  }
+
+  /**
+   * @param processContext new value of {@link #getProcessContext()}.
+   * @return this {@link PackageManagerRequest} for fluent API calls.
+   */
+  public PackageManagerRequest setProcessContext(ProcessContext processContext) {
+
+    if (this.processContext != null) {
+      throw new IllegalStateException();
+    }
+    this.processContext = processContext;
+    return this;
+  }
+
+  /**
+   * @return the {@link ProcessMode} used to invoke the package manager.
+   */
+  public ProcessMode getProcessMode() {
+
+    return this.processMode;
+  }
+
+  /**
+   * @param processMode new value of {@link #getProcessMode()}.
+   * @return this {@link PackageManagerRequest} for fluent API calls.
+   */
+  public PackageManagerRequest setProcessMode(ProcessMode processMode) {
+
+    if (this.processMode != null) {
+      throw new IllegalStateException();
+    }
+    this.processMode = processMode;
+    return this;
+  }
+
+}

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
@@ -142,15 +142,15 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
   @Override
   public void run() {
 
-    runTool(this.arguments.asArray());
+    runTool(this.arguments.asList());
   }
 
   /**
    * @param args the command-line arguments to run the tool.
    * @return the {@link ProcessResult result}.
-   * @see ToolCommandlet#runTool(ProcessMode, GenericVersionRange, String...)
+   * @see ToolCommandlet#runTool(ProcessMode, GenericVersionRange, List)
    */
-  public ProcessResult runTool(String... args) {
+  public ProcessResult runTool(List<String> args) {
 
     return runTool(ProcessMode.DEFAULT, null, args);
   }
@@ -164,7 +164,7 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
    * @param args the command-line arguments to run the tool.
    * @return the {@link ProcessResult result}.
    */
-  public final ProcessResult runTool(ProcessMode processMode, GenericVersionRange toolVersion, String... args) {
+  public final ProcessResult runTool(ProcessMode processMode, GenericVersionRange toolVersion, List<String> args) {
 
     return runTool(processMode, toolVersion, ProcessErrorHandling.THROW_CLI, args);
   }
@@ -179,7 +179,7 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
    * @param args the command-line arguments to run the tool.
    * @return the {@link ProcessResult result}.
    */
-  public ProcessResult runTool(ProcessMode processMode, GenericVersionRange toolVersion, ProcessErrorHandling errorHandling, String... args) {
+  public ProcessResult runTool(ProcessMode processMode, GenericVersionRange toolVersion, ProcessErrorHandling errorHandling, List<String> args) {
 
     ProcessContext pc = this.context.newProcess().errorHandling(errorHandling);
     ToolInstallRequest request = new ToolInstallRequest(true);
@@ -198,7 +198,7 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
    * @param args the command-line arguments to run the tool.
    * @return the {@link ProcessResult result}.
    */
-  public ProcessResult runTool(ToolInstallRequest request, ProcessMode processMode, String... args) {
+  public ProcessResult runTool(ToolInstallRequest request, ProcessMode processMode, List<String> args) {
 
     install(request);
     return runTool(request.getProcessContext(), processMode, args);
@@ -210,7 +210,7 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
    * @param args the command-line arguments to run the tool.
    * @return the {@link ProcessResult result}.
    */
-  public ProcessResult runTool(ProcessContext pc, ProcessMode processMode, String... args) {
+  public ProcessResult runTool(ProcessContext pc, ProcessMode processMode, List<String> args) {
 
     if (this.executionDirectory != null) {
       pc.directory(this.executionDirectory);
@@ -232,9 +232,9 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
   /**
    * @param pc the {@link ProcessContext}.
    * @param processMode the {@link ProcessMode}.
-   * @param args the command-line arguments to {@link ProcessContext#addArgs(Object...) add}.
+   * @param args the command-line arguments to {@link ProcessContext#addArgs(List) add}.
    */
-  protected void configureToolArgs(ProcessContext pc, ProcessMode processMode, String... args) {
+  protected void configureToolArgs(ProcessContext pc, ProcessMode processMode, List<String> args) {
 
     pc.addArgs(args);
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolEditionAndVersion.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolEditionAndVersion.java
@@ -108,4 +108,16 @@ public class ToolEditionAndVersion {
     }
     this.resolvedVersion = resolvedVersion;
   }
+
+  @Override
+  public String toString() {
+
+    if (this.edition == null) {
+      return "<none>";
+    }
+    if ((this.resolvedVersion == null) || (this.resolvedVersion == this.version)) {
+      return this.edition + "@" + this.version;
+    }
+    return this.edition + "@" + this.resolvedVersion + "[" + this.version + "]";
+  }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/docker/Docker.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/docker/Docker.java
@@ -9,7 +9,7 @@ import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.os.SystemArchitecture;
 import com.devonfw.tools.ide.tool.GlobalToolCommandlet;
-import com.devonfw.tools.ide.tool.PackageManager;
+import com.devonfw.tools.ide.tool.NativePackageManager;
 import com.devonfw.tools.ide.tool.PackageManagerCommand;
 import com.devonfw.tools.ide.tool.repository.ToolRepository;
 import com.devonfw.tools.ide.version.VersionIdentifier;
@@ -70,10 +70,10 @@ public class Docker extends GlobalToolCommandlet {
     VersionIdentifier configuredVersion = getConfiguredVersion();
     String resolvedVersion = toolRepository.resolveVersion(this.tool, edition, configuredVersion, this).toString();
 
-    return List.of(new PackageManagerCommand(PackageManager.ZYPPER, List.of(
+    return List.of(new PackageManagerCommand(NativePackageManager.ZYPPER, List.of(
             "sudo zypper addrepo https://download.opensuse.org/repositories/isv:/Rancher:/stable/rpm/isv:Rancher:stable.repo",
             String.format("sudo zypper --no-gpg-checks install rancher-desktop=%s*", resolvedVersion))),
-        new PackageManagerCommand(PackageManager.APT, List.of(
+        new PackageManagerCommand(NativePackageManager.APT, List.of(
             "curl -s https://download.opensuse.org/repositories/isv:/Rancher:/stable/deb/Release.key | gpg --dearmor |"
                 + " sudo dd status=none of=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg",
             "echo 'deb [signed-by=/usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg]"
@@ -97,9 +97,9 @@ public class Docker extends GlobalToolCommandlet {
 
     List<PackageManagerCommand> pmCommands = new ArrayList<>();
     pmCommands.add(
-        new PackageManagerCommand(PackageManager.ZYPPER, Arrays.asList("sudo zypper remove rancher-desktop")));
+        new PackageManagerCommand(NativePackageManager.ZYPPER, Arrays.asList("sudo zypper remove rancher-desktop")));
     pmCommands.add(
-        new PackageManagerCommand(PackageManager.APT, Arrays.asList("sudo apt -y autoremove rancher-desktop")));
+        new PackageManagerCommand(NativePackageManager.APT, Arrays.asList("sudo apt -y autoremove rancher-desktop")));
 
     return pmCommands;
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
@@ -5,6 +5,7 @@ import java.io.RandomAccessFile;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 import com.devonfw.tools.ide.cli.CliException;
@@ -55,7 +56,7 @@ public class Eclipse extends IdeToolCommandlet {
   }
 
   @Override
-  protected void configureToolArgs(ProcessContext pc, ProcessMode processMode, String... args) {
+  protected void configureToolArgs(ProcessContext pc, ProcessMode processMode, List<String> args) {
 
     // configure workspace location
     pc.addArg("-data").addArg(this.context.getWorkspacePath());
@@ -70,7 +71,7 @@ public class Eclipse extends IdeToolCommandlet {
       pc.addArg("-consoleLog").addArg("-nosplash");
     }
     super.configureToolArgs(pc, processMode, args);
-    if ((args.length > 0) && !VMARGS.equals(args[0])) {
+    if ((!args.isEmpty()) && !VMARGS.equals(args.getFirst())) {
       String vmArgs = this.context.getVariables().get("ECLIPSE_VMARGS");
       if ((vmArgs != null) && !vmArgs.isEmpty()) {
         pc.addArg(VMARGS).addArg(vmArgs);
@@ -87,8 +88,8 @@ public class Eclipse extends IdeToolCommandlet {
   @Override
   public boolean installPlugin(ToolPluginDescriptor plugin, Step step, ProcessContext pc) {
 
-    ProcessResult result = runTool(pc, ProcessMode.DEFAULT_CAPTURE, "-application", "org.eclipse.equinox.p2.director",
-        "-repository", plugin.url(), "-installIU", plugin.id());
+    ProcessResult result = runTool(pc, ProcessMode.DEFAULT_CAPTURE, List.of("-application", "org.eclipse.equinox.p2.director",
+        "-repository", plugin.url(), "-installIU", plugin.id()));
     if (result.isSuccessful()) {
       for (String line : result.getOut()) {
         if (line.contains("Overall install request is satisfiable")) {
@@ -141,8 +142,8 @@ public class Eclipse extends IdeToolCommandlet {
       this.groovyInstalled = true;
     }
     // -DdevonImportPath=\"${import_path}\" -DdevonImportWorkingSet=\"${importWorkingSets}\""
-    runTool(ProcessMode.DEFAULT, null, ProcessErrorHandling.THROW_CLI, VMARGS,
+    runTool(ProcessMode.DEFAULT, null, ProcessErrorHandling.THROW_CLI, List.of(VMARGS,
         "-DrepositoryImportPath=\"" + repositoryPath + "\" -DrepositoryImportWorkingSet=\"" + "" + "\"", "-application", "org.eclipse.ant.core.antRunner",
-        "-buildfile", this.context.getIdeInstallationPath().resolve(IdeContext.FOLDER_INTERNAL).resolve("eclipse-import.xml").toString());
+        "-buildfile", this.context.getIdeInstallationPath().resolve(IdeContext.FOLDER_INTERNAL).resolve("eclipse-import.xml").toString()));
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/gradle/Gradle.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/gradle/Gradle.java
@@ -46,7 +46,7 @@ public class Gradle extends LocalToolCommandlet {
   @Override
   protected void configureToolBinary(ProcessContext pc, ProcessMode processMode) {
     Path gradle = Path.of(getBinaryName());
-    Path wrapper = findWrapper(GRADLE_WRAPPER_FILENAME, path -> Files.exists(path.resolve(BUILD_GRADLE)) || Files.exists(path.resolve(BUILD_GRADLE_KTS)));
+    Path wrapper = findWrapper(GRADLE_WRAPPER_FILENAME);
     pc.executable(Objects.requireNonNullElse(wrapper, gradle));
   }
 
@@ -63,4 +63,17 @@ public class Gradle extends LocalToolCommandlet {
     return gradleConfigFolder;
   }
 
+  @Override
+  public Path findBuildDescriptor(Path directory) {
+
+    Path buildDescriptor = directory.resolve(BUILD_GRADLE);
+    if (Files.exists(buildDescriptor)) {
+      return buildDescriptor;
+    }
+    buildDescriptor = directory.resolve(BUILD_GRADLE_KTS);
+    if (Files.exists(buildDescriptor)) {
+      return buildDescriptor;
+    }
+    return super.findBuildDescriptor(directory);
+  }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeToolCommandlet.java
@@ -2,6 +2,7 @@ package com.devonfw.tools.ide.tool.ide;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 import com.devonfw.tools.ide.common.Tag;
@@ -52,7 +53,7 @@ public abstract class IdeToolCommandlet extends PluginBasedCommandlet {
   }
 
   @Override
-  public ProcessResult runTool(String... args) {
+  public ProcessResult runTool(List<String> args) {
 
     return runTool(ProcessMode.BACKGROUND, null, args);
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -1,7 +1,6 @@
 package com.devonfw.tools.ide.tool.ide;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -41,7 +40,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     if (customRepo) {
       args.add(plugin.url());
     }
-    ProcessResult result = runTool(pc, ProcessMode.DEFAULT, args.toArray(String[]::new));
+    ProcessResult result = runTool(pc, ProcessMode.DEFAULT, args);
     if (result.isSuccessful()) {
       this.context.success("Successfully installed plugin: {}", plugin.name());
       step.success();
@@ -53,9 +52,8 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
   }
 
   @Override
-  public ProcessResult runTool(String... args) {
-    List<String> extendedArgs = new ArrayList<>(Arrays.asList(args));
-    extendedArgs.add(this.context.getWorkspacePath().toString());
-    return super.runTool(extendedArgs.toArray(new String[0]));
+  public ProcessResult runTool(List<String> args) {
+    args.add(this.context.getWorkspacePath().toString());
+    return super.runTool(args);
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/jasypt/Jasypt.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/jasypt/Jasypt.java
@@ -1,6 +1,7 @@
 package com.devonfw.tools.ide.tool.jasypt;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 
 import com.devonfw.tools.ide.common.Tag;
@@ -59,7 +60,7 @@ public class Jasypt extends LocalToolCommandlet {
   }
 
   @Override
-  public ProcessResult runTool(ProcessContext pc, ProcessMode processMode, String... args) {
+  public ProcessResult runTool(ProcessContext pc, ProcessMode processMode, List<String> args) {
 
     return runJasypt(determineJasyptMainClass(), pc, processMode);
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/jmc/Jmc.java
@@ -1,18 +1,18 @@
 package com.devonfw.tools.ide.tool.jmc;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.stream.Stream;
-
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.io.FileAccess;
 import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * {@link ToolCommandlet} for <a href="https://www.oracle.com/java/technologies/jdk-mission-control.html">JDK Mission Control</a>, An advanced set of tools for
@@ -33,7 +33,7 @@ public class Jmc extends LocalToolCommandlet {
   @Override
   public void run() {
 
-    runTool(ProcessMode.BACKGROUND, null, this.arguments.asArray());
+    runTool(ProcessMode.BACKGROUND, null, this.arguments.asList());
   }
 
   @Override

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/node/Node.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/node/Node.java
@@ -7,6 +7,7 @@ import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.nls.NlsBundle;
 import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
+import com.devonfw.tools.ide.tool.PackageManagerRequest;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolInstallRequest;
 import com.devonfw.tools.ide.tool.npm.Npm;
@@ -30,8 +31,14 @@ public class Node extends LocalToolCommandlet {
   protected void postInstallOnNewInstallation(ToolInstallRequest request) {
 
     super.postInstallOnNewInstallation(request);
+    // this code is slightly dangerous: npm has a dependency to node, while here in node we call npm causing a cyclic dependency
+    // the problem is that node package already comes with npm so we already have to configure npm properly here
+    // inside npm we have to guarantee that we will not trigger an installation (again) causing an infinity loop
+    // we would love to get this clean but node and npm are already flawed forcing us to do such hacks...
     Npm npm = this.context.getCommandletManager().getCommandlet(Npm.class);
-    ProcessResult result = npm.runPackageManager("config", "set", "prefix", getToolPath().toString());
+    PackageManagerRequest packageManagerRequest = new PackageManagerRequest("config", this.tool).addArg("config").addArg("set").addArg("prefix")
+        .addArg(getToolPath().toString());
+    ProcessResult result = npm.runPackageManager(packageManagerRequest, true);
     if (result.isSuccessful()) {
       this.context.success("Setting npm config prefix to: {} was successful", getToolPath());
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/npm/Npm.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/npm/Npm.java
@@ -40,7 +40,6 @@ public class Npm extends NpmBasedCommandlet {
     return null;
   }
 
-
   @Override
   public String getToolHelpArguments() {
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/npm/NpmBasedCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/npm/NpmBasedCommandlet.java
@@ -6,11 +6,10 @@ import java.util.Set;
 
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
-import com.devonfw.tools.ide.process.ProcessContext;
-import com.devonfw.tools.ide.process.ProcessErrorHandling;
 import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
+import com.devonfw.tools.ide.tool.PackageManagerRequest;
 import com.devonfw.tools.ide.tool.node.NodeBasedCommandlet;
 import com.devonfw.tools.ide.tool.repository.ToolRepository;
 import com.devonfw.tools.ide.version.VersionIdentifier;
@@ -18,7 +17,7 @@ import com.devonfw.tools.ide.version.VersionIdentifier;
 /**
  * {@link LocalToolCommandlet} for tools based on <a href="https://www.npmjs.com/">npm</a>.
  */
-public abstract class NpmBasedCommandlet extends NodeBasedCommandlet {
+public abstract class NpmBasedCommandlet extends NodeBasedCommandlet<Npm> {
 
   /**
    * The constructor.
@@ -33,15 +32,15 @@ public abstract class NpmBasedCommandlet extends NodeBasedCommandlet {
   }
 
   @Override
-  public ToolRepository getToolRepository() {
+  protected Class<Npm> getPackageManagerClass() {
 
-    return this.context.getNpmRepository();
+    return Npm.class;
   }
 
   @Override
-  protected boolean isIgnoreMissingSoftwareVersionFile() {
+  public ToolRepository getToolRepository() {
 
-    return true;
+    return this.context.getNpmRepository();
   }
 
   @Override
@@ -49,12 +48,14 @@ public abstract class NpmBasedCommandlet extends NodeBasedCommandlet {
     return runPackageManagerGetInstalledVersion(getPackageName());
   }
 
-  protected VersionIdentifier runPackageManagerGetInstalledVersion(String npmPackage) {
+  private VersionIdentifier runPackageManagerGetInstalledVersion(String npmPackage) {
     if (!Files.isDirectory(this.context.getSoftwarePath().resolve("node"))) {
       this.context.trace("Since node is not installed, also package {} for tool {} cannot be installed.", npmPackage, this.tool);
       return null;
     }
-    ProcessResult result = runPackageManager(ProcessMode.DEFAULT_CAPTURE, ProcessErrorHandling.NONE, "list", "-g", npmPackage, "--depth=0");
+    PackageManagerRequest request = new PackageManagerRequest("list", npmPackage).addArg("-g").addArg(npmPackage).addArg("--depth=0")
+        .setProcessMode(ProcessMode.DEFAULT_CAPTURE);
+    ProcessResult result = runPackageManager(request);
     if (result.isSuccessful()) {
       List<String> versions = result.getOut();
       String parsedVersion = null;
@@ -71,15 +72,6 @@ public abstract class NpmBasedCommandlet extends NodeBasedCommandlet {
       this.context.debug("The npm package {} for tool {} is not installed.", npmPackage, this.tool);
     }
     return null;
-  }
-
-  @Override
-  protected ProcessResult runPackageManager(ProcessMode processMode, ProcessErrorHandling errorHandling, String... args) {
-
-    ProcessContext pc = this.context.newProcess().errorHandling(errorHandling);
-    Npm npm = this.context.getCommandletManager().getCommandlet(Npm.class);
-
-    return npm.runTool(pc, processMode, args);
   }
 
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/pgadmin/PgAdmin.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/pgadmin/PgAdmin.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.tool.GlobalToolCommandlet;
-import com.devonfw.tools.ide.tool.PackageManager;
+import com.devonfw.tools.ide.tool.NativePackageManager;
 import com.devonfw.tools.ide.tool.PackageManagerCommand;
 import com.devonfw.tools.ide.tool.repository.ToolRepository;
 import com.devonfw.tools.ide.version.VersionIdentifier;
@@ -36,7 +36,7 @@ public class PgAdmin extends GlobalToolCommandlet {
     VersionIdentifier configuredVersion = getConfiguredVersion();
     String resolvedVersion = toolRepository.resolveVersion(this.tool, edition, configuredVersion, this).toString();
 
-    PackageManagerCommand packageManagerCommand = new PackageManagerCommand(PackageManager.APT, List.of(
+    PackageManagerCommand packageManagerCommand = new PackageManagerCommand(NativePackageManager.APT, List.of(
         "curl -fsS https://www.pgadmin.org/static/packages_pgadmin_org.pub | "
             + "sudo gpg --yes --dearmor -o /usr/share/keyrings/packages-pgadmin-org.gpg",
         "sudo sh -c 'echo \"deb [signed-by=/usr/share/keyrings/packages-pgadmin-org.gpg] "
@@ -61,7 +61,7 @@ public class PgAdmin extends GlobalToolCommandlet {
 
     List<PackageManagerCommand> pmCommands = new ArrayList<>();
 
-    pmCommands.add(new PackageManagerCommand(PackageManager.APT,
+    pmCommands.add(new PackageManagerCommand(NativePackageManager.APT,
         Arrays.asList("sudo apt -y autoremove pgadmin4 pgadmin4-server pgadmin4-desktop pgadmin4-web")));
 
     return pmCommands;

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/sonar/Sonar.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/sonar/Sonar.java
@@ -1,6 +1,7 @@
 package com.devonfw.tools.ide.tool.sonar;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -54,7 +55,7 @@ public class Sonar extends LocalToolCommandlet {
 
     switch (command) {
       case ANALYZE:
-        getCommandlet(Mvn.class).runTool("sonar:sonar");
+        getCommandlet(Mvn.class).runTool(List.of("sonar:sonar"));
         break;
       case START:
         printSonarWebPort();

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/terraform/Terraform.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/terraform/Terraform.java
@@ -1,5 +1,6 @@
 package com.devonfw.tools.ide.tool.terraform;
 
+import java.util.List;
 import java.util.Set;
 
 import com.devonfw.tools.ide.common.Tag;
@@ -28,7 +29,7 @@ public class Terraform extends LocalToolCommandlet {
   protected void postInstallOnNewInstallation(ToolInstallRequest request) {
 
     super.postInstallOnNewInstallation(request);
-    runTool(request, ProcessMode.DEFAULT, "-install-autocomplete");
+    runTool(request, ProcessMode.DEFAULT, List.of("-install-autocomplete"));
   }
 
   @Override

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/tomcat/Tomcat.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/tomcat/Tomcat.java
@@ -3,6 +3,7 @@ package com.devonfw.tools.ide.tool.tomcat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -54,12 +55,13 @@ public class Tomcat extends LocalToolCommandlet {
   }
 
   @Override
-  public ProcessResult runTool(ProcessMode processMode, GenericVersionRange toolVersion, ProcessErrorHandling errorHandling, String... args) {
+  public ProcessResult runTool(ProcessMode processMode, GenericVersionRange toolVersion, ProcessErrorHandling errorHandling, List<String> args) {
 
-    if (args.length == 0) {
-      args = new String[] { "run" };
+    if (args.isEmpty()) {
+      args.add("run");
     }
-    boolean startup = args[0].equals("start") || args[0].equals("run");
+    String first = args.getFirst();
+    boolean startup = first.equals("start") || first.equals("run");
     if (startup) {
       processMode = ProcessMode.BACKGROUND;
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/uv/Uv.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/uv/Uv.java
@@ -1,7 +1,6 @@
 package com.devonfw.tools.ide.tool.uv;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -40,13 +39,7 @@ public class Uv extends LocalToolCommandlet {
   public void installPython(Path installationPath, VersionIdentifier resolvedVersion, ProcessContext processContext) {
 
     processContext.directory(installationPath);
-
-    List<String> uvInstallCommands = new ArrayList<>();
-    uvInstallCommands.add("venv");
-    uvInstallCommands.add("--python");
-    uvInstallCommands.add(resolvedVersion.toString());
-
-    ProcessResult result = runTool(processContext, ProcessMode.DEFAULT_CAPTURE, uvInstallCommands.toArray(String[]::new));
+    ProcessResult result = runTool(processContext, ProcessMode.DEFAULT_CAPTURE, List.of("venv", "--python", resolvedVersion.toString()));
     assert result.isSuccessful();
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/vscode/Vscode.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/vscode/Vscode.java
@@ -59,7 +59,7 @@ public class Vscode extends IdeToolCommandlet {
     extensionsCommands.add("--force");
     extensionsCommands.add("--install-extension");
     extensionsCommands.add(plugin.id());
-    ProcessResult result = runTool(pc, ProcessMode.DEFAULT_CAPTURE, extensionsCommands.toArray(String[]::new));
+    ProcessResult result = runTool(pc, ProcessMode.DEFAULT_CAPTURE, extensionsCommands);
     if (result.isSuccessful()) {
       this.context.success("Successfully installed plugin: {}", plugin.name());
       step.success();
@@ -71,7 +71,7 @@ public class Vscode extends IdeToolCommandlet {
   }
 
   @Override
-  protected void configureToolArgs(ProcessContext pc, ProcessMode processMode, String... args) {
+  protected void configureToolArgs(ProcessContext pc, ProcessMode processMode, List<String> args) {
 
     Path vsCodeConf = this.context.getWorkspacePath().resolve(".vscode/.userdata");
     pc.addArg("--new-window");

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/yarn/Yarn.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/yarn/Yarn.java
@@ -1,19 +1,19 @@
 package com.devonfw.tools.ide.tool.yarn;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
-import com.devonfw.tools.ide.process.ProcessContext;
 import com.devonfw.tools.ide.tool.npm.NpmBasedCommandlet;
-import com.devonfw.tools.ide.tool.repository.ToolRepository;
-import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
  * {@link NpmBasedCommandlet} for <a href="https://yarnpkg.com">yarn</a>.
  */
 public class Yarn extends NpmBasedCommandlet {
+
+  private static final String YARN_LOCK = "yarn.lock";
 
   /**
    * The constructor.
@@ -23,5 +23,15 @@ public class Yarn extends NpmBasedCommandlet {
   public Yarn(IdeContext context) {
 
     super(context, "yarn", Set.of(Tag.TYPE_SCRIPT, Tag.BUILD));
+  }
+
+  @Override
+  public Path findBuildDescriptor(Path directory) {
+
+    Path lockFile = directory.resolve(YARN_LOCK);
+    if (!Files.exists(lockFile)) {
+      return null; // if we do not find a yarn.lock file, we let npm take over the package.json
+    }
+    return super.findBuildDescriptor(directory);
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java
@@ -62,8 +62,17 @@ public interface IdeVariables {
   /** {@link VariableDefinition} arguments for maven to set the m2 repo location. */
   VariableDefinitionPath M2_REPO = new VariableDefinitionPath("M2_REPO", null, IdeVariables::getMavenRepositoryPath, false, true);
 
-  /** {@link VariableDefinition} for {@link com.devonfw.tools.ide.context.IdeContext#getWorkspaceName() WORKSPACE}. */
+  /**
+   * {@link VariableDefinition} for {@link com.devonfw.tools.ide.tool.ToolCommandlet#getConfiguredEdition() edition} of
+   * {@link com.devonfw.tools.ide.tool.docker.Docker docker}.
+   */
   VariableDefinitionString DOCKER_EDITION = new VariableDefinitionString("DOCKER_EDITION", null, c -> "rancher");
+
+  /**
+   * {@link VariableDefinition} for {@link com.devonfw.tools.ide.tool.ToolCommandlet#getConfiguredEdition() edition} of
+   * {@link com.devonfw.tools.ide.tool.pip.Pip pip}.
+   */
+  VariableDefinitionString PIP_EDITION = new VariableDefinitionString("PIP_EDITION", null, c -> "uv");
 
   /** {@link VariableDefinition} for default build options of mvn */
   VariableDefinitionString MVN_BUILD_OPTS = new VariableDefinitionString("MVN_BUILD_OPTS", null, c -> "clean install");

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionIdentifier.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionIdentifier.java
@@ -334,9 +334,12 @@ public final class VersionIdentifier implements VersionObject<VersionIdentifier>
 
     if (version == null) {
       return null;
-    } else if (version.equals("latest") || version.equals("*")) {
+    }
+    version = version.trim();
+    if (version.equals("latest") || version.equals("*")) {
       return VersionIdentifier.LATEST;
     }
+    assert !version.contains(" ") && !version.contains("\n") && !version.contains("\t") : version;
     VersionSegment startSegment = VersionSegment.of(version);
     if (startSegment == null) {
       return null;

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionRange.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionRange.java
@@ -226,14 +226,14 @@ public final class VersionRange implements Comparable<VersionRange>, GenericVers
       min = VersionIdentifier.of(value);
       max = min;
     } else {
-      String minString = value.substring(0, index);
+      String minString = value.substring(0, index).trim();
       if (!minString.isBlank()) {
         min = VersionIdentifier.of(minString);
         if (min == VersionIdentifier.LATEST) {
           min = null;
         }
       }
-      String maxString = value.substring(index + 1);
+      String maxString = value.substring(index + 1).trim();
       if (!maxString.isBlank()) {
         max = VersionIdentifier.of(maxString);
         if (max == VersionIdentifier.LATEST) {

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/corepack/CorepackTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/corepack/CorepackTest.java
@@ -58,7 +58,7 @@ public class CorepackTest extends AbstractIdeContextTest {
     // assert II
     assertThat(context).logAtInfo().hasNoMessageContaining("npm uninstall -g corepack");
     assertThat(context).logAtInfo().hasMessageContaining("IDEasy does not support uninstalling the tool corepack since this will break your installation.\n"
-        + "If you really want to uninstall it, please uninstall the entire node installation:\n"
+        + "If you really want to uninstall it, please uninstall its parent tool via:\n"
         + "ide uninstall node");
 
     assertThat(context).logAtSuccess().hasMessage("Successfully uninstalled corepack");

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/gradle/GradleTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/gradle/GradleTest.java
@@ -88,7 +88,7 @@ public class GradleTest extends AbstractIdeContextTest {
     gradle.run();
 
     // assert
-    assertThat(context).logAtDebug().hasMessage("Using wrapper file at: " + context.getWorkspacePath());
+    assertThat(context).logAtDebug().hasMessage("Using wrapper: " + context.getWorkspacePath().resolve("gradlew"));
     assertThat(context).logAtInfo().hasMessage("gradlew " + "foo bar");
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/ide/IdeToolDummyCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/ide/IdeToolDummyCommandletTest.java
@@ -74,7 +74,7 @@ public class IdeToolDummyCommandletTest extends AbstractIdeContextTest {
     }
 
     @Override
-    public ProcessResult runTool(ProcessMode processMode, GenericVersionRange toolVersion, ProcessErrorHandling errorHandling, String... args) {
+    public ProcessResult runTool(ProcessMode processMode, GenericVersionRange toolVersion, ProcessErrorHandling errorHandling, List<String> args) {
 
       // skip installation but trigger postInstall to test mocked plugin installation
       ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.THROW_CLI);

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnTest.java
@@ -94,7 +94,7 @@ public class MvnTest extends AbstractIdeContextTest {
     mvn.run();
 
     // assert
-    assertThat(context).logAtDebug().hasMessage("Using wrapper file at: " + context.getWorkspacePath());
+    assertThat(context).logAtDebug().hasMessage("Using wrapper: " + context.getWorkspacePath().resolve("mvnw"));
     assertThat(context).logAtInfo().hasMessage("mvnw " + "foo bar");
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/npm/NpmTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/npm/NpmTest.java
@@ -51,8 +51,7 @@ public class NpmTest extends AbstractIdeContextTest {
     commandlet.run();
 
     // assert
-    assertThat(context).logAtInfo().hasMessageContaining("npm --version");
-    assertThat(context).logAtInfo().hasMessageContaining("npm version: 9.9.2");
+    assertThat(context).logAtInfo().hasMessage("9.9.2");
   }
 
   /**
@@ -79,7 +78,7 @@ public class NpmTest extends AbstractIdeContextTest {
     // assert II
     assertThat(context).logAtInfo().hasNoMessageContaining("npm uninstall -g npm");
     assertThat(context).logAtInfo().hasMessageContaining("IDEasy does not support uninstalling the tool npm since this will break your installation.\n"
-        + "If you really want to uninstall it, please uninstall the entire node installation:\n"
+        + "If you really want to uninstall it, please uninstall its parent tool via:\n"
         + "ide uninstall node");
 
     assertThat(context).logAtSuccess().hasMessage("Successfully uninstalled npm");

--- a/cli/src/test/resources/ide-projects/corepack/repository/node/node/default/bin/npm
+++ b/cli/src/test/resources/ide-projects/corepack/repository/node/node/default/bin/npm
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ "$1" == "--version" ]; then
+  echo "9.9.2"
+  exit
+fi
 echo "npm $*"
 
 if [ "$1" == "install" ]; then

--- a/cli/src/test/resources/ide-projects/ng/repository/node/node/default/npm
+++ b/cli/src/test/resources/ide-projects/ng/repository/node/node/default/npm
@@ -1,2 +1,6 @@
 #!/bin/bash
+if [ "$1" == "--version" ]; then
+  echo "9.9.2"
+  exit
+fi
 echo "npm $*"

--- a/cli/src/test/resources/ide-projects/npm/repository/node/node/default/bin/npm
+++ b/cli/src/test/resources/ide-projects/npm/repository/node/node/default/bin/npm
@@ -1,6 +1,6 @@
 #!/bin/bash
-echo "npm $*"
-
 if [ "${1}" == "--version" ]; then
-  echo "npm version: 9.9.2"
+  echo "9.9.2"
+  exit
 fi
+echo "npm $*"

--- a/cli/src/test/resources/ide-projects/yarn/repository/node/node/default/bin/npm
+++ b/cli/src/test/resources/ide-projects/yarn/repository/node/node/default/bin/npm
@@ -1,6 +1,9 @@
 #!/bin/bash
+if [ "${1}" == "--version" ]; then
+  echo "9.9.2"
+  exit
+fi
 echo "npm $*"
-
 if [ "$1" == "install" ]; then
   cp target/ide-projects/yarn/repository/yarn/yarn/default/yarn target/ide-projects/yarn/project/software/node/bin
 fi

--- a/cli/src/test/resources/ide-projects/yarn/repository/node/node/default/npm
+++ b/cli/src/test/resources/ide-projects/yarn/repository/node/node/default/npm
@@ -1,6 +1,0 @@
-#!/bin/bash
-echo "npm $*"
-
-if [ "$1" == "install" ]; then
-  cp target/ide-projects/yarn/repository/yarn/yarn/default/yarn target/ide-projects/yarn/project/software/node/bin
-fi

--- a/cli/src/test/resources/ide-projects/yarn/repository/node/node/default/npx
+++ b/cli/src/test/resources/ide-projects/yarn/repository/node/node/default/npx
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "npx $*"


### PR DESCRIPTION
allowing reuse for pip

### This PR prepares issue #39

### Implemented changes:

* complex refactoring to extract `PackageManagerBasedLocalToolCommandlet`
* renamed `PackageManager` to `NativePackageManager` to avoid confusion
* refactored all CLI args from vararg array to `List<String>` to simplify usage (prepending or appending extra arguments)
* fixed inconsistencies in `ide-projects` (causing `VersionIdentifier` to be instantiated with values like `npm --version` as version)
* added assertion to prevent such nonsense in the future
* debugged infinity loops and fixed cyclic dependencies, adding comments to make that transparent
* reworked `BuildCommandlet` and improved code-style by adding `LocalToolCommandlet.findBuildDescriptor` method (SoC)
* improved `LocalToolCommandlet.findWrapper` to reuse `findBuildDescriptor`

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`