### PR TITLE
#1821: Back up and restore user state before and after integration tests

### DIFF
--- a/cli/src/test/all-tests.sh
+++ b/cli/src/test/all-tests.sh
@@ -28,11 +28,13 @@ function doRestoreLicenseAgreement() {
 function doRestoreWindowsRegistry() {
   # restore HKCU\Environment on windows
   # reg import only adds/overwrites, so delete existing values first
-  if [ -n "$BAK_HKCU_ENVIRONMENT" ] && [ -f "$BAK_HKCU_ENVIRONMENT" ]; then
-    reg delete "HKCU\\Environment" //va //f
-    reg import "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")"
-    rm -f "$BAK_HKCU_ENVIRONMENT"
-    echo "Restored HKCU\\Environment from backup"
+  if doIsWindows; then
+    if [ -n "$BAK_HKCU_ENVIRONMENT" ] && [ -f "$BAK_HKCU_ENVIRONMENT" ]; then
+      reg delete "HKCU\\Environment" //va //f
+      reg import "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")"
+      rm -f "$BAK_HKCU_ENVIRONMENT"
+      echo "Restored HKCU\\Environment from backup"
+    fi
   fi
 }
 

--- a/cli/src/test/all-tests.sh
+++ b/cli/src/test/all-tests.sh
@@ -26,7 +26,8 @@ function doRestoreLicenseAgreement() {
 }
 
 function doRestoreWindowsRegistry() {
-  # Restore Windows user environment registry from backup
+  # restore HKCU\Environment on windows
+  # reg import only adds/overwrites, so delete existing values first
   if [ -n "$BAK_HKCU_ENVIRONMENT" ] && [ -f "$BAK_HKCU_ENVIRONMENT" ]; then
     reg delete "HKCU\\Environment" //va //f >/dev/null 2>&1
     reg import "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")" >/dev/null 2>&1
@@ -133,7 +134,7 @@ if [ -f "$HOME/.zshrc" ]; then
   BAK_ZSHRC="$HOME/.zshrc.ideasy-test-backup"
   cp "$HOME/.zshrc" "$BAK_ZSHRC"
 fi
-# On Windows, back up user environment registry before tests
+# backup HKCU\Environment on windows
 BAK_HKCU_ENVIRONMENT=""
 if doIsWindows; then
   BAK_HKCU_ENVIRONMENT="$HOME/hkcu-environment.ideasy-test-backup.reg"

--- a/cli/src/test/all-tests.sh
+++ b/cli/src/test/all-tests.sh
@@ -14,6 +14,17 @@ function doRestoreRcFiles() {
   fi
 }
 
