### PR TITLE
#1050: add lazydocker dependencies

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1552[#1552]: Add Commandlet to fix TLS issue
 * https://github.com/devonfw/IDEasy/issues/1799[#1799]: Add support for file URL in GitUrl validation for local development
 * https://github.com/devonfw/IDEasy/issues/1760[#1760]: Accept empty input for single option
+* https://github.com/devonfw/IDEasy/issues/1050[#1050]: Introduce dependencies.json for LazyDocker and remove hardcoded dependency
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/43?closed=1[milestone 2026.04.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/LocalToolCommandlet.java
@@ -77,18 +77,10 @@ public abstract class LocalToolCommandlet extends ToolCommandlet {
     return false;
   }
 
-  /**
-   * @deprecated will be removed once all "dependencies.json" are created in ide-urls.
-   */
-  @Deprecated
-  protected void installDependencies() {
-
-  }
 
   @Override
   protected ToolInstallation doInstall(ToolInstallRequest request) {
 
-    installDependencies();
     Step step = request.getStep();
     if (step == null) {
       return doInstallStep(request);

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/lazydocker/LazyDocker.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/lazydocker/LazyDocker.java
@@ -2,26 +2,15 @@ package com.devonfw.tools.ide.tool.lazydocker;
 
 import java.util.Set;
 
-import com.devonfw.tools.ide.cli.CliException;
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
-import com.devonfw.tools.ide.log.IdeLogLevel;
-import com.devonfw.tools.ide.process.ProcessContext;
-import com.devonfw.tools.ide.process.ProcessErrorHandling;
-import com.devonfw.tools.ide.process.ProcessMode;
-import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
-import com.devonfw.tools.ide.tool.docker.Docker;
-import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
  * {@link ToolCommandlet} for <a href="https://github.com/jesseduffield/lazydocker">lazydocker</a>.
  */
 public class LazyDocker extends LocalToolCommandlet {
-
-  private static final VersionIdentifier MIN_API_VERSION = VersionIdentifier.of("1.25");
-  private static final VersionIdentifier MIN_COMPOSE_VERSION = VersionIdentifier.of("1.23.2");
 
   /**
    * The constructor.
@@ -31,42 +20,6 @@ public class LazyDocker extends LocalToolCommandlet {
   public LazyDocker(IdeContext context) {
 
     super(context, "lazydocker", Set.of(Tag.DOCKER, Tag.ADMIN));
-  }
-
-  @Override
-  protected void installDependencies() {
-
-    // TODO create lazydocker/lazydocker/dependencies.json file in ide-urls and delete this method
-    getCommandlet(Docker.class).install();
-    // verify docker API version requirements
-    ProcessContext pc = this.context.newProcess().errorHandling(ProcessErrorHandling.NONE).executable("docker").addArg("version").addArg("--format")
-        .addArg("'{{.Client.APIVersion}}'");
-    ProcessResult result = pc.run(ProcessMode.DEFAULT_CAPTURE);
-    verifyDockerVersion(result, MIN_API_VERSION, "docker API");
-
-    // verify docker compose version requirements
-    pc = this.context.newProcess().errorHandling(ProcessErrorHandling.NONE).executable("docker-compose").addArg("version").addArg("--short");
-    result = pc.run(ProcessMode.DEFAULT_CAPTURE);
-    verifyDockerVersion(result, MIN_COMPOSE_VERSION, "docker-compose");
-  }
-
-  private void verifyDockerVersion(ProcessResult result, VersionIdentifier minimumVersion, String kind) {
-    // we have this pattern a lot that we want to get a single line output of a successful ProcessResult.
-    // we should create a generic method in ProcessResult for this use-case.
-    if (!result.isSuccessful()) {
-      result.log(IdeLogLevel.WARNING);
-    }
-    if (result.getOut().isEmpty()) {
-      throw new CliException("Docker is not installed, but required for lazydocker.\n" //
-          + "To install docker, call the following command:\n" //
-          + "ide install docker");
-    }
-    VersionIdentifier installedVersion = VersionIdentifier.of(result.getOut().get(0).toString());
-    if (installedVersion.isLess(minimumVersion)) {
-      throw new CliException("The installed " + kind + " version is '" + installedVersion + "'.\n" + //
-          "But lazydocker requires at least " + kind + " version '" + minimumVersion + "'.\n" //
-          + "Please upgrade your installation of docker, before installing lazydocker.");
-    }
   }
 
 }


### PR DESCRIPTION
### This PR fixes [#1050](https://github.com/devonfw/IDEasy/issues/1050)

### Implemented changes:

* Deleted deprecated method installDependencies and the used verifyDockerVersion
* Created dependencies.json for LazyDocker in ide-urls (see https://github.com/devonfw/ide-urls/pull/38)
* Updated Changelog

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`