### PR TITLE
#1761: exclude BETA_OR_BUILD from development phases

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionPhase.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionPhase.java
@@ -9,7 +9,7 @@ public enum VersionPhase implements AbstractVersionPhase {
   UNDEFINED,
 
   /** A revision number (actually not a development phase like {@link #UNDEFINED}). */
-  REVISION(Boolean.TRUE, "revision", "rev"),
+  REVISION(Boolean.TRUE, "revision", "rev", "u"),
 
   /** Unstable marker - see {@link VersionSegment#PATTERN_MATCH_ANY_VERSION}. */
   UNSTABLE(Boolean.FALSE, "!"),
@@ -97,7 +97,7 @@ public enum VersionPhase implements AbstractVersionPhase {
    */
   public boolean isValid(int number) {
 
-    if ((this == UNDEFINED) || (this == BETA_OR_BUILD)) {
+    if (this == UNDEFINED) {
       return false;
     }
     if (this.hasNumber != null) {

--- a/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
@@ -61,7 +61,7 @@ class VersionIdentifierTest extends Assertions {
    */
   @ParameterizedTest
   // arrange
-  @ValueSource(strings = { "1.0", "0.1", "2023.08.001", "2023-06-M1", "11.0.4_11.4", "5.2.23.RELEASE" })
+  @ValueSource(strings = { "1.0", "0.1", "2023.08.001", "2023-06-M1", "11.0.4_11.4", "5.2.23.RELEASE", "8u412b08" })
   void testValid(String version) {
 
     // act
@@ -78,7 +78,7 @@ class VersionIdentifierTest extends Assertions {
    */
   @ParameterizedTest
   // arrange
-  @ValueSource(strings = { "0", "0.0", "1.0.pineapple-pen", "1.0-rc", ".1.0", "1.-0", "RC1", "Beta1", "donut", "8u412b08", "0*.0", "*0", "*.", "17.*alpha",
+  @ValueSource(strings = { "0", "0.0", "1.0.pineapple-pen", "1.0-rc", ".1.0", "1.-0", "RC1", "Beta1", "donut", "0*.0", "*0", "*.", "17.*alpha",
       "17*.1" })
   void testInvalid(String version) {
 


### PR DESCRIPTION
### This PR fixes [#1761](https://github.com/devonfw/IDEasy/issues/1761)

### Implemented changes:

* Excluded BETA_OR_BUILD from development phases to ensure legacy Java 8 version patterns are correctly recognized as stable during installation.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)