+function doRestoreLicenseAgreement() {
+  # Restore license agreement from backup, or remove it if it didn't pre-exist
+  if [ -n "$BAK_LICENSE_AGREEMENT" ] && [ -f "$BAK_LICENSE_AGREEMENT" ]; then
+    mv "$BAK_LICENSE_AGREEMENT" "$LICENSE_AGREEMENT"
+    echo "Restored ~/.ide/.license.agreement from backup"
+  else
+    rm -f "$LICENSE_AGREEMENT"
+    echo "Removed ~/.ide/.license.agreement created by test run"
+  fi
+}
+
 function doResetVariables() {
   IDE_HOME="${DEBUG_INTEGRATION_TEST}"
   export IDE_ROOT="${IDE_HOME}/projects"
@@ -81,8 +92,16 @@ function doTests () {
 }
 
 # Workaround to create license.agreement file and simulate a proper installation.
-mkdir -p "${HOME}"/.ide
-touch "${HOME}"/.ide/.license.agreement
+# Back up any pre-existing file so tests (which may delete it) can't destroy user's state.
+LICENSE_AGREEMENT="${HOME}/.ide/.license.agreement"
+BAK_LICENSE_AGREEMENT=""
+mkdir -p "${HOME}/.ide"
+if [ -f "${LICENSE_AGREEMENT}" ]; then
+  BAK_LICENSE_AGREEMENT="${LICENSE_AGREEMENT}.ideasy-test-backup"
+  cp "${LICENSE_AGREEMENT}" "${BAK_LICENSE_AGREEMENT}"
+else
+  touch "${LICENSE_AGREEMENT}"
+fi
 
 source "$(dirname "${0}")"/all-tests-functions.sh
 
@@ -106,7 +125,7 @@ if [ -f "$HOME/.zshrc" ]; then
   cp "$HOME/.zshrc" "$BAK_ZSHRC"
 fi
 
-trap "export PATH=\"${BAK_PATH}\" && export IDE_ROOT=\"${BAK_IDE_ROOT}\" && doRestoreRcFiles && echo \"PATH, IDE_ROOT, and shell RC files restored\"" EXIT
+trap "export PATH=\"${BAK_PATH}\" && export IDE_ROOT=\"${BAK_IDE_ROOT}\" && doRestoreRcFiles && doRestoreLicenseAgreement && echo \"PATH, IDE_ROOT, and shell RC files restored\"" EXIT
 
 # Switch IDEasy binary file name based on github workflow matrix.os name (first argument of all-tests.sh)
 BINARY_FILE_NAME="ideasy"

--- a/cli/src/test/all-tests.sh
+++ b/cli/src/test/all-tests.sh
@@ -15,13 +15,23 @@ function doRestoreRcFiles() {
 }
 
 function doRestoreLicenseAgreement() {
-  # Restore license agreement from backup, or remove it if it didn't pre-exist
+  # Restore license agreement file to its pre-test state
   if [ -n "$BAK_LICENSE_AGREEMENT" ] && [ -f "$BAK_LICENSE_AGREEMENT" ]; then
     mv "$BAK_LICENSE_AGREEMENT" "$LICENSE_AGREEMENT"
     echo "Restored ~/.ide/.license.agreement from backup"
   else
     rm -f "$LICENSE_AGREEMENT"
     echo "Removed ~/.ide/.license.agreement created by test run"
+  fi
+}
+
+function doRestoreWindowsRegistry() {
+  # Restore Windows user environment registry from backup
+  if [ -n "$BAK_HKCU_ENVIRONMENT" ] && [ -f "$BAK_HKCU_ENVIRONMENT" ]; then
+    reg delete "HKCU\\Environment" //va //f >/dev/null 2>&1
+    reg import "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")" >/dev/null 2>&1
+    rm -f "$BAK_HKCU_ENVIRONMENT"
+    echo "Restored HKCU\\Environment from backup"
   fi
 }
 
@@ -92,7 +102,6 @@ function doTests () {
 }
 
 # Workaround to create license.agreement file and simulate a proper installation.
-# Back up any pre-existing file so tests (which may delete it) can't destroy user's state.
 LICENSE_AGREEMENT="${HOME}/.ide/.license.agreement"
 BAK_LICENSE_AGREEMENT=""
 mkdir -p "${HOME}/.ide"
@@ -124,8 +133,14 @@ if [ -f "$HOME/.zshrc" ]; then
   BAK_ZSHRC="$HOME/.zshrc.ideasy-test-backup"
   cp "$HOME/.zshrc" "$BAK_ZSHRC"
 fi
+# On Windows, back up user environment registry before tests
+BAK_HKCU_ENVIRONMENT=""
+if doIsWindows; then
+  BAK_HKCU_ENVIRONMENT="$HOME/hkcu-environment.ideasy-test-backup.reg"
+  reg export "HKCU\\Environment" "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")" //y >/dev/null
+fi
 
-trap "export PATH=\"${BAK_PATH}\" && export IDE_ROOT=\"${BAK_IDE_ROOT}\" && doRestoreRcFiles && doRestoreLicenseAgreement && echo \"PATH, IDE_ROOT, and shell RC files restored\"" EXIT
+trap "export PATH=\"${BAK_PATH}\" && export IDE_ROOT=\"${BAK_IDE_ROOT}\" && doRestoreRcFiles && doRestoreLicenseAgreement && doRestoreWindowsRegistry && echo \"Test environment restored\"" EXIT
 
 # Switch IDEasy binary file name based on github workflow matrix.os name (first argument of all-tests.sh)
 BINARY_FILE_NAME="ideasy"

