### PR TITLE
#1679: fix determine version if npm list has exit code 1

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessContext.java
@@ -3,6 +3,7 @@ package com.devonfw.tools.ide.process;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import com.devonfw.tools.ide.log.IdeSubLogger;
 
@@ -118,6 +119,20 @@ public interface ProcessContext extends EnvironmentContext {
   ProcessContext withPathEntry(Path path);
 
   /**
+   * @param exitCodeAcceptor the {@link Predicate} that {@link Predicate#test(Object) tests} which {@link ProcessResult#getExitCode() exit codes} should be
+   *     accepted as {@link ProcessResult#isSuccessful() success}.
+   * @return this {@link ProcessContext} for fluent API calls.
+   */
+  ProcessContext withExitCodeAcceptor(Predicate<Integer> exitCodeAcceptor);
+
+  /**
+   * @return a new child {@link ProcessContext} connected with this {@link ProcessContext} sharing the same {@link #withEnvVar(String, String) environment} and
+   *     {@link #withPathEntry(Path) PATH} but not specific things like {@link #withExitCodeAcceptor(Predicate) exitCodeAcceptor} or
+   *     {@link #errorHandling(ProcessErrorHandling) errorHandling}.
+   */
+  ProcessContext createChild();
+
+  /**
    * Runs the previously configured {@link #executable(Path) command} with the configured {@link #addArgs(String...) arguments}. Will reset the
    * {@link #addArgs(String...) arguments} but not the {@link #executable(Path) command} for sub-sequent calls.
    *
@@ -224,5 +239,6 @@ public interface ProcessContext extends EnvironmentContext {
   default void setOutputListener(OutputListener listener) {
 
   }
+
 
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessResult.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessResult.java
@@ -1,6 +1,7 @@
 package com.devonfw.tools.ide.process;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import com.devonfw.tools.ide.cli.CliProcessException;
 import com.devonfw.tools.ide.context.IdeContext;
@@ -60,7 +61,9 @@ public interface ProcessResult {
   int getExitCode();
 
   /**
-   * @return {@code true} if the {@link #getExitCode() exit code} indicates {@link #SUCCESS}, {@code false} otherwise (an error occurred).
+   * @return {@code true} if the process execution was successful, {@code false} otherwise (an error occurred). By default, success means the
+   *     {@link #getExitCode() exit code} was {@link #SUCCESS}.
+   * @see ProcessContext#withExitCodeAcceptor(Predicate)
    */
   default boolean isSuccessful() {
 

--- a/cli/src/main/java/com/devonfw/tools/ide/process/ProcessResultImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/process/ProcessResultImpl.java
@@ -22,6 +22,8 @@ public class ProcessResultImpl implements ProcessResult {
 
   private final List<OutputMessage> outputMessages;
 
+  private final boolean success;
+
   /**
    * The constructor.
    *
@@ -31,11 +33,25 @@ public class ProcessResultImpl implements ProcessResult {
    * @param outputMessages {@link #getOutputMessages() output Messages}.
    */
   public ProcessResultImpl(String executable, String command, int exitCode, List<OutputMessage> outputMessages) {
+    this(executable, command, exitCode, exitCode == SUCCESS, outputMessages);
+  }
+
+  /**
+   * The constructor.
+   *
+   * @param executable the {@link #getExecutable() executable}.
+   * @param command the {@link #getCommand() command}.
+   * @param exitCode the {@link #getExitCode() exit code}.
+   * @param success the {@link #isSuccessful() success} flag.
+   * @param outputMessages {@link #getOutputMessages() output Messages}.
+   */
+  public ProcessResultImpl(String executable, String command, int exitCode, boolean success, List<OutputMessage> outputMessages) {
 
     super();
     this.executable = executable;
     this.command = command;
     this.exitCode = exitCode;
+    this.success = success;
     this.outputMessages = Objects.requireNonNullElse(outputMessages, Collections.emptyList());
   }
 
@@ -124,7 +140,12 @@ public class ProcessResultImpl implements ProcessResult {
   public List<OutputMessage> getOutputMessages() {
 
     return this.outputMessages;
+  }
 
+  @Override
+  public boolean isSuccessful() {
+
+    return this.success;
   }
 
   @Override

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/PackageManagerBasedLocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/PackageManagerBasedLocalToolCommandlet.java
@@ -85,13 +85,12 @@ public abstract class PackageManagerBasedLocalToolCommandlet<P extends ToolComma
     completeRequest(request);
     ProcessContext pc = request.getProcessContext();
     ToolCommandlet pm = request.getPackageManager();
-    if (skipInstallation) { // See Node.postInstallOnNewInstallation
-      return pm.runTool(pc, request.getProcessMode(), request.getArgs());
-    } else {
+    if (!skipInstallation) { // See Node.postInstallOnNewInstallation
       ToolInstallRequest installRequest = new ToolInstallRequest(true);
-      installRequest.setProcessContext(pc);
-      return pm.runTool(installRequest, request.getProcessMode(), request.getArgs());
+      installRequest.setProcessContext(pc.createChild());
+      pm.install(installRequest);
     }
+    return pm.runTool(pc, request.getProcessMode(), request.getArgs());
   }
 
   protected void completeRequest(PackageManagerRequest request) {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/npm/NpmBasedCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/npm/NpmBasedCommandlet.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.process.ProcessContext;
+import com.devonfw.tools.ide.process.ProcessErrorHandling;
 import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
@@ -55,6 +57,9 @@ public abstract class NpmBasedCommandlet extends NodeBasedCommandlet<Npm> {
     }
     PackageManagerRequest request = new PackageManagerRequest("list", npmPackage).addArg("list").addArg("-g").addArg(npmPackage).addArg("--depth=0")
         .setProcessMode(ProcessMode.DEFAULT_CAPTURE);
+    ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.THROW_CLI)
+        .withExitCodeAcceptor(rc -> true); // if the tool is not installed npm list will end with exit code 1
+    request.setProcessContext(pc);
     ProcessResult result = runPackageManager(request);
     if (result.isSuccessful()) {
       List<String> versions = result.getOut();

--- a/cli/src/test/java/com/devonfw/tools/ide/context/ProcessContextGitMock.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/ProcessContextGitMock.java
@@ -61,6 +61,12 @@ public class ProcessContextGitMock extends ProcessContextImpl {
   }
 
   @Override
+  public ProcessContext createChild() {
+
+    return this;
+  }
+
+  @Override
   public ProcessResult run(ProcessMode processMode) {
 
     if (!this.executable.getFileName().toString().equals("git")) {

--- a/cli/src/test/java/com/devonfw/tools/ide/context/ProcessContextTestImpl.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/context/ProcessContextTestImpl.java
@@ -1,6 +1,7 @@
 package com.devonfw.tools.ide.context;
 
 import com.devonfw.tools.ide.log.IdeLogLevel;
+import com.devonfw.tools.ide.process.ProcessContext;
 import com.devonfw.tools.ide.process.ProcessContextImpl;
 import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.process.ProcessResult;
@@ -18,6 +19,12 @@ public class ProcessContextTestImpl extends ProcessContextImpl {
   public ProcessContextTestImpl(IdeContext context) {
 
     super(context);
+  }
+
+  @Override
+  public ProcessContext createChild() {
+
+    return this;
   }
 
   @Override

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/yarn/YarnTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/yarn/YarnTest.java
@@ -36,7 +36,7 @@ class YarnTest extends AbstractIdeContextTest {
   }
 
   @Test
-  void testYarnInstallWhenNpmInstalled(WireMockRuntimeInfo wireMockRuntimeInfo) {
+  void testYarnInstallWhenNodeInstalled(WireMockRuntimeInfo wireMockRuntimeInfo) {
 
     // arrange
     IdeTestContext context = newContext(PROJECT_YARN, wireMockRuntimeInfo);
@@ -50,6 +50,7 @@ class YarnTest extends AbstractIdeContextTest {
     // assert
     assertThat(context).logAtDebug()
         .hasMessageContaining("npm' using bash with arguments 'list' '-g' 'yarn' '--depth=0'"); // since npm was installed this should be called
+    assertThat(context).log().hasNoMessageContaining("-- yarn@");
     checkInstallation(context);
   }
 

--- a/cli/src/test/resources/ide-projects/yarn/repository/node/node/default/bin/npm
+++ b/cli/src/test/resources/ide-projects/yarn/repository/node/node/default/bin/npm
@@ -5,7 +5,7 @@ if [ "$1" = "--version" ]; then
 elif [ "$1" = "list" ] && [ "$2" = "-g" ]; then
   echo $IDE_HOME/software/node
   echo "-- $3@9.9.2"
-  exit
+  exit 1
 fi
 echo "npm $*"
 if [ "$1" == "install" ]; then


### PR DESCRIPTION
### This PR fixes #1679

### Implemented changes:

* do not fail if `npm list` gives exit code 1 (for tool not installed) since this seems normal in `npm`.
* added method `ProcessContext.withExitCodeAcceptor`
* use that method in `NpmBasedCommandlet`
* added method `ProcessContext.createChild()`
* use that method for `ToolInstallRequest` so we do not disable default exit code handling for parent tool installations
* extended test

Labeled as `internal` since the ticket was already added to CHANGELOG by PR #1680 

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`