### PR TITLE
#1799: Add support for file URL in GitUrl validation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 Release with new features and bugfixes:
 
 * https://github.com/devonfw/IDEasy/issues/1552[#1552]: Add Commandlet to fix TLS issue
+* https://github.com/devonfw/IDEasy/issues/1799[#1799]: Add support for file URL in GitUrl validation for local development
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/43?closed=1[milestone 2026.04.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitUrl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitUrl.java
@@ -60,13 +60,13 @@ public record GitUrl(String url, String branch) {
   }
 
   /**
-   * @return {@code true} if the URL starts with http://, https://, ssh:// or git@ - otherwise returns {@code false}.
+   * @return {@code true} if the URL starts with http://, https://, ssh://, git@ or file:// - otherwise returns {@code false}.
    */
   public boolean isValid() {
     if (url == null || url.isBlank()) {
       return false;
     }
-    return url.startsWith("http://") || url.startsWith("https://") || url.startsWith("ssh://") || url.startsWith("git@");
+    return url.startsWith("http://") || url.startsWith("https://") || url.startsWith("ssh://") || url.startsWith("git@") || url.startsWith("file://");
   }
 
   @Override


### PR DESCRIPTION
### This PR fixes [#1799](https://github.com/devonfw/IDEasy/issues/1799)

### Implemented changes:

* Extend Git URL support to include local repositories via file:// URLs

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
