### PR TITLE
#1102: Signing IDEasy MSI Installer

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -2,6 +2,10 @@ name: Nightly Build (SNAPSHOT release)
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   # Builds all native images and uploads each binary as a separate artifact
   build-natives:
@@ -52,12 +56,32 @@ jobs:
           wix extension add WixToolset.UI.wixext/5.0.2
           wix extension add WixToolset.Util.wixext/5.0.2
           wix build Package.wxs WixUI_IDEasySetup.wxs -loc Package.en-us.wxl -ext WixToolset.UI.wixext -ext WixToolset.Util.wixext -o ideasy.msi
+      
+      - name: Upload unsigned MSI
+        if: runner.os == 'Windows'
+        id: upload-msi
+        uses: actions/upload-artifact@v4
+        with:
+          name: msi-unsigned
+          path: windows-installer/ideasy.msi
+      - name: Sign MSI
+        if: runner.os == 'Windows'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '428e13ed-ca0c-47ca-8a73-63b76cabb59b'
+          project-slug: 'IDEasy'
+          signing-policy-slug: 'test-signing'
+          artifact-configuration-slug: 'IDEasy'
+          github-artifact-id: '${{ steps.upload-msi.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: 'windows-installer/signed'
       - name: Upload MSI
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: msi
-          path: windows-installer/ideasy.msi
+          path: windows-installer/signed/ideasy.msi
 
   # Downloads all native image artifacts to cli/target and builds the project using assemblies for final deployment to OSSRH Nexus
   deploy:


### PR DESCRIPTION
### This PR fixes #1102 

### Implemented changes:

* Integrated SignPath MSI Signing: Added automated code signing for Windows MSI installers using the SignPath GitHub Action.

* Dual-Workflow Support: Enabled signing for both SNAPSHOT releases in nightly-build.yml and official releases in release.yml.

* OIDC Authentication: Added id-token: write permissions to allow secure, secret-less authentication between GitHub Actions and SignPath.

* Artifact Pipeline Update: Refactored the build process to upload unsigned binaries as temporary artifacts, sign them via SignPath, and distribute only the signed versions.

* Git Configuration: Updated .gitignore to ensure .github workflow changes are correctly tracked and not blocked by global dotfile rules.

---

## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
