### PR TITLE
#402: docker/rancher .zip for macos arm64 to .dmg

### DIFF
--- a/url-updater/src/main/java/com/devonfw/tools/ide/url/tool/docker/DockerRancherDesktopUrlUpdater.java
+++ b/url-updater/src/main/java/com/devonfw/tools/ide/url/tool/docker/DockerRancherDesktopUrlUpdater.java
@@ -45,7 +45,7 @@ public class DockerRancherDesktopUrlUpdater extends GithubUrlTagUpdater {
 
     doAddVersion(urlVersion, baseUrl + "Rancher.Desktop.Setup.${version}.msi", WINDOWS);
     doAddVersion(urlVersion, baseUrl + "Rancher.Desktop-${version}.x86_64.dmg", MAC, X64);
-    doAddVersion(urlVersion, baseUrl + "Rancher.Desktop-${version}-aarch64.dmg", MAC, ARM64);
+    doAddVersion(urlVersion, baseUrl + "Rancher.Desktop-${version}.aarch64.dmg", MAC, ARM64);
     doAddVersion(urlVersion, baseUrl + "rancher-desktop-linux-v${version}.zip", LINUX);
 
   }


### PR DESCRIPTION
### This PR fixes #402 

### Implemented changes:

* changed installer url for Mac ARM from `.zip` to `.dmg`

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`