### PR TITLE
#1815: Suppress update notification while updating

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1552[#1552]: Add Commandlet to fix TLS issue
 * https://github.com/devonfw/IDEasy/issues/1799[#1799]: Add support for file URL in GitUrl validation for local development
 * https://github.com/devonfw/IDEasy/issues/1760[#1760]: Accept empty input for single option
+* https://github.com/devonfw/IDEasy/issues/1815[#1815]: Suppress Update notification while updating
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/43?closed=1[milestone 2026.04.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -1296,19 +1296,11 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
             if (getGitContext().isRepositoryUpdateAvailable(settingsRepository, getSettingsCommitIdPath()) || (
                 getGitContext().fetchIfNeeded(settingsRepository) && getGitContext().isRepositoryUpdateAvailable(
                     settingsRepository, getSettingsCommitIdPath()))) {
-              
-              if (isSettingsRepositorySymlinkOrJunction()) {
-                if (!(cmd instanceof UpdateCommandlet) && isForceMode()) {
-                  // Only print the update nag if the user did not explicitly call "ide -f update" to prevent confusion when the user already wants to apply the updates.
-                  String msg = "Updates are available for the settings repository. Please pull the latest changes by yourself or by calling \"ide -f update\" to apply them.";
-                  IdeLogLevel.INTERACTION.log(LOG, msg);
-                }
-              } else {
-                if (!(cmd instanceof UpdateCommandlet)) {
-                  // Only print the update nag if the user did not explicitly call "ide update" to prevent confusion when the user already wants to apply the updates.
-                  String msg = "Updates are available for the settings repository. If you want to apply the latest changes, call \"ide update\"";
-                  IdeLogLevel.INTERACTION.log(LOG, msg);
-                }
+
+              // Inform the user that an update is available. The update message is suppressed if we are already running the update
+              String msg = determineSettingsUpdateMessage(cmd);
+              if (msg != null) {
+                IdeLogLevel.INTERACTION.log(LOG, msg);
               }
             }
           }
@@ -1327,6 +1319,29 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
       LOG.trace("Commandlet did not match");
     }
     return result;
+  }
+
+
+  /**
+   * When an update is available for the settings repository, we log a message to the console, reminding the user to run {@code ide update}.
+   * This method determines the correct message to log, depending on whether the settings repository is a symlink/junction, or not.
+   * Should the user already be running the appropriate {@code ide update} command, the message is suppressed to avoid confusion.
+   *
+   * @param cmd the {@link Commandlet}.
+   * @return {@code msg} to log to the console. {@code null} if the message is suppressed.
+   */
+  private String determineSettingsUpdateMessage(Commandlet cmd) {
+    if (isSettingsRepositorySymlinkOrJunction()) {
+      if ((cmd instanceof UpdateCommandlet) && isForceMode()) {
+        return null;
+      }
+      return "Updates are available for the settings repository. Please pull the latest changes by yourself or by calling \"ide -f update\" to apply them.";
+    } else {
+      if (cmd instanceof UpdateCommandlet) {
+        return null;
+      }
+      return "Updates are available for the settings repository. If you want to apply the latest changes, call \"ide update\"";
+    }
   }
 
   private boolean ensureLicenseAgreement(Commandlet cmd) {

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -1295,13 +1295,19 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
             if (getGitContext().isRepositoryUpdateAvailable(settingsRepository, getSettingsCommitIdPath()) || (
                 getGitContext().fetchIfNeeded(settingsRepository) && getGitContext().isRepositoryUpdateAvailable(
                     settingsRepository, getSettingsCommitIdPath()))) {
-              String msg;
               if (isSettingsRepositorySymlinkOrJunction()) {
-                msg = "Updates are available for the settings repository. Please pull the latest changes by yourself or by calling \"ide -f update\" to apply them.";
+                if (!(arguments.getInitialArgument().get().equals("update") && isForceMode())) {
+                  // Only print the update nag if the user did not explicitly call "ide -f update" to prevent confusion when the user already wants to apply the updates.
+                  String msg = "Updates are available for the settings repository. Please pull the latest changes by yourself or by calling \"ide -f update\" to apply them.";
+                  IdeLogLevel.INTERACTION.log(LOG, msg);
+                }
               } else {
-                msg = "Updates are available for the settings repository. If you want to apply the latest changes, call \"ide update\"";
+                if (!arguments.getInitialArgument().get().equals("update")) {
+                  // Only print the update nag if the user did not explicitly call "ide update" to prevent confusion when the user already wants to apply the updates.
+                  String msg = "Updates are available for the settings repository. If you want to apply the latest changes, call \"ide update\"";
+                  IdeLogLevel.INTERACTION.log(LOG, msg);
+                }
               }
-              IdeLogLevel.INTERACTION.log(LOG, msg);
             }
           }
         }

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -34,6 +34,7 @@ import com.devonfw.tools.ide.commandlet.CommandletManager;
 import com.devonfw.tools.ide.commandlet.CommandletManagerImpl;
 import com.devonfw.tools.ide.commandlet.ContextCommandlet;
 import com.devonfw.tools.ide.commandlet.EnvironmentCommandlet;
+import com.devonfw.tools.ide.commandlet.UpdateCommandlet;
 import com.devonfw.tools.ide.common.SystemPath;
 import com.devonfw.tools.ide.completion.CompletionCandidate;
 import com.devonfw.tools.ide.completion.CompletionCandidateCollector;
@@ -1295,14 +1296,15 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
             if (getGitContext().isRepositoryUpdateAvailable(settingsRepository, getSettingsCommitIdPath()) || (
                 getGitContext().fetchIfNeeded(settingsRepository) && getGitContext().isRepositoryUpdateAvailable(
                     settingsRepository, getSettingsCommitIdPath()))) {
+              
               if (isSettingsRepositorySymlinkOrJunction()) {
-                if (!(arguments.getInitialArgument().get().equals("update") && isForceMode())) {
+                if (!(cmd instanceof UpdateCommandlet) && isForceMode()) {
                   // Only print the update nag if the user did not explicitly call "ide -f update" to prevent confusion when the user already wants to apply the updates.
                   String msg = "Updates are available for the settings repository. Please pull the latest changes by yourself or by calling \"ide -f update\" to apply them.";
                   IdeLogLevel.INTERACTION.log(LOG, msg);
                 }
               } else {
-                if (!arguments.getInitialArgument().get().equals("update")) {
+                if (!(cmd instanceof UpdateCommandlet)) {
                   // Only print the update nag if the user did not explicitly call "ide update" to prevent confusion when the user already wants to apply the updates.
                   String msg = "Updates are available for the settings repository. If you want to apply the latest changes, call \"ide update\"";
                   IdeLogLevel.INTERACTION.log(LOG, msg);


### PR DESCRIPTION
### This PR fixes #1815 

### Implemented changes:

* IDEasy will no longer inform users about an update while running `ide update`

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`

