### PR TITLE
#1833: Missing commit id file

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,10 +4,9 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 == 2026.05.001
 
-* https://github.com/devonfw/IDEasy/issues/1833[#1833]: No settings repo update with missing `.commit.id`
-
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/1833[#1833]: No settings repo update with missing `.commit.id`
 * https://github.com/devonfw/IDEasy/issues/1693[#1693]: Fix behavior when there's no settings repo (.../settings/.git)
 * https://github.com/devonfw/IDEasy/issues/1815[#1815]: Suppress Update notification while updating
 * https://github.com/devonfw/IDEasy/issues/1050[#1050]: Introduce dependencies.json for LazyDocker and remove hardcoded dependency

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,8 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 == 2026.05.001
 
+* https://github.com/devonfw/IDEasy/issues/1833[#1833]: No settings repo update with missing `.commit.id`
+
 Release with new features and bugfixes:
 
 

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
@@ -75,6 +75,7 @@ public class GitContextImpl implements GitContext {
 
     String trackedCommitId = this.context.getFileAccess().readFileContent(trackedCommitIdPath);
     if (trackedCommitId == null) {
+      LOG.warn("Commit ID was not present at {}", trackedCommitIdPath);
       return true;
     }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
@@ -72,9 +72,9 @@ public class GitContextImpl implements GitContext {
 
   @Override
   public boolean isRepositoryUpdateAvailable(Path repository, Path trackedCommitIdPath) {
-    
+
     String trackedCommitId = this.context.getFileAccess().readFileContent(trackedCommitIdPath);
-    if (trackedCommitId == null)
+    if (trackedCommitId == null) {
       return true;
     }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
@@ -77,7 +77,7 @@ public class GitContextImpl implements GitContext {
     try {
       trackedCommitId = Files.readString(trackedCommitIdPath);
     } catch (IOException e) {
-      return false;
+      return true;
     }
     String remoteFailureMessage = String.format("Failed to get the remote commit id of settings repository '%s', missing remote upstream branch?", repository);
     String remoteCommitId = runGitCommandAndGetSingleOutput(remoteFailureMessage, repository, ProcessMode.DEFAULT_CAPTURE, "rev-parse", "@{u}");

--- a/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/git/GitContextImpl.java
@@ -72,13 +72,12 @@ public class GitContextImpl implements GitContext {
 
   @Override
   public boolean isRepositoryUpdateAvailable(Path repository, Path trackedCommitIdPath) {
-
-    String trackedCommitId;
-    try {
-      trackedCommitId = Files.readString(trackedCommitIdPath);
-    } catch (IOException e) {
+    
+    String trackedCommitId = this.context.getFileAccess().readFileContent(trackedCommitIdPath);
+    if (trackedCommitId == null)
       return true;
     }
+
     String remoteFailureMessage = String.format("Failed to get the remote commit id of settings repository '%s', missing remote upstream branch?", repository);
     String remoteCommitId = runGitCommandAndGetSingleOutput(remoteFailureMessage, repository, ProcessMode.DEFAULT_CAPTURE, "rev-parse", "@{u}");
     return !trackedCommitId.equals(remoteCommitId);


### PR DESCRIPTION
### This PR fixes #1833 

### Implemented changes:

When the `.commit.id` file is missing in the setup, the settings repo is assumed to be up-to-date and not pulled, even if there are new remote changes. The behavior has changed as follows: If the `.commit.id` file is missing, the settings repo is always cloned or pulled and the `.commit.id` file is recreated.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
