### PR TITLE
Close FileOutputStream in downloadFileWithProgress

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -172,21 +172,22 @@ public class FileAccessImpl extends HttpDownloader implements FileAccess {
     int count;
 
     try (InputStream body = response.body();
-        FileOutputStream fileOutput = new FileOutputStream(target.toFile());
-        BufferedOutputStream bufferedOut = new BufferedOutputStream(fileOutput, data.length);
-        IdeProgressBar pb = this.context.newProgressBarForDownload(contentLength)) {
-      while (!fileComplete) {
-        count = body.read(data);
-        if (count <= 0) {
-          fileComplete = true;
-        } else {
-          bufferedOut.write(data, 0, count);
-          pb.stepBy(count);
+        try (FileOutputStream fileOutput = new FileOutputStream(target.toFile())) {
+                    BufferedOutputStream bufferedOut = new BufferedOutputStream(fileOutput, data.length);
+                    IdeProgressBar pb = this.context.newProgressBarForDownload(contentLength)) {
+                  while (!fileComplete) {
+                    count = body.read(data);
+                    if (count <= 0) {
+                      fileComplete = true;
+                    } else {
+                      bufferedOut.write(data, 0, count);
+                      pb.stepBy(count);
+                    }
+                  }
+                } catch (Exception e) {
+                  throw new RuntimeException(e);
+                }
         }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
   }
 
   private void copyFileWithProgressBar(Path source, Path target) {


### PR DESCRIPTION
downloadFileWithProgressBar is close, but the resource opened there can leak if downloadFileWithProgressBar exits on an error path. I moved the allocation into try-with-resources so cleanup happens on every exit path.