### PR TITLE
#1693: Soft-delete corrupted repo after confirmation on 'ide update'

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1552[#1552]: Add Commandlet to fix TLS issue
 * https://github.com/devonfw/IDEasy/issues/1799[#1799]: Add support for file URL in GitUrl validation for local development
 * https://github.com/devonfw/IDEasy/issues/1760[#1760]: Accept empty input for single option
+* https://github.com/devonfw/IDEasy/issues/1693[#1693]: Fix behavior when there's no settings repo (.../settings/.git)
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/43?closed=1[milestone 2026.04.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -176,7 +176,7 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
     GitContext gitContext = this.context.getGitContext();
     // here we do not use pullOrClone to prevent asking a pointless question for repository URL...
     if (Files.isDirectory(settingsPath) && this.context.getGitContext().isGitRepo(settingsPath)) {
-      if (this.context.isForcePull() || this.context.isForceMode() || Files.isDirectory(settingsPath.resolve(GitContext.GIT_FOLDER))) {
+      if (this.context.isForcePull() || this.context.isForceMode()) {
         if (gitContext.hasUntrackedFiles(settingsPath)) {
           gitContext.pullSafelyWithStash(settingsPath);
         } else {

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -175,7 +175,7 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
     Path settingsPath = this.context.getSettingsPath();
     GitContext gitContext = this.context.getGitContext();
     // here we do not use pullOrClone to prevent asking a pointless question for repository URL...
-    if (Files.isDirectory(settingsPath) && this.context.getGitContext().isGitRepo(settingsPath)) {
+    if (Files.isDirectory(settingsPath) && this.context.getGitContext().isGitRepo(settingsPath) || this.context.isSettingsRepositorySymlinkOrJunction()) {
       if (this.context.isForcePull() || this.context.isForceMode()) {
         if (gitContext.hasUntrackedFiles(settingsPath)) {
           gitContext.pullSafelyWithStash(settingsPath);

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -188,16 +188,10 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
       }
     } else {
       if (!this.context.getFileAccess().isEmptyDir(settingsPath)) {
-        String answer =
-          this.context.askForInput(
-            "Your settings repository can be updated, but this will override local changes. The "
-            + "settings contents will be backed up. Do you want to proceed?",
-            "Y/n"
-          );
-
-        if (answer.toLowerCase().equals("n")) {
-          return;
-        }
+        this.context.askToContinue(
+          "Your settings repository can be updated, but this will override local changes. The "
+          + "settings contents will be backed up. Do you want to proceed?"
+        );
 
         this.context.getFileAccess().backup(settingsPath);
       }

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -189,8 +189,8 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
     } else {
       if (!this.context.getFileAccess().isEmptyDir(settingsPath)) {
         this.context.askToContinue(
-          "Your settings repository can be updated, but this will override local changes. The "
-          + "settings contents will be backed up. Do you want to proceed?"
+          "Your settings repository seems to be broken ('.git' folder not present). We can fix this by moving "
+          + " your settings the backed up. You will be asked for the settings git URL and your settings will be cloned from scratch. Do you want to proceed?"
         );
 
         this.context.getFileAccess().backup(settingsPath);

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -175,7 +175,7 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
     Path settingsPath = this.context.getSettingsPath();
     GitContext gitContext = this.context.getGitContext();
     // here we do not use pullOrClone to prevent asking a pointless question for repository URL...
-    if (Files.isDirectory(settingsPath) && this.context.getSettingsGitRepository() != null) {
+    if (Files.isDirectory(settingsPath) && this.context.getGitContext().isGitRepo(settingsPath)) {
       if (this.context.isForcePull() || this.context.isForceMode() || Files.isDirectory(settingsPath.resolve(GitContext.GIT_FOLDER))) {
         if (gitContext.hasUntrackedFiles(settingsPath)) {
           gitContext.pullSafelyWithStash(settingsPath);

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -175,7 +175,7 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
     Path settingsPath = this.context.getSettingsPath();
     GitContext gitContext = this.context.getGitContext();
     // here we do not use pullOrClone to prevent asking a pointless question for repository URL...
-    if (Files.isDirectory(settingsPath) && !this.context.getFileAccess().isEmptyDir(settingsPath)) {
+    if (Files.isDirectory(settingsPath) && this.context.getSettingsGitRepository() != null) {
       if (this.context.isForcePull() || this.context.isForceMode() || Files.isDirectory(settingsPath.resolve(GitContext.GIT_FOLDER))) {
         if (gitContext.hasUntrackedFiles(settingsPath)) {
           gitContext.pullSafelyWithStash(settingsPath);

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/AbstractUpdateCommandlet.java
@@ -187,6 +187,21 @@ public abstract class AbstractUpdateCommandlet extends Commandlet {
         LOG.info("Skipping git pull in settings due to code repository. Use --force-pull to enforce pulling.");
       }
     } else {
+      if (!this.context.getFileAccess().isEmptyDir(settingsPath)) {
+        String answer =
+          this.context.askForInput(
+            "Your settings repository can be updated, but this will override local changes. The "
+            + "settings contents will be backed up. Do you want to proceed?",
+            "Y/n"
+          );
+
+        if (answer.toLowerCase().equals("n")) {
+          return;
+        }
+
+        this.context.getFileAccess().backup(settingsPath);
+      }
+
       GitUrl gitUrl = getOrAskSettingsUrl();
       checkProjectNameConvention(gitUrl.getProjectName());
       initializeRepository(gitUrl);

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitContext.java
@@ -61,7 +61,13 @@ public interface GitContext {
    */
   boolean fetchIfNeeded(Path repository, String remoteName, String branch);
 
-  boolean isGitRepo(Path repository);
+  /**
+   * Checks if the given `repository` is a valid Git repository.
+   * 
+   * @param directory the {@link Path} to the directory to check for repo status
+   * @return {@code true} if `directory` is a Git repo, {@code false} otherwise
+   */
+  boolean isGitRepo(Path directory);
 
   /**
    * Checks if there are updates available for the Git repository in the specified target folder by comparing the local commit hash with the remote commit

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitContext.java
@@ -62,8 +62,6 @@ public interface GitContext {
   boolean fetchIfNeeded(Path repository, String remoteName, String branch);
 
   /**
-   * Checks if the given `repository` is a valid Git repository.
-   * 
    * @param directory the {@link Path} to the directory to check for repo status
    * @return {@code true} if `directory` is a Git repo, {@code false} otherwise
    */

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitContext.java
@@ -61,6 +61,8 @@ public interface GitContext {
    */
   boolean fetchIfNeeded(Path repository, String remoteName, String branch);
 
+  boolean isGitRepo(Path repository);
+
   /**
    * Checks if there are updates available for the Git repository in the specified target folder by comparing the local commit hash with the remote commit
    * hash.

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
@@ -354,8 +354,8 @@ public class GitContextImpl implements GitContext {
   }
 
   @Override
-  public boolean isGitRepo(Path repository) {
-    return repository != null && Files.exists(repository.resolve(".git"));
+  public boolean isGitRepo(Path directory) {
+    return directory != null && Files.exists(directory.resolve(".git"));
   }
 
   private Path findGitOnWindowsViaBash() {

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
@@ -353,6 +353,11 @@ public class GitContextImpl implements GitContext {
     return gitPath;
   }
 
+  @Override
+  public boolean isGitRepo(Path repository) {
+    return repository != null && Files.exists(repository.resolve(".git"));
+  }
+
   private Path findGitOnWindowsViaBash() {
     Path gitPath;
     Path bashBinary = this.context.findBashRequired();

--- a/cli/src/test/java/com/devonfw/tools/ide/git/GitContextMock.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/git/GitContextMock.java
@@ -1,5 +1,6 @@
 package com.devonfw.tools.ide.git;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -85,6 +86,11 @@ public class GitContextMock implements GitContext {
   public boolean fetchIfNeeded(Path repository) {
 
     return false;
+  }
+
+  @Override
+  public boolean isGitRepo(Path repository) {
+    return true;
   }
 
   @Override

--- a/cli/src/test/java/com/devonfw/tools/ide/git/GitContextMock.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/git/GitContextMock.java
@@ -89,7 +89,7 @@ public class GitContextMock implements GitContext {
   }
 
   @Override
-  public boolean isGitRepo(Path repository) {
+  public boolean isGitRepo(Path directory) {
     return true;
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/git/GitContextTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/git/GitContextTest.java
@@ -183,6 +183,29 @@ class GitContextTest extends AbstractIdeContextTest {
     assertThat(tempDir.resolve("new-folder")).doesNotExist();
   }
 
+  @Test
+  void testGitRepoIsRecognizedCorrectly(@TempDir Path tempDir) {
+    String gitRepoUrl = "https://github.com/test";
+    
+    IdeTestContext context = newGitContext(tempDir);
+    GitContext gitContext = context.getGitContext();
+
+    gitContext.pullOrCloneAndResetIfNeeded(GitUrl.ofMain(gitRepoUrl), tempDir, "origin");
+
+    assertThat(gitContext.isGitRepo(tempDir)).isTrue();
+  }
+
+  @Test
+  void testNormalDirIsNoRepo(@TempDir Path tempDir) {
+    IdeTestContext context = newGitContext(tempDir);
+    GitContext gitContext = context.getGitContext();
+    
+    FileAccess fileAccess = context.getFileAccess();
+    fileAccess.mkdirs(tempDir.resolve("new-folder"));
+
+    assertThat(gitContext.isGitRepo(tempDir)).isFalse();
+  }
+
   /**
    * Test for fetchIfNeeded when the system is offline.
    *


### PR DESCRIPTION
### This PR fixes #1693 

### Implemented changes:
When the `.git` folder in the settings repo is deleted, `ide update` will prompt for reinitialization. If the user confirms, the current settings directory is backed up before removal and then reinitialized.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