--- a/cli/src/test/all-tests.sh
+++ b/cli/src/test/all-tests.sh
@@ -29,8 +29,8 @@ function doRestoreWindowsRegistry() {
   # restore HKCU\Environment on windows
   # reg import only adds/overwrites, so delete existing values first
   if [ -n "$BAK_HKCU_ENVIRONMENT" ] && [ -f "$BAK_HKCU_ENVIRONMENT" ]; then
-    reg delete "HKCU\\Environment" //va //f >/dev/null 2>&1
-    reg import "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")" >/dev/null 2>&1
+    reg delete "HKCU\\Environment" //va //f
+    reg import "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")"
     rm -f "$BAK_HKCU_ENVIRONMENT"
     echo "Restored HKCU\\Environment from backup"
   fi
@@ -102,17 +102,6 @@ function doTests () {
   exit 0
 }
 
-# Workaround to create license.agreement file and simulate a proper installation.
-LICENSE_AGREEMENT="${HOME}/.ide/.license.agreement"
-BAK_LICENSE_AGREEMENT=""
-mkdir -p "${HOME}/.ide"
-if [ -f "${LICENSE_AGREEMENT}" ]; then
-  BAK_LICENSE_AGREEMENT="${LICENSE_AGREEMENT}.ideasy-test-backup"
-  cp "${LICENSE_AGREEMENT}" "${BAK_LICENSE_AGREEMENT}"
-else
-  touch "${LICENSE_AGREEMENT}"
-fi
-
 source "$(dirname "${0}")"/all-tests-functions.sh
 
 # Remove side-effects
@@ -134,11 +123,21 @@ if [ -f "$HOME/.zshrc" ]; then
   BAK_ZSHRC="$HOME/.zshrc.ideasy-test-backup"
   cp "$HOME/.zshrc" "$BAK_ZSHRC"
 fi
+# Workaround to create license.agreement file and simulate a proper installation.
+LICENSE_AGREEMENT="${HOME}/.ide/.license.agreement"
+BAK_LICENSE_AGREEMENT=""
+mkdir -p "${HOME}/.ide"
+if [ -f "${LICENSE_AGREEMENT}" ]; then
+  BAK_LICENSE_AGREEMENT="${LICENSE_AGREEMENT}.ideasy-test-backup"
+  cp "${LICENSE_AGREEMENT}" "${BAK_LICENSE_AGREEMENT}"
+else
+  touch "${LICENSE_AGREEMENT}"
+fi
 # backup HKCU\Environment on windows
 BAK_HKCU_ENVIRONMENT=""
 if doIsWindows; then
   BAK_HKCU_ENVIRONMENT="$HOME/hkcu-environment.ideasy-test-backup.reg"
-  reg export "HKCU\\Environment" "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")" //y >/dev/null
+  reg export "HKCU\\Environment" "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")" //y
 fi
 
 trap "export PATH=\"${BAK_PATH}\" && export IDE_ROOT=\"${BAK_IDE_ROOT}\" && doRestoreRcFiles && doRestoreLicenseAgreement && doRestoreWindowsRegistry && echo \"Test environment restored\"" EXIT

--- a/cli/src/test/all-tests.sh
+++ b/cli/src/test/all-tests.sh
@@ -27,10 +27,8 @@ function doRestoreLicenseAgreement() {
 
 function doRestoreWindowsRegistry() {
   # restore HKCU\Environment on windows
-  # reg import only adds/overwrites, so delete existing values first
   if doIsWindows; then
     if [ -n "$BAK_HKCU_ENVIRONMENT" ] && [ -f "$BAK_HKCU_ENVIRONMENT" ]; then
-      reg delete "HKCU\\Environment" //va //f
       reg import "$(cygpath -w "$BAK_HKCU_ENVIRONMENT")"
       rm -f "$BAK_HKCU_ENVIRONMENT"
       echo "Restored HKCU\\Environment from backup"


### PR DESCRIPTION
### This PR fixes [#1821](https://github.com/devonfw/IDEasy/issues/1821)

### Implemented changes:

* License agreement and windows registries are backed up and restored during integration tests.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)