### PR TITLE
#1735: improve repository properties handling and logging

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/git/repository/RepositoryProperties.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/repository/RepositoryProperties.java
@@ -278,7 +278,7 @@ final class RepositoryProperties {
       if (!linkTarget.isEmpty()) {
         linkTarget = sanatizeRelativePath(linkTarget, PROPERTY_LINK_TARGET);
       }
-      if (linkPath != null) {
+      if ((linkPath != null) && (linkTarget != null)) {
         links.add(new RepositoryLink(linkPath, linkTarget));
       }
     }


### PR DESCRIPTION
### This PR improves the logging for #1735 from PR #1739

### Implemented changes:

During test of #1739 we were observing this log message:
```
Invalid path  from D:\projects\ai\settings\repositories\ai-instructions.properties
```
This was confusing since the `path` property in that properties file was not empty.

* fixed problem to avoid pointless warning (link target may be empty)
* if the warning is generated include the property name where the value was taken from

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`