### PR TITLE
#906: Add feature configurable intellij vm args

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1552[#1552]: Add Commandlet to fix TLS issue
 * https://github.com/devonfw/IDEasy/issues/1799[#1799]: Add support for file URL in GitUrl validation for local development
 * https://github.com/devonfw/IDEasy/issues/1760[#1760]: Accept empty input for single option
+* https://github.com/devonfw/IDEasy/issues/1820[#1820]: Introduce ide variable INTELLIJ_VM_ARGS to configure jvm options for IntelliJ.
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/43?closed=1[milestone 2026.04.002].
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,7 +9,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1552[#1552]: Add Commandlet to fix TLS issue
 * https://github.com/devonfw/IDEasy/issues/1799[#1799]: Add support for file URL in GitUrl validation for local development
 * https://github.com/devonfw/IDEasy/issues/1760[#1760]: Accept empty input for single option
-* https://github.com/devonfw/IDEasy/issues/1820[#1820]: Introduce ide variables INTELLIJ_VM_ARGS, ANDROID_STUDIO_VM_ARGS and PYCHARM_VM_ARGS to configure jvm options for IntelliJ, Android Studio and Pycharm.
+* https://github.com/devonfw/IDEasy/issues/906[#906]: Introduce variables INTELLIJ_VM_ARGS, ANDROID_STUDIO_VM_ARGS and PYCHARM_VM_ARGS to configure jvm options for JetBrains
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/43?closed=1[milestone 2026.04.002].
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,7 +9,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1552[#1552]: Add Commandlet to fix TLS issue
 * https://github.com/devonfw/IDEasy/issues/1799[#1799]: Add support for file URL in GitUrl validation for local development
 * https://github.com/devonfw/IDEasy/issues/1760[#1760]: Accept empty input for single option
-* https://github.com/devonfw/IDEasy/issues/1820[#1820]: Introduce ide variable INTELLIJ_VM_ARGS to configure jvm options for IntelliJ.
+* https://github.com/devonfw/IDEasy/issues/1820[#1820]: Introduce ide variables INTELLIJ_VM_ARGS, ANDROID_STUDIO_VM_ARGS and PYCHARM_VM_ARGS to configure jvm options for IntelliJ, Android Studio and Pycharm.
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/43?closed=1[milestone 2026.04.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/androidstudio/AndroidStudio.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/androidstudio/AndroidStudio.java
@@ -52,6 +52,12 @@ public class AndroidStudio extends IdeaBasedIdeToolCommandlet {
   }
 
   @Override
+  protected String getIdeProductPrefix() {
+
+    return STUDIO;
+  }
+
+  @Override
   public void setEnvironment(EnvironmentContext environmentContext, ToolInstallation toolInstallation, boolean additionalInstallation) {
 
     super.setEnvironment(environmentContext, toolInstallation, additionalInstallation);

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -181,7 +181,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     return arg;
   }
 
-  private boolean sameJvmKey(String a, String b) {
+  private boolean isJvmKeySimilar(String a, String b) {
 
     return extractJvmOptionsKey(a).equals(extractJvmOptionsKey(b));
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -143,7 +143,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
           break;
         }
       }
-      if (!replaced) { // in case of arg does not exist in default options
+      if (!replaced) { // Extend case: user configured arg does not exist in default options
         result.add(userArg);
       }
     }
@@ -153,17 +153,29 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
 
   private String extractJvmOptionsKey(String arg) {
 
-    // Only options with clear override semantics are merged.
-    // All other JVM arguments are treated as atomic flags by design.
     if (arg.startsWith("-Xmx")) {
       return "-Xmx";
     }
     if (arg.startsWith("-Xms")) {
       return "-Xms";
     }
-    if (arg.startsWith("-XX:") || arg.startsWith("-D")) {
+    if (arg.startsWith("-Xmn")) {
+      return "-Xmn";
+    }
+    if (arg.startsWith("-Xss")) {
+      return "-Xss";
+    }
+    if (arg.startsWith("-D")) {
       int eq = arg.indexOf('=');
       return eq > 0 ? arg.substring(0, eq) : arg;
+    }
+    if (arg.startsWith("-XX:")) {
+      String opt = arg.substring(4);
+      if (opt.startsWith("+") || opt.startsWith("-")) {
+        return "-XX:" + opt.substring(1);
+      }
+      int eq = opt.indexOf('=');
+      return eq > 0 ? "-XX:" + opt.substring(0, eq) : arg;
     }
 
     return arg;

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -27,6 +27,12 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
 
   private static final Logger LOG = LoggerFactory.getLogger(IdeaBasedIdeToolCommandlet.class);
 
+  private static final String VM_OPTIONS_FILE_EXTENSION = ".vmoptions";
+
+  private static final String VM_ARGS_ENV_SUFFIX = "_VM_ARGS";
+
+  private static final String VM_OPTIONS_ENV_SUFFIX = "_VM_OPTIONS";
+
   /**
    * The constructor.
    *
@@ -78,7 +84,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
   public ProcessResult runTool(ProcessContext pc, ProcessMode processMode, List<String> args) {
     args.add(this.context.getWorkspacePath().toString());
 
-    String variableName = getName().toUpperCase(Locale.ROOT).replace("-", "_") + "_VM_ARGS";
+    String variableName = getName().toUpperCase(Locale.ROOT).replace("-", "_") + VM_ARGS_ENV_SUFFIX;
     String userVmArgsContent = this.context.getVariables().get(variableName);
     if (userVmArgsContent == null || userVmArgsContent.isEmpty()) {
       return super.runTool(pc, processMode, args);
@@ -94,11 +100,11 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     }
     String[] defaultVmArgs = defaultVmArgsContent.trim().split("\\s+");
 
-    String userOptionsFileName = "." + prefix + ".vmoptions";
+    String userOptionsFileName = "." + prefix + VM_OPTIONS_FILE_EXTENSION;
     Path confPath = this.context.getWorkspacePath().resolve(userOptionsFileName);
     this.context.getFileAccess().writeFileContent(mergeVmArgs(defaultVmArgs, userVmArgs), confPath, true);
 
-    pc.withEnvVar(prefix.toUpperCase() + "_VM_OPTIONS", confPath.toAbsolutePath().toString());
+    pc.withEnvVar(prefix.toUpperCase() + VM_OPTIONS_ENV_SUFFIX, confPath.toAbsolutePath().toString());
     return super.runTool(pc, processMode, args);
   }
 
@@ -111,7 +117,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     if (this.context.getSystemInfo().isWindows()) {
       return softwarePath
           .resolve("bin")
-          .resolve(ideProductPrefix + "64.exe.vmoptions");
+          .resolve(ideProductPrefix + "64.exe" + VM_OPTIONS_FILE_EXTENSION);
     }
 
     if (this.context.getSystemInfo().isMac()) {
@@ -119,7 +125,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
         return softwarePath.toRealPath()
             .getParent()
             .resolve("bin")
-            .resolve(ideProductPrefix + ".vmoptions");
+            .resolve(ideProductPrefix + VM_OPTIONS_FILE_EXTENSION);
       } catch (Exception e) {
         LOG.error("Failed to resolve real path for software path: {}", softwarePath, e);
       }
@@ -127,7 +133,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
 
     return softwarePath // Linux
         .resolve("bin")
-        .resolve(ideProductPrefix + "64.vmoptions");
+        .resolve(ideProductPrefix + "64" + VM_OPTIONS_FILE_EXTENSION);
   }
 
   private String mergeVmArgs(String[] defaults, String[] userArgs) {
@@ -137,7 +143,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     for (String userArg : userArgs) {
       boolean replaced = false;
       for (int i = 0; i < result.size(); i++) {
-        if (sameJvmKey(result.get(i), userArg)) {
+        if (isSameJvmKey(result.get(i), userArg)) {
           result.set(i, userArg); //override default arg with user defined arg
           replaced = true;
           break;
@@ -181,7 +187,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     return arg;
   }
 
-  private boolean isJvmKeySimilar(String a, String b) {
+  private boolean isSameJvmKey(String a, String b) {
 
     return extractJvmOptionsKey(a).equals(extractJvmOptionsKey(b));
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -1,7 +1,10 @@
 package com.devonfw.tools.ide.tool.ide;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -57,9 +60,113 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     }
   }
 
+  /**
+   * Returns the IDE product prefix used in various files inside the {@code bin} directory, e.g. {@code "idea"} for {@code idea64.exe} or {@code "studio"} for
+   * {@code studio64.vmoptions}.
+   * <p>
+   * By default, this method returns the tool name ({@link #getName()}). Subclasses may override this method if the IDE binary or vmoptions file uses a more
+   * specific or different prefix.
+   *
+   * @return the IDE product prefix
+   */
+  protected String getIdeProductPrefix() {
+
+    return getName();
+  }
+
   @Override
-  public ProcessResult runTool(List<String> args) {
+  public ProcessResult runTool(ProcessContext pc, ProcessMode processMode, List<String> args) {
     args.add(this.context.getWorkspacePath().toString());
-    return super.runTool(args);
+
+    String variableName = getName().toUpperCase(Locale.ROOT).replace("-", "_") + "_VM_ARGS";
+    String userVmArgsContent = this.context.getVariables().get(variableName);
+    if (userVmArgsContent == null || userVmArgsContent.isEmpty()) {
+      return super.runTool(pc, processMode, args);
+    }
+    String[] userVmArgs = userVmArgsContent.trim().split("\\s+");
+
+    String prefix = getIdeProductPrefix();
+    Path defaultVmOptionsPath = resolveDefaultVmOptionsPath(this.getToolPath(), prefix);
+    String defaultVmArgsContent = this.context.getFileAccess().readFileContent(defaultVmOptionsPath);
+    if (defaultVmArgsContent == null || defaultVmArgsContent.isEmpty()) {
+      LOG.debug("Default {} jvm options not found at: {}", getName(), defaultVmOptionsPath);
+      return super.runTool(pc, processMode, args);
+    }
+    String[] defaultVmArgs = defaultVmArgsContent.trim().split("\\s+");
+
+    String userOptionsFileName = "." + prefix + ".vmoptions";
+    Path confPath = this.context.getWorkspacePath().resolve(userOptionsFileName);
+    this.context.getFileAccess().writeFileContent(mergeVmArgs(defaultVmArgs, userVmArgs), confPath, true);
+
+    pc.withEnvVar(prefix.toUpperCase() + "_VM_OPTIONS", confPath.toAbsolutePath().toString());
+    return super.runTool(pc, processMode, args);
+  }
+
+  private Path resolveDefaultVmOptionsPath(Path softwarePath, String ideProductPrefix) {
+    if (ideProductPrefix == null) {
+      LOG.debug("Binary prefix for tool {} is not set", getName());
+      return null;
+    }
+
+    if (this.context.getSystemInfo().isWindows()) {
+      return softwarePath
+          .resolve("bin")
+          .resolve(ideProductPrefix + "64.exe.vmoptions");
+    }
+
+    if (this.context.getSystemInfo().isMac()) {
+      return softwarePath.toAbsolutePath()
+          .getParent()
+          .resolve("bin")
+          .resolve(ideProductPrefix + ".vmoptions");
+    }
+
+    return softwarePath // Linux
+        .resolve("bin")
+        .resolve(ideProductPrefix + "64.vmoptions");
+  }
+
+  private String mergeVmArgs(String[] defaults, String[] userArgs) {
+
+    List<String> result = new ArrayList<>(defaults.length + userArgs.length);
+    Collections.addAll(result, defaults);
+    for (String userArg : userArgs) {
+      boolean replaced = false;
+      for (int i = 0; i < result.size(); i++) {
+        if (sameJvmKey(result.get(i), userArg)) {
+          result.set(i, userArg); //override default arg with user defined arg
+          replaced = true;
+          break;
+        }
+      }
+      if (!replaced) { // in case of arg does not exist in default options
+        result.add(userArg);
+      }
+    }
+
+    return String.join(System.lineSeparator(), result);
+  }
+
+  private String extractJvmOptionsKey(String arg) {
+
+    // Only options with clear override semantics are merged.
+    // All other JVM arguments are treated as atomic flags by design.
+    if (arg.startsWith("-Xmx")) {
+      return "-Xmx";
+    }
+    if (arg.startsWith("-Xms")) {
+      return "-Xms";
+    }
+    if (arg.startsWith("-XX:") || arg.startsWith("-D")) {
+      int eq = arg.indexOf('=');
+      return eq > 0 ? arg.substring(0, eq) : arg;
+    }
+
+    return arg;
+  }
+
+  private boolean sameJvmKey(String a, String b) {
+
+    return extractJvmOptionsKey(a).equals(extractJvmOptionsKey(b));
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -115,10 +115,14 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     }
 
     if (this.context.getSystemInfo().isMac()) {
-      return softwarePath.toAbsolutePath()
-          .getParent()
-          .resolve("bin")
-          .resolve(ideProductPrefix + ".vmoptions");
+      try {
+        return softwarePath.toRealPath()
+            .getParent()
+            .resolve("bin")
+            .resolve(ideProductPrefix + ".vmoptions");
+      } catch (Exception e) {
+        LOG.error("Failed to resolve real path for software path: {}", softwarePath, e);
+      }
     }
 
     return softwarePath // Linux

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
@@ -2,6 +2,9 @@ package com.devonfw.tools.ide.tool.intellij;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -20,6 +23,9 @@ import com.devonfw.tools.ide.environment.ExtensibleEnvironmentVariables;
 import com.devonfw.tools.ide.merge.xml.XmlMergeDocument;
 import com.devonfw.tools.ide.merge.xml.XmlMerger;
 import com.devonfw.tools.ide.process.EnvironmentContext;
+import com.devonfw.tools.ide.process.ProcessContext;
+import com.devonfw.tools.ide.process.ProcessMode;
+import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolInstallation;
 import com.devonfw.tools.ide.tool.gradle.Gradle;
@@ -130,4 +136,100 @@ public class Intellij extends IdeaBasedIdeToolCommandlet {
     LOG.warn("No supported build descriptor was found for project import in {}", repositoryPath);
   }
 
+  @Override
+  public ProcessResult runTool(ProcessContext pc, ProcessMode processMode, List<String> args) {
+
+    String userVmArgsContent = this.context.getVariables().get("INTELLIJ_VM_ARGS");
+    if (userVmArgsContent == null || userVmArgsContent.isEmpty()) {
+      return super.runTool(pc, processMode, args);
+    }
+    String[] userVmArgs = userVmArgsContent.trim().split("\\s+");
+
+    Path defaultVmOptionsPath = resolveDefaultVmOptionsPath(this.context.getSoftwarePath());
+    String defaultVmArgsContent = this.context.getFileAccess().readFileContent(defaultVmOptionsPath);
+    if (defaultVmArgsContent == null || defaultVmArgsContent.isEmpty()) {
+      LOG.debug("Default intellij jvm options not found");
+      return super.runTool(pc, processMode, args);
+    }
+    String[] defaultVmArgs = defaultVmArgsContent.trim().split("\\s+");
+
+    Path confPath = this.context.getConfPath().resolve("intellij").resolve("idea.vmoptions");
+    this.context.getFileAccess().writeFileContent(mergeVmArgs(defaultVmArgs, userVmArgs), confPath, true);
+
+    pc.withEnvVar("IDEA_VM_OPTIONS", confPath.toAbsolutePath().toString());
+    return super.runTool(pc, processMode, args);
+  }
+
+  private Path resolveDefaultVmOptionsPath(Path softwarePath) {
+
+    Path intellijBase = softwarePath.resolve("intellij");
+    if (this.context.getSystemInfo().isWindows()) {
+      return intellijBase
+          .resolve("bin")
+          .resolve("idea64.exe.vmoptions");
+    }
+    if (this.context.getSystemInfo().isMac()) {
+      return intellijBase
+          .resolve("IntelliJ IDEA.app")
+          .resolve("Contents")
+          .resolve("bin")
+          .resolve("idea.vmoptions");
+    }
+
+    return intellijBase // Linux
+        .resolve("bin")
+        .resolve("idea64.vmoptions");
+  }
+
+  /**
+   * Extracts a key from a jvm option. Only options with clear override semantics are normalized. All other options are treated as atomic flags and returned
+   * unchanged by design.
+   *
+   * @param arg a jvm option (e.g. "-Xmx2048m").
+   * @return a jvm option key.
+   */
+  private String extractJvmOptionsKey(String arg) {
+
+    if (arg.startsWith("-Xmx")) {
+      return "-Xmx";
+    }
+    if (arg.startsWith("-Xms")) {
+      return "-Xms";
+    }
+    if (arg.startsWith("-XX:") || arg.startsWith("-D")) {
+      int eq = arg.indexOf('=');
+      return eq > 0 ? arg.substring(0, eq) : arg;
+    }
+
+    return arg;
+  }
+
+  /**
+   * Compares two jvm options by using {@link #extractJvmOptionsKey(String)}}.
+   */
+  private boolean sameJvmKey(String a, String b) {
+
+    return extractJvmOptionsKey(a).equals(extractJvmOptionsKey(b));
+  }
+
+  private String mergeVmArgs(String[] defaults, String[] userArgs) {
+
+    List<String> result = new ArrayList<>(defaults.length + userArgs.length);
+    Collections.addAll(result, defaults);
+    for (String userArg : userArgs) {
+      boolean replaced = false;
+      for (int i = 0; i < result.size(); i++) {
+        if (sameJvmKey(result.get(i), userArg)) {
+          result.set(i, userArg); //override default arg with user defined arg
+          replaced = true;
+          break;
+        }
+      }
+      if (!replaced) { // in case of arg does not exist in default options
+        result.add(userArg);
+      }
+    }
+
+    return String.join(System.lineSeparator(), result);
+  }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
@@ -2,9 +2,6 @@ package com.devonfw.tools.ide.tool.intellij;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -23,9 +20,6 @@ import com.devonfw.tools.ide.environment.ExtensibleEnvironmentVariables;
 import com.devonfw.tools.ide.merge.xml.XmlMergeDocument;
 import com.devonfw.tools.ide.merge.xml.XmlMerger;
 import com.devonfw.tools.ide.process.EnvironmentContext;
-import com.devonfw.tools.ide.process.ProcessContext;
-import com.devonfw.tools.ide.process.ProcessMode;
-import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolInstallation;
 import com.devonfw.tools.ide.tool.gradle.Gradle;
@@ -78,6 +72,12 @@ public class Intellij extends IdeaBasedIdeToolCommandlet {
         return IDEA;
       }
     }
+  }
+
+  @Override
+  protected String getIdeProductPrefix() {
+
+    return IDEA;
   }
 
   @Override
@@ -134,92 +134,5 @@ public class Intellij extends IdeaBasedIdeToolCommandlet {
       }
     }
     LOG.warn("No supported build descriptor was found for project import in {}", repositoryPath);
-  }
-
-  @Override
-  public ProcessResult runTool(ProcessContext pc, ProcessMode processMode, List<String> args) {
-
-    String userVmArgsContent = this.context.getVariables().get("INTELLIJ_VM_ARGS");
-    if (userVmArgsContent == null || userVmArgsContent.isEmpty()) {
-      return super.runTool(pc, processMode, args);
-    }
-    String[] userVmArgs = userVmArgsContent.trim().split("\\s+");
-
-    Path defaultVmOptionsPath = resolveDefaultVmOptionsPath(this.getToolPath());
-    String defaultVmArgsContent = this.context.getFileAccess().readFileContent(defaultVmOptionsPath);
-    if (defaultVmArgsContent == null || defaultVmArgsContent.isEmpty()) {
-      LOG.debug("Default intellij jvm options not found at: {}", defaultVmOptionsPath);
-      return super.runTool(pc, processMode, args);
-    }
-    String[] defaultVmArgs = defaultVmArgsContent.trim().split("\\s+");
-
-    Path confPath = this.context.getWorkspacePath().resolve(".idea.vmoptions");
-    this.context.getFileAccess().writeFileContent(mergeVmArgs(defaultVmArgs, userVmArgs), confPath, true);
-
-    pc.withEnvVar("IDEA_VM_OPTIONS", confPath.toAbsolutePath().toString());
-    return super.runTool(pc, processMode, args);
-  }
-
-  private Path resolveDefaultVmOptionsPath(Path softwarePath) {
-
-    if (this.context.getSystemInfo().isWindows()) {
-      return softwarePath
-          .resolve("bin")
-          .resolve("idea64.exe.vmoptions");
-    }
-    //if (this.context.getSystemInfo().isMac()) {
-    //  return softwarePath
-    //      .resolve("..")
-    //      .resolve("bin")
-    //      .resolve("idea.vmoptions");
-    //} TODO: Mac sym links are linked "too deep"
-
-    return softwarePath // Linux
-        .resolve("bin")
-        .resolve("idea64.vmoptions");
-  }
-
-  private String extractJvmOptionsKey(String arg) {
-
-    // Only options with clear override semantics are merged.
-    // All other JVM arguments are treated as atomic flags by design.
-    if (arg.startsWith("-Xmx")) {
-      return "-Xmx";
-    }
-    if (arg.startsWith("-Xms")) {
-      return "-Xms";
-    }
-    if (arg.startsWith("-XX:") || arg.startsWith("-D")) {
-      int eq = arg.indexOf('=');
-      return eq > 0 ? arg.substring(0, eq) : arg;
-    }
-
-    return arg;
-  }
-
-  private boolean sameJvmKey(String a, String b) {
-
-    return extractJvmOptionsKey(a).equals(extractJvmOptionsKey(b));
-  }
-
-  private String mergeVmArgs(String[] defaults, String[] userArgs) {
-
-    List<String> result = new ArrayList<>(defaults.length + userArgs.length);
-    Collections.addAll(result, defaults);
-    for (String userArg : userArgs) {
-      boolean replaced = false;
-      for (int i = 0; i < result.size(); i++) {
-        if (sameJvmKey(result.get(i), userArg)) {
-          result.set(i, userArg); //override default arg with user defined arg
-          replaced = true;
-          break;
-        }
-      }
-      if (!replaced) { // in case of arg does not exist in default options
-        result.add(userArg);
-      }
-    }
-
-    return String.join(System.lineSeparator(), result);
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
@@ -145,10 +145,10 @@ public class Intellij extends IdeaBasedIdeToolCommandlet {
     }
     String[] userVmArgs = userVmArgsContent.trim().split("\\s+");
 
-    Path defaultVmOptionsPath = resolveDefaultVmOptionsPath(this.context.getSoftwarePath());
+    Path defaultVmOptionsPath = resolveDefaultVmOptionsPath(this.getToolPath());
     String defaultVmArgsContent = this.context.getFileAccess().readFileContent(defaultVmOptionsPath);
     if (defaultVmArgsContent == null || defaultVmArgsContent.isEmpty()) {
-      LOG.debug("Default intellij jvm options not found");
+      LOG.debug("Default intellij jvm options not found at: {}", defaultVmOptionsPath);
       return super.runTool(pc, processMode, args);
     }
     String[] defaultVmArgs = defaultVmArgsContent.trim().split("\\s+");
@@ -162,21 +162,19 @@ public class Intellij extends IdeaBasedIdeToolCommandlet {
 
   private Path resolveDefaultVmOptionsPath(Path softwarePath) {
 
-    Path intellijBase = softwarePath.resolve("intellij");
     if (this.context.getSystemInfo().isWindows()) {
-      return intellijBase
+      return softwarePath
           .resolve("bin")
           .resolve("idea64.exe.vmoptions");
     }
-    if (this.context.getSystemInfo().isMac()) {
-      return intellijBase
-          .resolve("IntelliJ IDEA.app")
-          .resolve("Contents")
-          .resolve("bin")
-          .resolve("idea.vmoptions");
-    }
+//    if (this.context.getSystemInfo().isMac()) {
+//      return softwarePath
+//          .resolve("..")
+//          .resolve("bin")
+//          .resolve("idea.vmoptions");
+//    } TODO: Mac sym links are not linked "too deep"
 
-    return intellijBase // Linux
+    return softwarePath // Linux
         .resolve("bin")
         .resolve("idea64.vmoptions");
   }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
@@ -167,12 +167,12 @@ public class Intellij extends IdeaBasedIdeToolCommandlet {
           .resolve("bin")
           .resolve("idea64.exe.vmoptions");
     }
-//    if (this.context.getSystemInfo().isMac()) {
-//      return softwarePath
-//          .resolve("..")
-//          .resolve("bin")
-//          .resolve("idea.vmoptions");
-//    } TODO: Mac sym links are not linked "too deep"
+    //if (this.context.getSystemInfo().isMac()) {
+    //  return softwarePath
+    //      .resolve("..")
+    //      .resolve("bin")
+    //      .resolve("idea.vmoptions");
+    //} TODO: Mac sym links are linked "too deep"
 
     return softwarePath // Linux
         .resolve("bin")

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/intellij/Intellij.java
@@ -153,7 +153,7 @@ public class Intellij extends IdeaBasedIdeToolCommandlet {
     }
     String[] defaultVmArgs = defaultVmArgsContent.trim().split("\\s+");
 
-    Path confPath = this.context.getConfPath().resolve("intellij").resolve("idea.vmoptions");
+    Path confPath = this.context.getWorkspacePath().resolve(".idea.vmoptions");
     this.context.getFileAccess().writeFileContent(mergeVmArgs(defaultVmArgs, userVmArgs), confPath, true);
 
     pc.withEnvVar("IDEA_VM_OPTIONS", confPath.toAbsolutePath().toString());
@@ -181,15 +181,10 @@ public class Intellij extends IdeaBasedIdeToolCommandlet {
         .resolve("idea64.vmoptions");
   }
 
-  /**
-   * Extracts a key from a jvm option. Only options with clear override semantics are normalized. All other options are treated as atomic flags and returned
-   * unchanged by design.
-   *
-   * @param arg a jvm option (e.g. "-Xmx2048m").
-   * @return a jvm option key.
-   */
   private String extractJvmOptionsKey(String arg) {
 
+    // Only options with clear override semantics are merged.
+    // All other JVM arguments are treated as atomic flags by design.
     if (arg.startsWith("-Xmx")) {
       return "-Xmx";
     }
@@ -204,9 +199,6 @@ public class Intellij extends IdeaBasedIdeToolCommandlet {
     return arg;
   }
 
-  /**
-   * Compares two jvm options by using {@link #extractJvmOptionsKey(String)}}.
-   */
   private boolean sameJvmKey(String a, String b) {
 
     return extractJvmOptionsKey(a).equals(extractJvmOptionsKey(b));

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/pycharm/Pycharm.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/pycharm/Pycharm.java
@@ -53,4 +53,10 @@ public class Pycharm extends IdeaBasedIdeToolCommandlet {
       }
     }
   }
+
+  @Override
+  protected String getIdeProductPrefix() {
+
+    return PYCHARM;
+  }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java
@@ -117,13 +117,16 @@ public interface IdeVariables {
   /** {@link VariableDefinition} for {@link com.devonfw.tools.ide.context.IdeContext#getProjectName() DEVON_IDE_CUSTOM_TOOLS}. */
   VariableDefinitionString DEVON_IDE_CUSTOM_TOOLS = new VariableDefinitionString("DEVON_IDE_CUSTOM_TOOLS");
 
+  /** {@link VariableDefinition} for support of overriding the default intellij jvm options. */
+  VariableDefinitionString INTELLIJ_VM_ARGS = new VariableDefinitionString("INTELLIJ_VM_ARGS", null);
+
   /** A {@link Collection} with all pre-defined {@link VariableDefinition}s. */
   Collection<VariableDefinition<?>> VARIABLES = List.of(PATH, HOME, WORKSPACE_PATH, IDE_HOME, IDE_ROOT, WORKSPACE, IDE_TOOLS, HTTP_VERSIONS,
       CREATE_START_SCRIPTS,
       IDE_MIN_VERSION, MVN_VERSION, M2_REPO, DOCKER_EDITION, MVN_BUILD_OPTS, NPM_BUILD_OPTS, NPM_CONFIG_USERCONFIG, GRADLE_BUILD_OPTS,
       GRADLE_USER_HOME,
       YARN_BUILD_OPTS, JASYPT_OPTS,
-      MAVEN_ARGS,
+      MAVEN_ARGS, INTELLIJ_VM_ARGS,
       PROJECT_NAME, IDE_VARIABLE_SYNTAX_LEGACY_SUPPORT_ENABLED, PREFERRED_GIT_PROTOCOL);
 
   /**

--- a/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java
@@ -120,13 +120,19 @@ public interface IdeVariables {
   /** {@link VariableDefinition} for support of overriding the default intellij jvm options. */
   VariableDefinitionString INTELLIJ_VM_ARGS = new VariableDefinitionString("INTELLIJ_VM_ARGS", null);
 
+  /** {@link VariableDefinition} for support of overriding the default android studio jvm options. */
+  VariableDefinitionString ANDROID_STUDIO_VM_ARGS = new VariableDefinitionString("ANDROID_STUDIO_VM_ARGS", null);
+
+  /** {@link VariableDefinition} for support of overriding the default pycharm jvm options. */
+  VariableDefinitionString PYCHARM_VM_ARGS = new VariableDefinitionString("PYCHARM_VM_ARGS", null);
+
   /** A {@link Collection} with all pre-defined {@link VariableDefinition}s. */
   Collection<VariableDefinition<?>> VARIABLES = List.of(PATH, HOME, WORKSPACE_PATH, IDE_HOME, IDE_ROOT, WORKSPACE, IDE_TOOLS, HTTP_VERSIONS,
       CREATE_START_SCRIPTS,
       IDE_MIN_VERSION, MVN_VERSION, M2_REPO, DOCKER_EDITION, MVN_BUILD_OPTS, NPM_BUILD_OPTS, NPM_CONFIG_USERCONFIG, GRADLE_BUILD_OPTS,
       GRADLE_USER_HOME,
       YARN_BUILD_OPTS, JASYPT_OPTS,
-      MAVEN_ARGS, INTELLIJ_VM_ARGS,
+      MAVEN_ARGS, INTELLIJ_VM_ARGS, ANDROID_STUDIO_VM_ARGS, PYCHARM_VM_ARGS,
       PROJECT_NAME, IDE_VARIABLE_SYNTAX_LEGACY_SUPPORT_ENABLED, PREFERRED_GIT_PROTOCOL);
 
   /**

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/androidstudio/AndroidStudioTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/androidstudio/AndroidStudioTest.java
@@ -84,6 +84,32 @@ class AndroidStudioTest extends AbstractIdeContextTest {
         ANDROID_STUDIO + " " + this.context.getSystemInfo().getOs() + " " + this.context.getWorkspacePath());
   }
 
+  /**
+   * Tests if the custom jvm options of the ide variable ANDROID_STUDIO_VM_ARGS have been set.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = { "windows", "mac", "linux" })
+  void testAndroidStudioRunWithCustomJvmOptions(String os) {
+    // arrange
+    SystemInfo systemInfo = SystemInfoMock.of(os);
+    context.setSystemInfo(systemInfo);
+    AndroidStudio androidStudio = context.getCommandletManager().getCommandlet(AndroidStudio.class);
+
+    // act
+    androidStudio.run();
+
+    // assert
+    assertThat(context.getWorkspacePath().resolve(".studio.vmoptions"))
+        .exists()
+        .hasContent("""
+            -Xms256m
+            -Xmx4096m
+            -XX:ReservedCodeCacheSize=512m
+            -ea
+            -Dsun.io.useCanonCaches=false
+            """);
+  }
+
   private void checkInstallation(IdeTestContext context) {
     // commandlet - android-studio
     assertThat(context.getSoftwarePath().resolve("android-studio/.ide.software.version")).exists().hasContent("2024.1.1.1");

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/androidstudio/AndroidStudioTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/androidstudio/AndroidStudioTest.java
@@ -104,9 +104,9 @@ class AndroidStudioTest extends AbstractIdeContextTest {
         .hasContent("""
             -Xms256m
             -Xmx4096m
-            -XX:ReservedCodeCacheSize=512m
+            -XX:ReservedCodeCacheSize=256m
             -ea
-            -Dsun.io.useCanonCaches=false
+            -Dsun.io.useCanonCaches=true
             """);
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
@@ -195,6 +195,33 @@ class IntellijTest extends AbstractIdeContextTest {
         """);
   }
 
+  /**
+   * Tests if the custom jvm options of the ide variable INTELLI_VM_ARGS have been set.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = { "windows", "linux" })
+  void testIntellijRunWithCustomJvmOptions(String os) {
+    // arrange
+    SystemInfo systemInfo = SystemInfoMock.of(os);
+    IdeTestContext context = newContext(PROJECT_INTELLIJ);
+    context.setSystemInfo(systemInfo);
+    Intellij intellij = context.getCommandletManager().getCommandlet(Intellij.class);
+
+    // act
+    intellij.run();
+
+    // assert
+    assertThat(context.getWorkspacePath().resolve(".idea.vmoptions"))
+        .exists()
+        .hasContent("""
+            -Xms256m
+            -Xmx4096m
+            -XX:ReservedCodeCacheSize=512m
+            -ea
+            -Dsun.io.useCanonCaches=false
+            """);
+  }
+
 
   private void checkInstallation(IdeTestContext context) {
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
@@ -199,11 +199,10 @@ class IntellijTest extends AbstractIdeContextTest {
    * Tests if the custom jvm options of the ide variable INTELLI_VM_ARGS have been set.
    */
   @ParameterizedTest
-  @ValueSource(strings = { "windows", "linux" })
+  @ValueSource(strings = { "windows", "mac", "linux" })
   void testIntellijRunWithCustomJvmOptions(String os) {
     // arrange
     SystemInfo systemInfo = SystemInfoMock.of(os);
-    IdeTestContext context = newContext(PROJECT_INTELLIJ);
     context.setSystemInfo(systemInfo);
     Intellij intellij = context.getCommandletManager().getCommandlet(Intellij.class);
 
@@ -221,7 +220,6 @@ class IntellijTest extends AbstractIdeContextTest {
             -Dsun.io.useCanonCaches=false
             """);
   }
-
 
   private void checkInstallation(IdeTestContext context) {
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
@@ -215,9 +215,9 @@ class IntellijTest extends AbstractIdeContextTest {
         .hasContent("""
             -Xms256m
             -Xmx4096m
-            -XX:ReservedCodeCacheSize=512m
+            -XX:ReservedCodeCacheSize=256m
             -ea
-            -Dsun.io.useCanonCaches=false
+            -Dsun.io.useCanonCaches=true
             """);
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/pycharm/PycharmTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/pycharm/PycharmTest.java
@@ -153,6 +153,32 @@ class PycharmTest extends AbstractIdeContextTest {
     assertThat(commandlet.retrievePluginMarkerFilePath(commandlet.getPlugin("ActivePlugin"))).exists();
   }
 
+  /**
+   * Tests if the custom jvm options of the ide variable PYCHARM_STUDIO_VM_ARGS have been set.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = { "windows", "mac", "linux" })
+  void testPycharmRunWithCustomJvmOptions(String os) {
+    // arrange
+    SystemInfo systemInfo = SystemInfoMock.of(os);
+    context.setSystemInfo(systemInfo);
+    Pycharm pycharm = context.getCommandletManager().getCommandlet(Pycharm.class);
+
+    // act
+    pycharm.run();
+
+    // assert
+    assertThat(context.getWorkspacePath().resolve(".pycharm.vmoptions"))
+        .exists()
+        .hasContent("""
+            -Xms256m
+            -Xmx4096m
+            -XX:ReservedCodeCacheSize=512m
+            -ea
+            -Dsun.io.useCanonCaches=false
+            """);
+  }
+
   private void checkInstallation(IdeTestContext context) {
 
     assertThat(context.getSoftwarePath().resolve("pycharm/.ide.software.version")).exists().hasContent("2024.3.5");

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/pycharm/PycharmTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/pycharm/PycharmTest.java
@@ -173,9 +173,9 @@ class PycharmTest extends AbstractIdeContextTest {
         .hasContent("""
             -Xms256m
             -Xmx4096m
-            -XX:ReservedCodeCacheSize=512m
+            -XX:ReservedCodeCacheSize=256m
             -ea
-            -Dsun.io.useCanonCaches=false
+            -Dsun.io.useCanonCaches=true
             """);
   }
 

--- a/cli/src/test/resources/ide-projects/android-studio/project/conf/ide.properties
+++ b/cli/src/test/resources/ide-projects/android-studio/project/conf/ide.properties
@@ -1,1 +1,2 @@
 # here the STUDIO_PROPERTIES variable should be added by the test
+ANDROID_STUDIO_VM_ARGS=-Xms256m -Xmx4096m

--- a/cli/src/test/resources/ide-projects/android-studio/project/conf/ide.properties
+++ b/cli/src/test/resources/ide-projects/android-studio/project/conf/ide.properties
@@ -1,2 +1,2 @@
 # here the STUDIO_PROPERTIES variable should be added by the test
-ANDROID_STUDIO_VM_ARGS=-Xms256m -Xmx4096m
+ANDROID_STUDIO_VM_ARGS=-Xms256m -Xmx4096m -XX:ReservedCodeCacheSize=256m -Dsun.io.useCanonCaches=true -ea

--- a/cli/src/test/resources/ide-projects/android-studio/repository/android-studio/android-studio/default/linux/bin/studio64.vmoptions
+++ b/cli/src/test/resources/ide-projects/android-studio/repository/android-studio/android-studio/default/linux/bin/studio64.vmoptions
@@ -1,0 +1,5 @@
+-Xms128m
+-Xmx2048m
+-XX:ReservedCodeCacheSize=512m
+-ea
+-Dsun.io.useCanonCaches=false

--- a/cli/src/test/resources/ide-projects/android-studio/repository/android-studio/android-studio/default/mac/Android Studio Preview.app/Contents/bin/studio.vmoptions
+++ b/cli/src/test/resources/ide-projects/android-studio/repository/android-studio/android-studio/default/mac/Android Studio Preview.app/Contents/bin/studio.vmoptions
@@ -1,0 +1,5 @@
+-Xms128m
+-Xmx2048m
+-XX:ReservedCodeCacheSize=512m
+-ea
+-Dsun.io.useCanonCaches=false

--- a/cli/src/test/resources/ide-projects/android-studio/repository/android-studio/android-studio/default/windows/bin/studio64.exe.vmoptions
+++ b/cli/src/test/resources/ide-projects/android-studio/repository/android-studio/android-studio/default/windows/bin/studio64.exe.vmoptions
@@ -1,0 +1,5 @@
+-Xms128m
+-Xmx2048m
+-XX:ReservedCodeCacheSize=512m
+-ea
+-Dsun.io.useCanonCaches=false

--- a/cli/src/test/resources/ide-projects/intellij/project/conf/ide.properties
+++ b/cli/src/test/resources/ide-projects/intellij/project/conf/ide.properties
@@ -1,1 +1,2 @@
 # here the INTELLIJ_PROPERTIES variable should be added by the test
+INTELLIJ_VM_ARGS=-Xms256m -Xmx4096m

--- a/cli/src/test/resources/ide-projects/intellij/project/conf/ide.properties
+++ b/cli/src/test/resources/ide-projects/intellij/project/conf/ide.properties
@@ -1,2 +1,2 @@
 # here the INTELLIJ_PROPERTIES variable should be added by the test
-INTELLIJ_VM_ARGS=-Xms256m -Xmx4096m
+INTELLIJ_VM_ARGS=-Xms256m -Xmx4096m -XX:ReservedCodeCacheSize=256m -Dsun.io.useCanonCaches=true -ea

--- a/cli/src/test/resources/ide-projects/intellij/repository/intellij/intellij/default/linux/bin/idea64.vmoptions
+++ b/cli/src/test/resources/ide-projects/intellij/repository/intellij/intellij/default/linux/bin/idea64.vmoptions
@@ -1,0 +1,5 @@
+-Xms128m
+-Xmx2048m
+-XX:ReservedCodeCacheSize=512m
+-ea
+-Dsun.io.useCanonCaches=false

--- a/cli/src/test/resources/ide-projects/intellij/repository/intellij/intellij/default/mac/IntelliJ IDEA CE.app/Contents/bin/idea.vmoptions
+++ b/cli/src/test/resources/ide-projects/intellij/repository/intellij/intellij/default/mac/IntelliJ IDEA CE.app/Contents/bin/idea.vmoptions
@@ -1,0 +1,5 @@
+-Xms128m
+-Xmx2048m
+-XX:ReservedCodeCacheSize=512m
+-ea
+-Dsun.io.useCanonCaches=false

--- a/cli/src/test/resources/ide-projects/intellij/repository/intellij/intellij/default/windows/bin/idea64.exe.vmoptions
+++ b/cli/src/test/resources/ide-projects/intellij/repository/intellij/intellij/default/windows/bin/idea64.exe.vmoptions
@@ -1,0 +1,5 @@
+-Xms128m
+-Xmx2048m
+-XX:ReservedCodeCacheSize=512m
+-ea
+-Dsun.io.useCanonCaches=false

--- a/cli/src/test/resources/ide-projects/pycharm/project/conf/ide.properties
+++ b/cli/src/test/resources/ide-projects/pycharm/project/conf/ide.properties
@@ -1,2 +1,2 @@
 # here the PYCHARM_PROPERTIES variable should be added by the test
-PYCHARM_VM_ARGS=-Xms256m -Xmx4096m
+PYCHARM_VM_ARGS=-Xms256m -Xmx4096m -XX:ReservedCodeCacheSize=256m -Dsun.io.useCanonCaches=true -ea

--- a/cli/src/test/resources/ide-projects/pycharm/project/conf/ide.properties
+++ b/cli/src/test/resources/ide-projects/pycharm/project/conf/ide.properties
@@ -1,0 +1,2 @@
+# here the PYCHARM_PROPERTIES variable should be added by the test
+PYCHARM_VM_ARGS=-Xms256m -Xmx4096m

--- a/cli/src/test/resources/ide-projects/pycharm/repository/pycharm/pycharm/default/linux/bin/pycharm64.vmoptions
+++ b/cli/src/test/resources/ide-projects/pycharm/repository/pycharm/pycharm/default/linux/bin/pycharm64.vmoptions
@@ -1,0 +1,5 @@
+-Xms128m
+-Xmx2048m
+-XX:ReservedCodeCacheSize=512m
+-ea
+-Dsun.io.useCanonCaches=false

--- a/cli/src/test/resources/ide-projects/pycharm/repository/pycharm/pycharm/default/mac/PyCharm CE.app/Contents/bin/pycharm.vmoptions
+++ b/cli/src/test/resources/ide-projects/pycharm/repository/pycharm/pycharm/default/mac/PyCharm CE.app/Contents/bin/pycharm.vmoptions
@@ -1,0 +1,5 @@
+-Xms128m
+-Xmx2048m
+-XX:ReservedCodeCacheSize=512m
+-ea
+-Dsun.io.useCanonCaches=false

--- a/cli/src/test/resources/ide-projects/pycharm/repository/pycharm/pycharm/default/windows/bin/pycharm64.exe.vmoptions
+++ b/cli/src/test/resources/ide-projects/pycharm/repository/pycharm/pycharm/default/windows/bin/pycharm64.exe.vmoptions
@@ -1,0 +1,5 @@
+-Xms128m
+-Xmx2048m
+-XX:ReservedCodeCacheSize=512m
+-ea
+-Dsun.io.useCanonCaches=false

--- a/documentation/variables.adoc
+++ b/documentation/variables.adoc
@@ -8,7 +8,7 @@ These environment variables are described by the following table.
 Those variables printed *bold* are automatically exported in your shell (except for windows CMD that does not have such concept).
 Variables with the value `-` are not set by default but may be set via link:configuration.adoc[configuration] to override defaults.
 Please note that we are trying to minimize any potential side-effect from `IDEasy` to the outside world by reducing the number of variables and only exporting those that are required.
-See also link:https://github.com/devonfw/IDEasy/blob/main/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java[IdeVariables.java] that defines all the available variables. 
+See also link:https://github.com/devonfw/IDEasy/blob/main/cli/src/main/java/com/devonfw/tools/ide/variable/IdeVariables.java[IdeVariables.java] that defines all the available variables.
 
 .Variables of IDEasy
 [options="header"]
@@ -41,4 +41,5 @@ See also link:https://github.com/devonfw/IDEasy/blob/main/cli/src/main/java/com/
 |`JASYPT_OPTS`|`algorithm=PBEWITHHMACSHA512ANDAES_256 ivGeneratorClassName=org.jasypt.iv.RandomIvGenerator`|Options of jasypt.
 |`IDE_XML_MERGE_LEGACY_SUPPORT_ENABLED`|e.g. `false`|Support of legacy xml templates without XML merge namespace.
 |`IDE_WRITE_LOGFILE`|`true`|Automatically write logfiles to `$IDE_ROOT/_ide/logs/YYYY/MM/dd/«project»-ide-«command»-HH-mm-ss.log`. If you are not inside an IDEasy project or your command is not related to a project then `«project»` will be `_ide`. The logfile structure is designed in a way that allows you to quickly find and cleanup based on date but also based on details like the project and sub-command.
+|`INTELLIJ_VM_ARGS`|e.g. `-Xms128m -Xmx2048m`|Support of the configuration of IntelliJ JVM options. The specified JVM options extend or overwrite the default JVM options.
 |=======================

--- a/documentation/variables.adoc
+++ b/documentation/variables.adoc
@@ -41,5 +41,7 @@ See also link:https://github.com/devonfw/IDEasy/blob/main/cli/src/main/java/com/
 |`JASYPT_OPTS`|`algorithm=PBEWITHHMACSHA512ANDAES_256 ivGeneratorClassName=org.jasypt.iv.RandomIvGenerator`|Options of jasypt.
 |`IDE_XML_MERGE_LEGACY_SUPPORT_ENABLED`|e.g. `false`|Support of legacy xml templates without XML merge namespace.
 |`IDE_WRITE_LOGFILE`|`true`|Automatically write logfiles to `$IDE_ROOT/_ide/logs/YYYY/MM/dd/«project»-ide-«command»-HH-mm-ss.log`. If you are not inside an IDEasy project or your command is not related to a project then `«project»` will be `_ide`. The logfile structure is designed in a way that allows you to quickly find and cleanup based on date but also based on details like the project and sub-command.
-|`INTELLIJ_VM_ARGS`|e.g. `-Xms128m -Xmx2048m`|Support of the configuration of IntelliJ JVM options. The specified JVM options extend or overwrite the default JVM options.
+|`INTELLIJ_VM_ARGS`|e.g. `-Xms128m -Xmx2048m`|Support for extension or overwrite of default IntelliJ JVM options.
+|`PYCHARM_VM_ARGS`|e.g. `-Xms128m -Xmx2048m`|Support for extension or overwrite of default Pycharm JVM options.
+|`ANDROID_STUDIO_VM_ARGS`|e.g. `-Xms128m -Xmx2048m`|Support for extension or overwrite of default Android Studio JVM options.
 |=======================


### PR DESCRIPTION
### This PR fixes #906 

### Implemented changes:

* Implement feature to configure jvm options for intellij, android-studio and pycharm via ide variable.
* Added functionality to create a custom .vmoptions file in the workspace folder which is the referenced by the intellij/studio/pycharm env variable IDEA_VM_OPTIONS/STUDIO_VM_OPTIONS/PYCHARM_VM_OPTIONS which extends or overwrites the default jvm options.
* Added variable to the [variables.doc](https://github.com/devonfw/IDEasy/blob/main/documentation/variables.adoc)

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
