### PR TITLE
#1665: Separate OSType and Architecture detection in Integration tests.

### DIFF
--- a/cli/src/test/all-tests-functions.sh
+++ b/cli/src/test/all-tests-functions.sh
@@ -101,8 +101,8 @@ function doGetArchNameForOs() {
     windows)
       # Prefer Windows-native environment variables (more reliable than uname in Git Bash/MSYS/Cygwin).
       # Normalize to lower-case for comparisons.
-      archEnv="$(printf '%s' "${PROCESSOR_ARCHITECTURE:-}" | tr '[:upper:]' '[:lower:]')"
-      archWow="$(printf '%s' "${PROCESSOR_ARCHITEW6432:-}" | tr '[:upper:]' '[:lower:]')"
+      archEnv="${PROCESSOR_ARCHITECTURE,,}"
+      archWow=${PROCESSOR_ARCHITEW6432,,}"
 
       # If running as 32-bit on 64-bit Windows, PROCESSOR_ARCHITEW6432 may reveal the underlying OS arch.
       case "${archWow:-$archEnv}" in

--- a/cli/src/test/all-tests-functions.sh
+++ b/cli/src/test/all-tests-functions.sh
@@ -44,8 +44,12 @@ function doDownloadRelease () {
     # Change OS type based on github workflow matrix.os name
     local osType
     osType=$(doGetOsType)
-    architecture=$(doGetArchNameForOs "$osType")
+    local architecture=$(doGetArchNameForOs "$osType")
     url=$(grep "href=\"https://.*${osType}-${architecture}.tar.gz" "$pageHtmlLocal" | grep -o "https://[^\"]*${osType}-${architecture}.tar.gz" | head -1)
+    if [ -z "$url" ]; then
+      doError "No release found for ${osType}-${architecture}"
+      exit 1
+    fi
     echo "Trying to download IDEasy for OS: ${osType} from: ${url} to: ${IDEASY_COMPRESSED_FILE:?} ..."
     curl -o "${IDEASY_COMPRESSED_FILE:?}" "$url"
     rm "${pageHtmlLocal:?}"
@@ -73,7 +77,7 @@ function doGetOsType() {
   echo "$osType"
 }
 
-doGetArchNameForOs() {
+function doGetArchNameForOs() {
   local machine archEnv archWow
   local osType="$1"
 

--- a/cli/src/test/all-tests-functions.sh
+++ b/cli/src/test/all-tests-functions.sh
@@ -44,7 +44,8 @@ function doDownloadRelease () {
     # Change OS type based on github workflow matrix.os name
     local osType
     osType=$(doGetOsType)
-    url=$(grep "href=\"https://.*${osType}.tar.gz" "$pageHtmlLocal" | grep -o "https://[^\"]*${osType}.tar.gz" | head -1)
+    architecture=$(doGetArchNameForOs "$osType")
+    url=$(grep "href=\"https://.*${osType}-${architecture}.tar.gz" "$pageHtmlLocal" | grep -o "https://[^\"]*${osType}-${architecture}.tar.gz" | head -1)
     echo "Trying to download IDEasy for OS: ${osType} from: ${url} to: ${IDEASY_COMPRESSED_FILE:?} ..."
     curl -o "${IDEASY_COMPRESSED_FILE:?}" "$url"
     rm "${pageHtmlLocal:?}"
@@ -55,27 +56,84 @@ function doGetOsType() {
   local osType
   case "$OSTYPE" in
     msys*|cygwin*|win32*)
-      osType="windows-x64"
+      osType="windows"
       ;;
     linux*|gnu*)
-      osType="linux-x64"
+      osType="linux"
       ;;
     darwin*|macos*)
-      # Try to distinguish between Apple Silicon and Intel Macs
-      if sysctl -n machdep.cpu.brand_string 2>/dev/null | grep -qi "Apple"; then
-        osType="mac-arm64"
-      else
-        osType="mac-x64"
-      fi
+      osType="mac"
       ;;
     *)
       echo "Unknown OSTYPE: $OSTYPE. Falling back to windows (most common developer machine)." >&2
-      osType="windows-x64"
+      osType="windows"
       ;;
   esac
   echo "Detected OS type: ${osType}" >&2
   echo "$osType"
 }
+
+doGetArchNameForOs() {
+  local machine archEnv archWow
+  local osType="$1"
+
+  case "$osType" in
+    linux|mac)
+      machine="$(uname -m 2>/dev/null || echo "")"
+      case "$machine" in
+        arm64|aarch64)
+          echo "arm64"
+          ;;
+        x86_64|amd64)
+          echo "x64"
+          ;;
+        *)
+          echo "Unknown architecture from uname -m: '$machine' (osType=$osType). Falling back to x64." >&2
+          echo "x64"
+          ;;
+      esac
+      ;;
+
+    windows)
+      # Prefer Windows-native environment variables (more reliable than uname in Git Bash/MSYS/Cygwin).
+      # Normalize to lower-case for comparisons.
+      archEnv="$(printf '%s' "${PROCESSOR_ARCHITECTURE:-}" | tr '[:upper:]' '[:lower:]')"
+      archWow="$(printf '%s' "${PROCESSOR_ARCHITEW6432:-}" | tr '[:upper:]' '[:lower:]')"
+
+      # If running as 32-bit on 64-bit Windows, PROCESSOR_ARCHITEW6432 may reveal the underlying OS arch.
+      case "${archWow:-$archEnv}" in
+        arm64)
+          echo "arm64"
+          ;;
+        amd64|x86_64)
+          echo "x64"
+          ;;
+        *)
+          # Best-effort fallback for environments where env vars aren't available/accurate.
+          machine="$(uname -m 2>/dev/null || echo "")"
+          case "$machine" in
+            arm64|aarch64)
+              echo "arm64"
+              ;;
+            x86_64|amd64)
+              echo "x64"
+              ;;
+            *)
+              echo "Unknown Windows architecture (PROCESSOR_ARCHITECTURE='${archEnv}', PROCESSOR_ARCHITEW6432='${archWow}', uname -m='${machine}'). Falling back to x64." >&2
+              echo "x64"
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+
+    *)
+      echo "Unsupported osType: $osType. Falling back to x64." >&2
+      echo "x64"
+      ;;
+  esac
+}
+
 
 # doCreateLink <source> <target-link>
 function doCreateLink() {


### PR DESCRIPTION
### This PR fixes #1665 

### Implemented changes:

* Split OSType and Architecture detection into two separate functions in the all-tests-functions.sh file
* combine OSType and architecture to generate valid download url 
* Added detection for linux-x64,linux-arm64, mac-x64,mac-arm64, windows-x64, and windows-arm64

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
