### PR TITLE
#1643 improve ux on syntax error

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1823[#1823]: Fix IDEasy creates duplicate entries in .gitconfig
 * https://github.com/devonfw/IDEasy/issues/1724[#1724]: Add gui commandlet
 * https://github.com/devonfw/IDEasy/issues/1853[#1853]: Add ARM releases for VSCode on Mac
+* https://github.com/devonfw/IDEasy/issues/1643[#1643]: Improve CLI error messages for unknown options and property values
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/44?closed=1[milestone 2026.05.001].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -1146,20 +1146,40 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
       }
       activateLogging(cmd);
       verifyIdeMinVersion(false);
-      if (result != null) {
-        LOG.error(result.getErrorMessage());
-      }
+
       if (cmd != null && result instanceof ValidationState res) {
         final CliArgument arg = res.getCliArgument();
         if (arg != null) {
-          step.error("Option {} not found for commandlet {}.", arg.get(), cmd.getName());
+          if (arg.getValue() != null) {
+            // --flag=value with an invalid value: reconstruct the error message here to control order
+            String exMsg = res.getParseExceptionMessage();
+            if (exMsg != null) {
+              step.error(Property.INVALID_ARGUMENT + ": {}", arg.getValue(), arg.getKey(), cmd.getName(), exMsg);
+            } else {
+              step.error(Property.INVALID_ARGUMENT, arg.getValue(), arg.getKey(), cmd.getName());
+            }
+            String hint = res.getParseHint();
+            if (hint != null) {
+              LOG.error(Property.INVALID_ARGUMENT_HELP_MULTIPLE, hint);
+            }
+          } else {
+            // Unknown option flag or positional value with invalid content
+            step.error("Option {} not found for commandlet {}.", arg.get(), cmd.getName());
+            String hint = res.getParseHint();
+            if (hint != null) {
+              LOG.error(Property.INVALID_ARGUMENT_HELP_MULTIPLE, hint);
+            }
+          }
           IdeLogLevel.INTERACTION.log(LOG, "To see the available options and arguments call the following command:\n"
               + "ide {} help", cmd.getName());
           return 1;
         }
       }
-      step.error("Invalid arguments: {}", current.getArgs());
-      IdeLogLevel.INTERACTION.log(LOG, "For additional details run ide help {}", cmd == null ? "" : cmd.getName());
+      if (result != null && (!(result instanceof ValidationState) || ((ValidationState) result).getCliArgument() == null) ) {
+        LOG.error(result.getErrorMessage());
+        step.error("Invalid arguments: {}", current.getArgs());
+        IdeLogLevel.INTERACTION.log(LOG, "For additional details run ide help {}", cmd == null ? "" : cmd.getName());
+      }
       return 1;
     } catch (Throwable t) {
       activateLogging(cmd);
@@ -1572,6 +1592,9 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
       if (!matches) {
         ValidationState state = new ValidationState(null);
         state.addErrorMessage("No matching property found");
+        state.setCliArgument(currentArgument);
+        state.setParseHint(currentProperty.getAndClearLastParseHint());
+        state.setParseExceptionMessage(currentProperty.getAndClearLastParseExceptionMessage());
         return state;
       }
       currentArgument = arguments.current();

--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -1149,6 +1149,15 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
       if (result != null) {
         LOG.error(result.getErrorMessage());
       }
+      if (cmd != null && result instanceof ValidationState res) {
+        final CliArgument arg = res.getCliArgument();
+        if (arg != null) {
+          step.error("Option {} not found for commandlet {}.", arg.get(), cmd.getName());
+          IdeLogLevel.INTERACTION.log(LOG, "To see the available options and arguments call the following command:\n"
+              + "ide {} help", cmd.getName());
+          return 1;
+        }
+      }
       step.error("Invalid arguments: {}", current.getArgs());
       IdeLogLevel.INTERACTION.log(LOG, "For additional details run ide help {}", cmd == null ? "" : cmd.getName());
       return 1;
@@ -1542,6 +1551,7 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
       if (currentProperty == null) {
         LOG.trace("No option or next value found");
         ValidationState state = new ValidationState(null);
+        state.setCliArgument(currentArgument);
         state.addErrorMessage("No matching property found");
         return state;
       }

--- a/cli/src/main/java/com/devonfw/tools/ide/property/BooleanProperty.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/property/BooleanProperty.java
@@ -82,6 +82,12 @@ public class BooleanProperty extends Property<Boolean> {
   }
 
   @Override
+  protected String getValidValuesErrorHint(IdeContext context, Commandlet commandlet) {
+
+    return "'true', 'yes', 'false', 'no'";
+  }
+
+  @Override
   protected boolean applyValue(String argValue, boolean lookahead, CliArguments args, IdeContext context, Commandlet commandlet,
       CompletionCandidateCollector collector) {
 

--- a/cli/src/main/java/com/devonfw/tools/ide/property/CommandletProperty.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/property/CommandletProperty.java
@@ -1,5 +1,7 @@
 package com.devonfw.tools.ide.property;
 
+import java.util.stream.Collectors;
+
 import com.devonfw.tools.ide.commandlet.Commandlet;
 import com.devonfw.tools.ide.completion.CompletionCandidateCollector;
 import com.devonfw.tools.ide.context.IdeContext;
@@ -56,6 +58,15 @@ public class CommandletProperty extends Property<Commandlet> {
         collector.add(cmdName, null, null, cmd);
       }
     }
+  }
+
+  @Override
+  protected String getValidValuesErrorHint(IdeContext context, Commandlet commandlet) {
+
+    return context.getCommandletManager().getCommandlets().stream()
+        .map(Commandlet::getName)
+        .map(n -> "'" + n + "'")
+        .collect(Collectors.joining(", "));
   }
 
   @Override

