### PR TITLE
#1688: Remove unnecessary cli message when tool install 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1552[#1552]: Add Commandlet to fix TLS issue
 * https://github.com/devonfw/IDEasy/issues/1799[#1799]: Add support for file URL in GitUrl validation for local development
 * https://github.com/devonfw/IDEasy/issues/1760[#1760]: Accept empty input for single option
+* https://github.com/devonfw/IDEasy/issues/1688[#1688]: Remove unnecessary cli message when installing global tools
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/43?closed=1[milestone 2026.04.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
@@ -188,18 +188,10 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
   }
 
   @Override
-  public VersionIdentifier getInstalledVersion() {
-    //TODO: handle "get-version <globaltool>"
-    LOG.error("Couldn't get installed version of " + this.getName());
-    return null;
-  }
+  public abstract VersionIdentifier getInstalledVersion();
 
   @Override
-  public String getInstalledEdition() {
-    //TODO: handle "get-edition <globaltool>"
-    LOG.error("Couldn't get installed edition of " + this.getName());
-    return null;
-  }
+  public abstract String getInstalledEdition();
 
   @Override
   protected Path getInstallationPath(String edition, VersionIdentifier resolvedVersion) {
@@ -217,8 +209,5 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
   }
 
   @Override
-  public void uninstall() {
-    //TODO: handle "uninstall <globaltool>"
-    LOG.error("Couldn't uninstall " + this.getName());
-  }
+  public abstract void uninstall();
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/docker/Docker.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/docker/Docker.java
@@ -164,10 +164,7 @@ public class Docker extends GlobalToolCommandlet {
 
     if (this.context.getSystemInfo().isLinux()) {
       runWithPackageManager(false, getPackageManagerCommandsUninstall());
-    } else {
-      super.uninstall();
     }
-
   }
 
   private List<PackageManagerCommand> getPackageManagerCommandsUninstall() {

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/pgadmin/PgAdmin.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/pgadmin/PgAdmin.java
@@ -1,22 +1,36 @@
 package com.devonfw.tools.ide.tool.pgadmin;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.devonfw.tools.ide.common.Tag;
 import com.devonfw.tools.ide.context.IdeContext;
+import com.devonfw.tools.ide.process.ProcessErrorHandling;
+import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.tool.GlobalToolCommandlet;
 import com.devonfw.tools.ide.tool.NativePackageManager;
 import com.devonfw.tools.ide.tool.PackageManagerCommand;
 import com.devonfw.tools.ide.tool.repository.ToolRepository;
 import com.devonfw.tools.ide.version.VersionIdentifier;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * {@link GlobalToolCommandlet} for <a href="https://www.pgadmin.org/">pgadmin</a>
  */
 public class PgAdmin extends GlobalToolCommandlet {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PgAdmin.class);
+
+  private static final String PG_ADMIN = "pgAdmin 4";
 
   /**
    * The constructor.
@@ -48,10 +62,65 @@ public class PgAdmin extends GlobalToolCommandlet {
   }
 
   @Override
+  public VersionIdentifier getInstalledVersion() {
+
+    if (this.context.getSystemInfo().isWindows()) {
+      Path installationPath = getWindowsInstallationPath();
+      Path sbomPath;
+      if (installationPath != null) {
+        sbomPath = installationPath.resolve("sbom.json");
+        if (Files.isRegularFile(sbomPath)) {
+          try {
+            JsonNode root = new ObjectMapper().readTree(sbomPath.toFile());
+            for (JsonNode component : root.path("components")) {
+              if (PG_ADMIN.equals(component.path("name").asText())) {
+                return VersionIdentifier.of(
+                    component.path("version")
+                        .asText()
+                        .replace("\"", "") // weirdly a quotation mark  present in the version string
+                );
+              }
+            }
+          } catch (Exception e) {
+            LOG.error("Could not read pgAdmin version from SBOM file '{}'", sbomPath, e);
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public String getInstalledEdition() {
+
+    if (this.context.getSystemInfo().isWindows()) {
+      Path installationPath = getWindowsInstallationPath();
+      if (installationPath != null) {
+        if (Files.exists(installationPath)) {
+          return "pgadmin";
+        }
+      }
+    }
+
+    return null;
+  }
+
+  @Override
   public void uninstall() {
 
     if (this.context.getSystemInfo().isLinux()) {
       runWithPackageManager(false, getPackageManagerCommandsUninstall());
+    } else if (this.context.getSystemInfo().isWindows()) {
+      Path installationPath = getWindowsInstallationPath();
+      if (installationPath != null) {
+        Path uninstallExecutablePath = installationPath.resolve("unins000.exe");
+        if (Files.isExecutable(uninstallExecutablePath)) {
+          this.context.newProcess().errorHandling(ProcessErrorHandling.LOG_WARNING)
+              .executable(uninstallExecutablePath)
+              .run(ProcessMode.BACKGROUND).getExitCode();
+        }
+      }
     } else {
       super.uninstall();
     }
@@ -71,5 +140,37 @@ public class PgAdmin extends GlobalToolCommandlet {
   protected String getBinaryName() {
 
     return "pgadmin4";
+  }
+
+  private Path getWindowsInstallationPath() {
+
+    String appDataPath = System.getenv("APPDATA");
+    if (appDataPath != null && !appDataPath.isBlank()) {
+      try {
+        Path shortcut = Paths.get(appDataPath)
+            .resolve("Microsoft")
+            .resolve("Windows")
+            .resolve("Start Menu")
+            .resolve("Programs")
+            .resolve(PG_ADMIN)
+            .resolve(PG_ADMIN + ".lnk");
+
+        Process process = new ProcessBuilder(
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            "(New-Object -ComObject WScript.Shell)"
+                + ".CreateShortcut('" + shortcut + "')"
+                + ".TargetPath"
+        ).redirectErrorStream(true).start();
+
+        Path installationPath = Paths.get(new String(process.getInputStream().readAllBytes()).trim());
+        return installationPath.getParent().getParent();
+      } catch (Exception e) {
+        LOG.error("Could not resolve installation path of {}", PG_ADMIN, e);
+      }
+    }
+
+    return null;
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/pgadmin/PgAdmin.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/pgadmin/PgAdmin.java
@@ -121,8 +121,6 @@ public class PgAdmin extends GlobalToolCommandlet {
               .run(ProcessMode.BACKGROUND).getExitCode();
         }
       }
-    } else {
-      super.uninstall();
     }
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/pgadmin/PgAdmin.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/pgadmin/PgAdmin.java
@@ -165,7 +165,9 @@ public class PgAdmin extends GlobalToolCommandlet {
         Path installationPath = Paths.get(new String(process.getInputStream().readAllBytes()).trim());
         return installationPath.getParent().getParent();
       } catch (Exception e) {
-        LOG.error("Could not resolve installation path of {}", PG_ADMIN, e);
+        // we only log this in debug because a meaningful message already gets logged from a super class
+        // if no installation is found. If the path is simply false the same applies.
+        LOG.debug("Couldn't resolve installation path of {}", PG_ADMIN);
       }
     }
 


### PR DESCRIPTION
### This PR fixes #1688 

### Implemented changes:

* Edit global tool commandlet to not log unnecessary cli messages for pgadmin.
* Add support for retrieving installed version of pgAdmin under windows.
* Make methods `getInstalledVersion`, `getInstalledEdition`, `uninstall` abstract to be implemented bei extending classes in the future.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
