### PR TITLE
Test quickfix: Load global user settings outside project

### DIFF
--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandletGlobalTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandletGlobalTest.java
@@ -34,8 +34,12 @@ class EnvironmentCommandletGlobalTest extends AbstractIdeContextTest {
     env.run();
 
     // assert
+    String expectedEntry = "export FOO=\"bar\"";
+    if (context.getSystemInfo().isWindows()) {
+      expectedEntry = "FOO=bar";
+    }
     assertThat(context).log().hasEntries( //
-        IdeLogEntry.ofProcessable("export FOO=\"bar\"") //
+        IdeLogEntry.ofProcessable(expectedEntry) //
     );
   }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandletGlobalTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandletGlobalTest.java
@@ -31,15 +31,12 @@ class EnvironmentCommandletGlobalTest extends AbstractIdeContextTest {
     EnvironmentCommandlet env = context.getCommandletManager().getCommandlet(EnvironmentCommandlet.class);
 
     // act
+    env.bash.setValue(true);
     env.run();
 
     // assert
-    String expectedEntry = "export FOO=\"bar\"";
-    if (context.getSystemInfo().isWindows()) {
-      expectedEntry = "FOO=bar";
-    }
     assertThat(context).log().hasEntries( //
-        IdeLogEntry.ofProcessable(expectedEntry) //
+        IdeLogEntry.ofProcessable("export FOO=\"bar\"") //
     );
   }
 }


### PR DESCRIPTION
### This PR fixes #1270

PR #1813 added a test that was green in CI build but failed on Windows.
This is fixed by this PR.

### Implemented changes:

* fixed environment test for windows
---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`

