### PR TITLE
#1644: fix pip GraalVM reflection and add automated validation test

### DIFF
--- a/cli/src/main/resources/META-INF/native-image/com.devonfw.tools.IDEasy/ide-cli/reflect-config.json
+++ b/cli/src/main/resources/META-INF/native-image/com.devonfw.tools.IDEasy/ide-cli/reflect-config.json
@@ -18,7 +18,28 @@
     ]
   },
   {
+    "name": "com.devonfw.tools.ide.github.GithubTag",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.devonfw.tools.ide.github.GithubTags",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
     "name": "com.devonfw.tools.ide.npm.NpmJsonObject",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.devonfw.tools.ide.pip.PypiJsonObject",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
     "allDeclaredFields": true,

--- a/cli/src/test/java/com/devonfw/tools/ide/nativeimage/GraalVmReflectionConfigTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/nativeimage/GraalVmReflectionConfigTest.java
@@ -1,0 +1,283 @@
+package com.devonfw.tools.ide.nativeimage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.devonfw.tools.ide.json.JsonMapping;
+import com.devonfw.tools.ide.json.JsonObject;
+import com.devonfw.tools.ide.json.JsonVersionItem;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Test to validate that all JSON classes used for deserialization are properly registered in GraalVM reflection
+ * configuration. This prevents runtime failures in native image builds where Jackson cannot deserialize JSON without
+ * explicit reflection registration.
+ */
+public class GraalVmReflectionConfigTest {
+
+  private static final String REFLECT_CONFIG_PATH = "META-INF/native-image/com.devonfw.tools.IDEasy/ide-cli/reflect-config.json";
+
+  private static final String BASE_PACKAGE = "com/devonfw/tools/ide";
+
+  /**
+   * Tests that all classes implementing {@link JsonObject} or {@link JsonVersionItem} are registered in the GraalVM
+   * reflection configuration file. These classes require reflection for Jackson JSON deserialization to work in native
+   * image builds.
+   *
+   * @throws Exception if the test fails
+   */
+  @Test
+  public void testAllJsonClassesRegisteredForReflection() throws Exception {
+
+    // Find all classes implementing JsonObject or JsonVersionItem
+    Set<String> jsonClasses = findJsonClasses();
+
+    // Load reflection configuration
+    Set<String> registeredClasses = loadReflectionConfig();
+
+    // Find missing classes
+    Set<String> missingClasses = new HashSet<>(jsonClasses);
+    missingClasses.removeAll(registeredClasses);
+
+    // Generate helpful error message with JSON snippet to add
+    if (!missingClasses.isEmpty()) {
+      String errorMessage = buildErrorMessage(missingClasses);
+      assertThat(missingClasses)
+          .as(errorMessage)
+          .isEmpty();
+    }
+  }
+
+  /**
+   * Scans the classpath for all classes in the com.devonfw.tools.ide package that implement {@link JsonObject} or
+   * {@link JsonVersionItem}.
+   *
+   * @return set of fully qualified class names
+   * @throws Exception if scanning fails
+   */
+  private Set<String> findJsonClasses() throws Exception {
+
+    Set<String> classes = new HashSet<>();
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+    // Get all class files in the base package
+    Enumeration<URL> resources = classLoader.getResources(BASE_PACKAGE);
+    while (resources.hasMoreElements()) {
+      URL resource = resources.nextElement();
+      classes.addAll(findClassesInResource(resource, BASE_PACKAGE));
+    }
+
+    // Filter for classes implementing JsonObject or JsonVersionItem
+    Set<String> jsonClasses = new HashSet<>();
+    for (String className : classes) {
+      try {
+        Class<?> clazz = Class.forName(className);
+        if (JsonObject.class.isAssignableFrom(clazz) || JsonVersionItem.class.isAssignableFrom(clazz)) {
+          // Don't include the interfaces themselves
+          if (!clazz.equals(JsonObject.class) && !clazz.equals(JsonVersionItem.class)) {
+            jsonClasses.add(className);
+          }
+        }
+      } catch (ClassNotFoundException | NoClassDefFoundError e) {
+        // Skip classes that cannot be loaded (e.g., optional dependencies)
+      }
+    }
+
+    return jsonClasses;
+  }
+
+  /**
+   * Finds all class files in a given resource URL (directory or JAR).
+   *
+   * @param resource the resource URL
+   * @param packagePath the package path
+   * @return set of fully qualified class names
+   * @throws IOException if reading fails
+   */
+  private Set<String> findClassesInResource(URL resource, String packagePath) throws IOException {
+
+    Set<String> classes = new HashSet<>();
+    String protocol = resource.getProtocol();
+
+    if ("file".equals(protocol)) {
+      // File system directory - use URI to handle Windows paths correctly
+      try {
+        Path directory = Paths.get(resource.toURI());
+        classes.addAll(findClassesInDirectory(directory, packagePath.replace('/', '.')));
+      } catch (Exception e) {
+        // Fallback: try to parse the path directly, removing leading slash on Windows
+        String path = resource.getPath();
+        if (path.startsWith("/") && path.length() > 2 && path.charAt(2) == ':') {
+          path = path.substring(1); // Remove leading slash for Windows paths like /C:/...
+        }
+        Path directory = Paths.get(path);
+        classes.addAll(findClassesInDirectory(directory, packagePath.replace('/', '.')));
+      }
+    } else if ("jar".equals(protocol)) {
+      // JAR file
+      String jarPath = resource.getPath();
+      if (jarPath.contains("!")) {
+        jarPath = jarPath.substring(0, jarPath.indexOf("!"));
+      }
+      if (jarPath.startsWith("file:")) {
+        jarPath = jarPath.substring(5);
+      }
+      // Handle Windows paths
+      if (jarPath.startsWith("/") && jarPath.length() > 2 && jarPath.charAt(2) == ':') {
+        jarPath = jarPath.substring(1);
+      }
+      classes.addAll(findClassesInJar(jarPath, packagePath));
+    }
+
+    return classes;
+  }
+
+  /**
+   * Finds all classes in a file system directory.
+   *
+   * @param directory the directory path
+   * @param packageName the package name
+   * @return set of fully qualified class names
+   * @throws IOException if reading fails
+   */
+  private Set<String> findClassesInDirectory(Path directory, String packageName) throws IOException {
+
+    Set<String> classes = new HashSet<>();
+
+    if (Files.exists(directory)) {
+      Files.walk(directory)
+          .filter(path -> path.toString().endsWith(".class"))
+          .forEach(path -> {
+            String relativePath = directory.relativize(path).toString();
+            String className = packageName + "."
+                + relativePath.replace('\\', '.').replace('/', '.').replace(".class", "");
+            classes.add(className);
+          });
+    }
+
+    return classes;
+  }
+
+  /**
+   * Finds all classes in a JAR file.
+   *
+   * @param jarPath the JAR file path
+   * @param packagePath the package path
+   * @return set of fully qualified class names
+   * @throws IOException if reading fails
+   */
+  private Set<String> findClassesInJar(String jarPath, String packagePath) throws IOException {
+
+    Set<String> classes = new HashSet<>();
+
+    try (ZipInputStream zip = new ZipInputStream(Files.newInputStream(Paths.get(jarPath)))) {
+      ZipEntry entry;
+      while ((entry = zip.getNextEntry()) != null) {
+        String name = entry.getName();
+        if (name.startsWith(packagePath) && name.endsWith(".class")) {
+          String className = name.replace('/', '.').replace(".class", "");
+          classes.add(className);
+        }
+      }
+    }
+
+    return classes;
+  }
+
+  /**
+   * Loads the GraalVM reflection configuration and extracts registered class names.
+   *
+   * @return set of registered class names
+   * @throws Exception if loading fails
+   */
+  private Set<String> loadReflectionConfig() throws Exception {
+
+    Set<String> registeredClasses = new HashSet<>();
+    ObjectMapper mapper = JsonMapping.create();
+
+    InputStream configStream = getClass().getClassLoader().getResourceAsStream(REFLECT_CONFIG_PATH);
+    if (configStream == null) {
+      throw new IllegalStateException("Could not find reflection config at: " + REFLECT_CONFIG_PATH);
+    }
+
+    JsonNode rootNode = mapper.readTree(configStream);
+    if (rootNode.isArray()) {
+      for (JsonNode node : rootNode) {
+        if (node.has("name")) {
+          String className = node.get("name").asText();
+          registeredClasses.add(className);
+        }
+      }
+    }
+
+    return registeredClasses;
+  }
+
+  /**
+   * Builds a helpful error message with the exact JSON snippet to add to the reflection config.
+   *
+   * @param missingClasses set of missing class names
+   * @return formatted error message
+   */
+  private String buildErrorMessage(Set<String> missingClasses) {
+
+    StringBuilder message = new StringBuilder();
+    message.append("\n\n");
+    message.append("====================================================================================\n");
+    message.append("GraalVM Reflection Configuration Error\n");
+    message.append("====================================================================================\n");
+    message.append("\n");
+    message.append("The following JSON classes are NOT registered in the GraalVM reflection config.\n");
+    message.append("This will cause Jackson deserialization to fail in native image builds.\n");
+    message.append("\n");
+    message.append("Missing classes:\n");
+    List<String> sortedClasses = missingClasses.stream().sorted().collect(Collectors.toList());
+    for (String className : sortedClasses) {
+      message.append("  - ").append(className).append("\n");
+    }
+    message.append("\n");
+    message.append("====================================================================================\n");
+    message.append("HOW TO FIX\n");
+    message.append("====================================================================================\n");
+    message.append("\n");
+    message.append("Add the following entries to:\n");
+    message.append("  cli/src/main/resources/META-INF/native-image/com.devonfw.tools.IDEasy/ide-cli/reflect-config.json\n");
+    message.append("\n");
+    message.append("Copy this JSON snippet into the array:\n");
+    message.append("\n");
+
+    for (String className : sortedClasses) {
+      message.append("  {\n");
+      message.append("    \"name\": \"").append(className).append("\",\n");
+      message.append("    \"allDeclaredConstructors\": true,\n");
+      message.append("    \"allPublicConstructors\": true,\n");
+      message.append("    \"allDeclaredFields\": true,\n");
+      message.append("    \"allDeclaredMethods\": true\n");
+      message.append("  },\n");
+    }
+
+    message.append("\n");
+    message.append("For detailed instructions, see:\n");
+    message.append("  documentation/graalvm-build-guide.adoc#reflection-configuration\n");
+    message.append("\n");
+    message.append("====================================================================================\n");
+
+    return message.toString();
+  }
+}

--- a/documentation/DoD.adoc
+++ b/documentation/DoD.adoc
@@ -49,5 +49,6 @@ Therefore, add proper help texts for all supported languages https://github.com/
 If that license is not yet included, the full license text needs to be added.
 ** [ ] The new commandlet installs potential dependencies automatically (e.g. `getCommandlet(«DependentTool».class).install()` in overridden `install` method).
 ** [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet so if present that edition and version will be downloaded and installed (happens by default but important if you implement custom installation logic).
+** [ ] If the tool uses JSON APIs, all JSON model classes are registered in `reflect-config.json` (validated by `GraalVmReflectionConfigTest`). See link:graalvm-build-guide.adoc#reflection-configuration[GraalVM Reflection Configuration].
 ** [ ] The new commandlet is tested on all platforms it is available for.
 Assuming you are using Windows, testing for Linux can be done with WSL or Virtual Box and for macOS we have a virtual cloud instance.

--- a/documentation/IDEasy-contribution-getting-started.adoc
+++ b/documentation/IDEasy-contribution-getting-started.adoc
@@ -89,6 +89,27 @@ The updaters use the function `doAddVersion()`, where the downloadUrl, OS and ar
 
 `VersionIdentifiers` can also be used if e.g. the downloadUrl changed after a specific version, or certain versions are not intended to be available. https://github.com/devonfw/IDEasy/blob/071e732e6c74aed7b12ccc1d522faf1c4a015dad/cli/src/main/java/com/devonfw/tools/ide/tool/helm/HelmUrlUpdater.java#L12[Example]
 
+*JSON Deserialization and GraalVM*
+
+If your `UrlUpdater` or tool implementation uses JSON deserialization with Jackson (e.g., extending `JsonRepository` or fetching JSON from external APIs):
+
+1. Ensure all JSON model classes implement `JsonObject` or `JsonVersionItem` interfaces
+2. Run the reflection configuration validation test:
++
+```
+mvn test -Dtest=GraalVmReflectionConfigTest
+```
++
+3. If the test fails, it will display the exact JSON snippet needed. Copy this snippet and add it to:
++
+```
+cli/src/main/resources/META-INF/native-image/com.devonfw.tools.IDEasy/ide-cli/reflect-config.json
+```
++
+4. Re-run the test to verify it passes
+
+This is required for native image builds to work correctly. For detailed instructions, see link:graalvm-build-guide.adoc#reflection-configuration[GraalVM Reflection Configuration].
+
 Once a day, the `UpdateInitiator` will run the updaters through GitHub Actions and fill the https://github.com/devonfw/ide-urls[ide-URL] repository with new version/tools that are identified by the Updaters.
 
 === Commandlet

--- a/documentation/graalvm-build-guide.adoc
+++ b/documentation/graalvm-build-guide.adoc
@@ -43,7 +43,71 @@ image:images/graalvmMvnArgs.png[image]
 
 Building the application might take up to 10 minutes depending on your machine.
 
-*4. Run your Application* +
+[[reflection-configuration]]
+*4. Reflection Configuration*
+
+GraalVM native images require explicit registration of classes that use reflection.
+Jackson JSON deserialization uses reflection to instantiate and populate objects.
+
+*4.1 Automated Validation*
+
+Before building a native image, validate that all JSON classes are properly registered:
+
+```
+mvn test -Dtest=GraalVmReflectionConfigTest
+```
+
+This test ensures all JSON classes implementing `JsonObject` or `JsonVersionItem` are registered in `reflect-config.json`.
+
+*4.2 Adding New Tools with JSON APIs*
+
+When adding a new tool that fetches JSON from external APIs (like npm, pip, or GitHub):
+
+1. *Create JSON model classes* implementing `JsonObject` or `JsonVersionItem`
+2. *Run the reflection test* to detect missing registrations:
++
+```
+mvn test -Dtest=GraalVmReflectionConfigTest
+```
++
+3. *Update reflect-config.json* - If the test fails, it will show a helpful error message with the exact JSON snippet to add. Copy the snippet from the error message and paste it into:
++
+```
+cli/src/main/resources/META-INF/native-image/com.devonfw.tools.IDEasy/ide-cli/reflect-config.json
+```
++
+4. *Re-run the test* to verify it passes
+5. *Build native image* to confirm everything works
+
+*4.3 Manual Registration*
+
+If you need to manually register a class for reflection, add an entry to `reflect-config.json`:
+
+```json
+{
+  "name": "com.devonfw.tools.ide.mytool.MyJsonObject",
+  "allDeclaredConstructors": true,
+  "allPublicConstructors": true,
+  "allDeclaredFields": true,
+  "allDeclaredMethods": true
+}
+```
+
+*4.4 Common Errors*
+
+*Error:* `InvalidDefinitionException: cannot deserialize from Object value` or `cannot construct instance` in native image
+
+*Cause:* Missing reflection config for JSON classes
+
+*Solution:* Run `GraalVmReflectionConfigTest` to identify missing classes, then add them to `reflect-config.json` as shown above
+
+*Error:* `No serializer found for class` in native image
+
+*Cause:* Missing serialization config (rare, usually only reflection needed)
+
+*Solution:* Add serialization config or use explicit custom serializers
+
+*5. Run your Application* +
 An ideasy executable (e.g. ideasy.exe under windows) should be created under *../workspace/main/IDEasy/cli/target*.
 
 To run the application open a cli and pass your arguments.


### PR DESCRIPTION
This PR fixes issue #1644 where pip was not working in the GraalVM native-image due to missing reflection configuration.

## Changes

### Core Fix
- **reflect-config.json**: Added missing reflection entries for:
  - `PypiJsonObject` (pip JSON response model)
  - `GithubTag` (GitHub API tag model)
  - `GithubTags` (GitHub API tags list model)

### Automated Validation
- **GraalVmReflectionConfigTest**: New test class that:
  - Scans classpath for all JSON model classes (implementing `JsonObject` or `JsonVersionItem`)
  - Validates they're registered in reflect-config.json
  - Provides helpful error messages with copy-paste JSON snippets when missing entries detected
  - Uses vanilla Java (no external dependencies) for classpath scanning
  - Handles Windows path formatting correctly

### Documentation Updates
- **graalvm-build-guide.adoc**: Added Section 4 "Reflection Configuration" covering:
  - Automated validation workflow
  - Adding new JSON API tools
  - Manual registration guide
  - Common error troubleshooting
- **DoD.adoc**: Added checklist requirement for JSON API tools to validate reflection config
- **IDEasy-contribution-getting-started.adoc**: Added "JSON Deserialization and GraalVM" subsection explaining the validation workflow

## Testing
- `mvn test -Dtest=GraalVmReflectionConfigTest` passes ✅
- Test initially detected missing `PypiJsonObject` (TDD red phase)
- After adding reflection entries, test passes (TDD green phase)

## DoD Checklist
- [x] Code follows coding conventions (no star imports, proper JavaDoc, CamelCase)
- [x] Added automated test (GraalVmReflectionConfigTest)
- [x] Documentation updated (graalvm-build-guide, DoD, contribution guide)
- [x] JSON model classes registered in reflect-config.json
- [x] Test validates future JSON classes automatically

Closes #1644