--- a/cli/src/main/java/com/devonfw/tools/ide/property/EnumProperty.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/property/EnumProperty.java
@@ -1,6 +1,8 @@
 package com.devonfw.tools.ide.property;
 
 import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.devonfw.tools.ide.commandlet.Commandlet;
 import com.devonfw.tools.ide.completion.CompletionCandidateCollector;
@@ -46,6 +48,19 @@ public class EnumProperty<V extends Enum<V>> extends Property<V> {
     }
 
     throw new IllegalArgumentException(String.format("Invalid Enum option: %s", valueAsString));
+  }
+
+  /**
+   * @return All possible EnumValues as string, delimited by a comma.
+   */
+  public String getEnumValuesAsString() {
+    return Stream.of(this.valueType.getEnumConstants()).map(c -> String.format("'%s'", c.toString().toLowerCase(Locale.ROOT))).collect(Collectors.joining(", "));
+  }
+
+  @Override
+  protected String getValidValuesErrorHint(IdeContext context, Commandlet commandlet) {
+
+    return getEnumValuesAsString();
   }
 
   @Override

--- a/cli/src/main/java/com/devonfw/tools/ide/property/Property.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/property/Property.java
@@ -32,7 +32,8 @@ public abstract class Property<V> {
 
   private static final Logger LOG = LoggerFactory.getLogger(Property.class);
 
-  private static final String INVALID_ARGUMENT = "Invalid CLI argument '{}' for property '{}' of commandlet '{}'";
+  public static final String INVALID_ARGUMENT = "Invalid CLI argument '{}' for property '{}' of commandlet '{}'";
+  public static final String INVALID_ARGUMENT_HELP_MULTIPLE = "Did you mean one of [{}]?";
 
   private static final String INVALID_ARGUMENT_WITH_EXCEPTION_MESSAGE = INVALID_ARGUMENT + ": {}";
 
@@ -52,6 +53,10 @@ public abstract class Property<V> {
 
   /** @see #getValue() */
   protected final List<V> value = new ArrayList<>();
+
+  private String lastParseHint;
+
+  private String lastParseExceptionMessage;
 
   /**
    * The constructor.
@@ -306,17 +311,49 @@ public abstract class Property<V> {
    */
   public final boolean assignValueAsString(String valueAsString, IdeContext context, Commandlet commandlet) {
 
+    this.lastParseHint = null;
+    this.lastParseExceptionMessage = null;
     try {
       setValueAsString(valueAsString, context);
       return true;
     } catch (Exception e) {
-      if (e instanceof IllegalArgumentException) {
-        LOG.warn(INVALID_ARGUMENT, valueAsString, getNameOrAlias(), commandlet.getName());
-      } else {
-        LOG.warn(INVALID_ARGUMENT_WITH_EXCEPTION_MESSAGE, valueAsString, getNameOrAlias(), commandlet.getName(), e.getMessage());
+      if (!(e instanceof IllegalArgumentException)) {
+        this.lastParseExceptionMessage = e.getMessage();
       }
+      this.lastParseHint = getValidValuesErrorHint(context, commandlet);
       return false;
     }
+  }
+
+  /**
+   * @return the hint string for the last failed parse (e.g. "Did you mean one of [...]?"), and clears it. Returns {@code null} if no hint is available.
+   */
+  public String getAndClearLastParseHint() {
+
+    String h = this.lastParseHint;
+    this.lastParseHint = null;
+    return h;
+  }
+
+  /**
+   * @return the exception message from the last failed parse if the exception was not an {@link IllegalArgumentException}, and clears it. Returns {@code null}
+   *     otherwise.
+   */
+  public String getAndClearLastParseExceptionMessage() {
+
+    String m = this.lastParseExceptionMessage;
+    this.lastParseExceptionMessage = null;
+    return m;
+  }
+
+  /**
+   * @param context the {@link IdeContext}.
+   * @param commandlet the {@link Commandlet} owning this property.
+   * @return a formatted string of valid values to show as a hint when an invalid value is given, or {@code null} if no hint is available.
+   */
+  protected String getValidValuesErrorHint(IdeContext context, Commandlet commandlet) {
+
+    return null;
   }
 
   /**

--- a/cli/src/main/java/com/devonfw/tools/ide/property/ToolProperty.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/property/ToolProperty.java
@@ -1,5 +1,7 @@
 package com.devonfw.tools.ide.property;
 
+import java.util.stream.Collectors;
+
 import com.devonfw.tools.ide.commandlet.Commandlet;
 import com.devonfw.tools.ide.completion.CompletionCandidateCollector;
 import com.devonfw.tools.ide.context.IdeContext;
@@ -66,6 +68,16 @@ public class ToolProperty extends Property<ToolCommandlet> {
   public ToolCommandlet parse(String valueAsString, IdeContext context) {
 
     return context.getCommandletManager().getRequiredToolCommandlet(valueAsString);
+  }
+
+  @Override
+  protected String getValidValuesErrorHint(IdeContext context, Commandlet commandlet) {
+
+    return context.getCommandletManager().getCommandlets().stream()
+        .filter(c -> c instanceof ToolCommandlet)
+        .map(Commandlet::getName)
+        .map(n -> "'" + n + "'")
+        .collect(Collectors.joining(", "));
   }
 
   @Override

--- a/cli/src/main/java/com/devonfw/tools/ide/validation/ValidationState.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/validation/ValidationState.java
@@ -1,5 +1,7 @@
 package com.devonfw.tools.ide.validation;
 
+import com.devonfw.tools.ide.cli.CliArgument;
+
 /**
  * Implementation of {@link ValidationResult} as a mutable state that can collect errors dynamically.
  */
@@ -8,6 +10,11 @@ public class ValidationState implements ValidationResult {
   private final String propertyName;
 
   private StringBuilder errorMessage;
+
+  /**
+   * Field for the {@link CliArgument} that was the reason for a failed validation.
+   */
+  private CliArgument cliArgument;
 
   /**
    * The default constructor for no property.
@@ -67,5 +74,19 @@ public class ValidationState implements ValidationResult {
         addErrorMessage(result.getErrorMessage());
       }
     }
+  }
+
+  /**
+   * @param cliArgument The {@link CliArgument} that failed the validation.
+   */
+  public void setCliArgument(CliArgument cliArgument) {
+    this.cliArgument = cliArgument;
+  }
+
+  /**
+   * @return The {@link CliArgument} that failed the validation.
+   */
+  public CliArgument getCliArgument() {
+    return this.cliArgument;
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/validation/ValidationState.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/validation/ValidationState.java
@@ -76,6 +76,10 @@ public class ValidationState implements ValidationResult {
     }
   }
 
+  private String parseHint;
+
+  private String parseExceptionMessage;
+
   /**
    * @param cliArgument The {@link CliArgument} that failed the validation.
    */
@@ -88,5 +92,33 @@ public class ValidationState implements ValidationResult {
    */
   public CliArgument getCliArgument() {
     return this.cliArgument;
+  }
+
+  /**
+   * @param parseHint the hint to display when a parse error occurred (e.g. a list of valid values).
+   */
+  public void setParseHint(String parseHint) {
+    this.parseHint = parseHint;
+  }
+
+  /**
+   * @return the hint for the failed parse, or {@code null} if none.
+   */
+  public String getParseHint() {
+    return this.parseHint;
+  }
+
+  /**
+   * @param parseExceptionMessage the message from a non-{@link IllegalArgumentException} parse failure.
+   */
+  public void setParseExceptionMessage(String parseExceptionMessage) {
+    this.parseExceptionMessage = parseExceptionMessage;
+  }
+
+  /**
+   * @return the exception message from a non-{@link IllegalArgumentException} parse failure, or {@code null}.
+   */
+  public String getParseExceptionMessage() {
+    return this.parseExceptionMessage;
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/version/VersionIdentifier.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/version/VersionIdentifier.java
@@ -1,7 +1,9 @@
 package com.devonfw.tools.ide.version;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,8 +90,31 @@ public final class VersionIdentifier implements VersionObject<VersionIdentifier>
         return vi;
       }
     }
+    List<VersionIdentifier> closest = findClosestVersions(version, versions, 5);
+    String closestStr = closest.stream().map(Object::toString).collect(Collectors.joining(", "));
     throw new CliException(
-        "Could not find any version matching '" + version + "' - there are " + versions.size() + " version(s) available but none matched!");
+        "Could not find any version matching '" + version + "' - there are " + versions.size()
+            + " version(s) available but none matched!\nDid you mean one of: " + closestStr + "?");
+  }
+
+  private static List<VersionIdentifier> findClosestVersions(GenericVersionRange version, List<VersionIdentifier> versions, int maxCount) {
+
+    if (version instanceof VersionIdentifier vi && !vi.isPattern()) {
+      long requestedMajor = vi.getStart().getNumber();
+      List<VersionIdentifier> majorMatches = new ArrayList<>();
+      for (VersionIdentifier v : versions) {
+        if (v.getStart().getNumber() == requestedMajor) {
+          majorMatches.add(v);
+          if (majorMatches.size() >= maxCount) {
+            break;
+          }
+        }
+      }
+      if (!majorMatches.isEmpty()) {
+        return majorMatches;
+      }
+    }
+    return versions.size() <= maxCount ? versions : versions.subList(0, maxCount);
   }
 
   /**

--- a/cli/src/test/java/com/devonfw/tools/ide/cli/CliAdvancedParsingTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/cli/CliAdvancedParsingTest.java
@@ -1,9 +1,14 @@
 package com.devonfw.tools.ide.cli;
 
+import com.devonfw.tools.ide.commandlet.Commandlet;
+import com.devonfw.tools.ide.tool.ToolCommandlet;
+
 import org.junit.jupiter.api.Test;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeTestContext;
+
+import java.util.stream.Collectors;
 
 /**
  * Integration test of {@link com.devonfw.tools.ide.context.AbstractIdeContext#run(CliArguments) CLI parsing}.
@@ -44,5 +49,38 @@ class CliAdvancedParsingTest extends AbstractIdeContextTest {
     int success = context.run(args);
     // assert
     assertThat(success).isEqualTo(0);
+  }
+
+  @Test
+  void testRunCommandletWithUnknownOption() {
+    IdeTestContext context = newContext(PROJECT_MVN);
+    CliArguments args = new CliArguments("install", "unknownOption");
+    args.next();
+    final String possibleCommands = context.getCommandletManager().getCommandlets().stream()
+        .filter(c -> c instanceof ToolCommandlet)
+        .map(Commandlet::getName)
+        .map(n -> "'" + n + "'")
+        .collect(Collectors.joining(", "));
+
+    int resultStatus = context.run(args);
+    assertThat(resultStatus).isEqualTo(1);
+    assertThat(context).logAtError().hasMessage("Option unknownOption not found for commandlet install.");
+    assertThat(context).logAtError().hasMessage("Did you mean one of [" + possibleCommands + "]?");
+    assertThat(context).logAtInteraction().hasMessage("To see the available options and arguments call the following command:\n"
+        + "ide install help");
+  }
+
+  @Test
+  void testRunCommandletWithUnknownOptionParamValue() {
+    IdeTestContext context = newContext(PROJECT_MVN);
+    CliArguments args = new CliArguments("set-version", "intellij", "--cfg=config");
+    args.next();
+
+    int resultStatus = context.run(args);
+    assertThat(resultStatus).isEqualTo(1);
+    assertThat(context).logAtError().hasMessage("Invalid CLI argument 'config' for property '--cfg' of commandlet 'set-version'");
+    assertThat(context).logAtError().hasMessage("Did you mean one of ['user', 'settings', 'workspace', 'conf']?");
+    assertThat(context).logAtInteraction().hasMessage("To see the available options and arguments call the following command:\n"
+        + "ide set-version help");
   }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/property/EnumPropertyTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/property/EnumPropertyTest.java
@@ -52,4 +52,15 @@ class EnumPropertyTest {
 
     assertThat(collector.getCandidates().stream().map(CompletionCandidate::text)).containsExactly(expectedCandidates);
   }
+
+  @Test
+  void testGetEnumValuesAsString() {
+    final String expectedResult = "'elementzero', 'elementone', 'elementtwo'";
+
+    final EnumProperty<TestEnum> enumProp = new EnumProperty<>("", false, "", TestEnum.class);
+    final String actualResult = enumProp.getEnumValuesAsString();
+
+    assertThat(actualResult).isEqualTo(expectedResult);
+
+  }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/version/VersionIdentifierTest.java
@@ -4,10 +4,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.devonfw.tools.ide.cli.CliException;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test of {@link VersionIdentifier}.
@@ -356,6 +360,36 @@ class VersionIdentifierTest extends Assertions {
     assertThat(VersionIdentifier.of("1.0-alpha1.rc2").isStable()).isFalse();
     assertThat(VersionIdentifier.LATEST.isStable()).isTrue();
     assertThat(VersionIdentifier.LATEST_UNSTABLE.isStable()).isFalse();
+  }
+
+  @Test
+  void testResolveVersionPatternVersionFound() {
+    final VersionIdentifier identifier = VersionIdentifier.of("2025.01.002");
+    final List<VersionIdentifier> availableVersions = List.of(identifier);
+
+    final VersionIdentifier resolvedVersion = VersionIdentifier.resolveVersionPattern(identifier, availableVersions);
+    assertThat(resolvedVersion).isEqualTo(identifier);
+  }
+
+  @Test
+  void testResolveVersionPatternVersionFoundPattern() {
+    final VersionIdentifier identifier = VersionIdentifier.of("2025.01.002");
+    final VersionIdentifier identifierPattern = VersionIdentifier.of("2025.01.*");
+    final List<VersionIdentifier> availableVersions = List.of(identifier);
+
+    final VersionIdentifier resolvedVersion = VersionIdentifier.resolveVersionPattern(identifierPattern, availableVersions);
+    assertThat(resolvedVersion).isEqualTo(identifier);
+  }
+
+  @Test
+  void testResolveVersionPatternNoVersionFound() {
+    final VersionIdentifier identifier = VersionIdentifier.of("2025.01.002");
+    final VersionIdentifier identifierPattern = VersionIdentifier.of("2026.01.*");
+    final List<VersionIdentifier> availableVersions = List.of(identifier);
+
+    final Exception exception = assertThrows(CliException.class, () -> VersionIdentifier.resolveVersionPattern(identifierPattern, availableVersions));
+    assertThat(exception.getMessage()).isEqualTo("Could not find any version matching '" + identifierPattern + "' - there are " + availableVersions.size()
+        + " version(s) available but none matched!\nDid you mean one of: " + identifier + "?");
   }
 
 }


### PR DESCRIPTION
### This PR fixes #1643

### Implemented changes:

* Improved CLI error message for unknown options given for commandlet
* Improved CLI error message for unknown property value given for commandlet property
* Added additional fields on ValidationState and Property to carry option/poperty value parse errors upwards for centralized CLI error message creation
* Added test cases for parsing of arguments and new error messages

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue
