### PR TITLE
#1737: fixed MacOS x64 release

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build native images
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
+      matrix: # ATTENTION: see also release.yml, image name are referenced in cli/src/main/assembly/*.xml files, on update do not forget to also update there
         os: [ windows-latest, ubuntu-latest, ubuntu-22.04-arm, macos-latest, macos-15 ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build native images
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
+      matrix: # ATTENTION: see also nightly-build.yml, image name are referenced in cli/src/main/assembly/*.xml files, on update do not forget to also update there
         os: [ windows-latest, ubuntu-latest, ubuntu-22.04-arm, macos-latest, macos-15 ]
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1713[#1713]: Advanced logging and writing logfiles
 * https://github.com/devonfw/IDEasy/issues/1642[#1642]: improve help output
 * https://github.com/devonfw/IDEasy/issues/1731[#1731]: Fixed SonarQube installation path resolution
+* https://github.com/devonfw/IDEasy/issues/1737[#1737]: macOS x64 release is broken
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/41?closed=1[milestone 2026.03.001].
 

--- a/cli/src/main/assembly/release-linux-arm64.xml
+++ b/cli/src/main/assembly/release-linux-arm64.xml
@@ -14,6 +14,7 @@
   </files>
   <fileSets>
     <fileSet>
+      <!-- references the matrix os image name from .github/workflows/release.yml (and nightly-build.yml) -->
       <directory>${project.build.directory}/natives-ubuntu-22.04-arm</directory>
       <outputDirectory>./bin</outputDirectory>
       <fileMode>0755</fileMode>

--- a/cli/src/main/assembly/release-linux-x64.xml
+++ b/cli/src/main/assembly/release-linux-x64.xml
@@ -14,6 +14,7 @@
   </files>
   <fileSets>
     <fileSet>
+      <!-- references the matrix os image name from .github/workflows/release.yml (and nightly-build.yml) -->
       <directory>${project.build.directory}/natives-ubuntu-latest</directory>
       <outputDirectory>./bin</outputDirectory>
       <fileMode>0755</fileMode>

--- a/cli/src/main/assembly/release-mac-arm64.xml
+++ b/cli/src/main/assembly/release-mac-arm64.xml
@@ -14,6 +14,7 @@
   </files>
   <fileSets>
     <fileSet>
+      <!-- references the matrix os image name from .github/workflows/release.yml (and nightly-build.yml) -->
       <directory>${project.build.directory}/natives-macos-latest</directory>
       <outputDirectory>./bin</outputDirectory>
       <fileMode>0755</fileMode>

--- a/cli/src/main/assembly/release-mac-x64.xml
+++ b/cli/src/main/assembly/release-mac-x64.xml
@@ -14,7 +14,8 @@
   </files>
   <fileSets>
     <fileSet>
-      <directory>${project.build.directory}/natives-macos-13</directory>
+      <!-- references the matrix os image name from .github/workflows/release.yml (and nightly-build.yml) -->
+      <directory>${project.build.directory}/natives-macos-15</directory>
       <outputDirectory>./bin</outputDirectory>
       <fileMode>0755</fileMode>
       <includes>

--- a/cli/src/main/assembly/release-win-x64.xml
+++ b/cli/src/main/assembly/release-win-x64.xml
@@ -7,13 +7,14 @@
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <files>
-	<file>
-		<source>${settings.localRepository}/com/devonfw/tools/IDEasy/ide-doc/${project.version}/ide-doc-${project.version}.pdf</source>
-		<destName>IDEasy.pdf</destName>
-	</file>
+    <file>
+      <source>${settings.localRepository}/com/devonfw/tools/IDEasy/ide-doc/${project.version}/ide-doc-${project.version}.pdf</source>
+      <destName>IDEasy.pdf</destName>
+    </file>
   </files>
   <fileSets>
     <fileSet>
+      <!-- references the matrix os image name from .github/workflows/release.yml (and nightly-build.yml) -->
       <directory>${project.build.directory}/natives-windows-latest</directory>
       <outputDirectory>./bin</outputDirectory>
       <includes>


### PR DESCRIPTION
### This PR fixes #1737

### Implemented changes:

* fixed MacOS x64 release
* added comments to reduce the risk that this will happen again
* wanted to fix that build fails if the binary file is missing, but seems not easily possible: https://stackoverflow.com/questions/42060335/maven-assembly-fail-if-file-not-found

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
