### PR TITLE
#1673: log error instead of throwing if installation version already present

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/tool/IdeasyCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/IdeasyCommandlet.java
@@ -181,27 +181,28 @@ public class IdeasyCommandlet extends MvnBasedLocalToolCommandlet {
     Path ideasySoftwarePath = idePath.resolve(IdeContext.FOLDER_SOFTWARE).resolve(MvnRepository.ID).resolve(IdeasyCommandlet.TOOL_NAME)
         .resolve(IdeasyCommandlet.TOOL_NAME);
     Path ideasyVersionPath = ideasySoftwarePath.resolve(IdeVersion.getVersionString());
-    if (Files.isDirectory(ideasyVersionPath)) {
-      throw new CliException("IDEasy is already installed at " + ideasyVersionPath + " - if your installation is broken, delete it manually and rerun setup!");
-    }
     FileAccess fileAccess = this.context.getFileAccess();
-    List<Path> installationArtifacts = new ArrayList<>();
-    boolean success = true;
-    success &= addInstallationArtifact(cwd, "bin", true, installationArtifacts);
-    success &= addInstallationArtifact(cwd, "functions", true, installationArtifacts);
-    success &= addInstallationArtifact(cwd, "internal", true, installationArtifacts);
-    success &= addInstallationArtifact(cwd, "system", true, installationArtifacts);
-    success &= addInstallationArtifact(cwd, "IDEasy.pdf", true, installationArtifacts);
-    success &= addInstallationArtifact(cwd, "setup", true, installationArtifacts);
-    success &= addInstallationArtifact(cwd, "setup.bat", false, installationArtifacts);
-    if (!success) {
-      throw new CliException("IDEasy release is inconsistent at " + cwd);
+    if (Files.isDirectory(ideasyVersionPath)) {
+      this.context.error("IDEasy is already installed at {} - if your installation is broken, delete it manually and rerun setup!", ideasyVersionPath);
+    } else {
+      List<Path> installationArtifacts = new ArrayList<>();
+      boolean success = true;
+      success &= addInstallationArtifact(cwd, "bin", true, installationArtifacts);
+      success &= addInstallationArtifact(cwd, "functions", true, installationArtifacts);
+      success &= addInstallationArtifact(cwd, "internal", true, installationArtifacts);
+      success &= addInstallationArtifact(cwd, "system", true, installationArtifacts);
+      success &= addInstallationArtifact(cwd, "IDEasy.pdf", true, installationArtifacts);
+      success &= addInstallationArtifact(cwd, "setup", true, installationArtifacts);
+      success &= addInstallationArtifact(cwd, "setup.bat", false, installationArtifacts);
+      if (!success) {
+        throw new CliException("IDEasy release is inconsistent at " + cwd);
+      }
+      fileAccess.mkdirs(ideasyVersionPath);
+      for (Path installationArtifact : installationArtifacts) {
+        fileAccess.copy(installationArtifact, ideasyVersionPath);
+      }
+      this.context.writeVersionFile(IdeVersion.getVersionIdentifier(), ideasyVersionPath);
     }
-    fileAccess.mkdirs(ideasyVersionPath);
-    for (Path installationArtifact : installationArtifacts) {
-      fileAccess.copy(installationArtifact, ideasyVersionPath);
-    }
-    this.context.writeVersionFile(IdeVersion.getVersionIdentifier(), ideasyVersionPath);
     fileAccess.symlink(ideasyVersionPath, installationPath);
     addToShellRc(BASHRC, ideRoot, null);
     addToShellRc(ZSHRC, ideRoot, "autoload -U +X bashcompinit && bashcompinit");


### PR DESCRIPTION
### This PR fixes #1673

### Implemented changes:

* do not throw error but log error if installation version of IDEasy is already present.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`