### PR TITLE
#1743: fixed mklink creation

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -493,17 +493,12 @@ public class FileAccessImpl extends HttpDownloader implements FileAccess {
       int count = getCommonNameCount(source, link);
       if (count < 1) {
         LOG.error("Cannot create relative link at {} pointing to {} - falling back to absolute link", link, source);
-        relative = false;
       } else {
         Path cwd = getPathStart(source, count - 1);
         finalSource = getPathEnd(source, count);
         finalLink = getPathEnd(link, count);
         pc.directory(cwd);
       }
-    }
-    Path parent = link.getParent();
-    if (parent == null) {
-      parent = Path.of(".");
     }
     if (type == PathLinkType.SYMBOLIC_LINK && Files.isDirectory(source)) {
       pc = pc.addArg("/j");
@@ -569,8 +564,10 @@ public class FileAccessImpl extends HttpDownloader implements FileAccess {
   public Path getPathEnd(Path path, int nameStart) {
 
     int count = path.getNameCount();
-    if (nameStart >= count) {
+    if (nameStart > count) {
       throw new IllegalArgumentException("Cannot get end after segment " + nameStart + " from path " + path + " that has only " + count + " segments.");
+    } else if (nameStart == count) {
+      return Path.of(".");
     }
     Path result = path.getName(nameStart++);
     while (nameStart < count) {

--- a/cli/src/test/java/com/devonfw/tools/ide/io/FileAccessImplTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/io/FileAccessImplTest.java
@@ -84,7 +84,7 @@ class FileAccessImplTest extends AbstractIdeContextTest {
    */
   @Test
   @EnabledOnOs(OS.WINDOWS)
-  void testSymlinkAbsoluteAsFallback(@TempDir Path tempDir) {
+  void testSymlinkFallback(@TempDir Path tempDir) {
 
     // arrange
     IdeTestContext context = new IdeTestContext();


### PR DESCRIPTION
### This PR fixes #1743

### Implemented changes:

* return "." as last path segment to avoid exception.
* renamed test method to avoid confusion since link is not created absolute but relative.
* removed dead code

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`