### PR TITLE
#836: fix exit autocompletion

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,6 +31,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/800[#800]: Fix infinite recursion in Sonar start/stop on macOS
 * https://github.com/devonfw/IDEasy/issues/1716[#1716]: Add commandlet for Claude Code CLI
 * https://github.com/devonfw/IDEasy/issues/1844[#1844]: Fix vscode installation hanging indefinitely in WSL Linux environments
+* https://github.com/devonfw/IDEasy/issues/1950[#1950]: Fix exit autocompletion
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/44?closed=1[milestone 2026.05.001].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/ShellCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/ShellCommandlet.java
@@ -4,16 +4,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
-import java.util.List;
 
 import org.fusesource.jansi.AnsiConsole;
-import org.jline.reader.Candidate;
-import org.jline.reader.Completer;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.MaskingCallback;
-import org.jline.reader.ParsedLine;
 import org.jline.reader.Parser;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.DefaultParser;
@@ -44,6 +40,8 @@ public final class ShellCommandlet extends Commandlet {
 
   private static final int RC_EXIT = 987654321;
 
+  private static final String EXIT_COMMAND = "exit";
+
   /**
    * The constructor.
    *
@@ -73,23 +71,9 @@ public final class ShellCommandlet extends Commandlet {
     try {
       Parser parser = new DefaultParser();
       try (Terminal terminal = TerminalBuilder.builder().build()) {
-        IdeCompleter ideCompleter = new IdeCompleter((AbstractIdeContext) this.context);
+        IdeCompleter completer = new IdeCompleter((AbstractIdeContext) this.context);
 
-        Completer shellCompleter = new Completer() {
-          @Override
-          public void complete(LineReader reader, ParsedLine commandLine, List<Candidate> candidates) {
-            String currentWord = commandLine.word();
-            int wordIndex = commandLine.wordIndex();
-
-            if (wordIndex == 0 && !currentWord.isEmpty() && "exit".startsWith(currentWord)) {
-              candidates.add(new Candidate("exit"));
-            }
-
-            ideCompleter.complete(reader, commandLine, candidates);
-          }
-        };
-
-        LineReader reader = LineReaderBuilder.builder().terminal(terminal).completer(shellCompleter).parser(parser)
+        LineReader reader = LineReaderBuilder.builder().terminal(terminal).completer(completer).parser(parser)
             .variable(LineReader.LIST_MAX, AUTOCOMPLETER_MAX_RESULTS).build();
 
         // Create autosuggestion widgets
@@ -107,6 +91,10 @@ public final class ShellCommandlet extends Commandlet {
           try {
             String prompt = context.getCwd() + "$ ide ";
             line = reader.readLine(prompt, rightPrompt, (MaskingCallback) null, null);
+            line = line.trim();
+            if (EXIT_COMMAND.equals(line)) {
+              return;
+            }
             reader.getHistory().add(line);
             int rc = runCommand(line);
             if (rc == RC_EXIT) {
@@ -141,7 +129,7 @@ public final class ShellCommandlet extends Commandlet {
    */
   private int runCommand(String args) {
 
-    if ("exit".equals(args) || "quit".equals(args)) {
+    if (EXIT_COMMAND.equals(args) || "quit".equals(args)) {
       return RC_EXIT;
     }
     String[] arguments = args.split(" ", 0);

--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/ShellCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/ShellCommandlet.java
@@ -4,18 +4,19 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
+import java.util.List;
 
 import org.fusesource.jansi.AnsiConsole;
+import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.MaskingCallback;
+import org.jline.reader.ParsedLine;
 import org.jline.reader.Parser;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.DefaultParser;
-import org.jline.reader.impl.completer.AggregateCompleter;
-import org.jline.reader.impl.completer.StringsCompleter;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.widget.AutosuggestionWidgets;
@@ -72,11 +73,23 @@ public final class ShellCommandlet extends Commandlet {
     try {
       Parser parser = new DefaultParser();
       try (Terminal terminal = TerminalBuilder.builder().build()) {
-        // initialize our own completer here and add exit as an autocompletion option
-        Completer completer = new AggregateCompleter(
-            new StringsCompleter("exit"), new IdeCompleter((AbstractIdeContext) this.context));
+        IdeCompleter ideCompleter = new IdeCompleter((AbstractIdeContext) this.context);
 
-        LineReader reader = LineReaderBuilder.builder().terminal(terminal).completer(completer).parser(parser)
+        Completer shellCompleter = new Completer() {
+          @Override
+          public void complete(LineReader reader, ParsedLine commandLine, List<Candidate> candidates) {
+            String currentWord = commandLine.word();
+            int wordIndex = commandLine.wordIndex();
+
+            if (wordIndex == 0 && !currentWord.isEmpty() && "exit".startsWith(currentWord)) {
+              candidates.add(new Candidate("exit"));
+            }
+
+            ideCompleter.complete(reader, commandLine, candidates);
+          }
+        };
+
+        LineReader reader = LineReaderBuilder.builder().terminal(terminal).completer(shellCompleter).parser(parser)
             .variable(LineReader.LIST_MAX, AUTOCOMPLETER_MAX_RESULTS).build();
 
         // Create autosuggestion widgets
@@ -94,10 +107,6 @@ public final class ShellCommandlet extends Commandlet {
           try {
             String prompt = context.getCwd() + "$ ide ";
             line = reader.readLine(prompt, rightPrompt, (MaskingCallback) null, null);
-            line = line.trim();
-            if (line.equals("exit")) {
-              return;
-            }
             reader.getHistory().add(line);
             int rc = runCommand(line);
             if (rc == RC_EXIT) {

--- a/cli/src/main/java/com/devonfw/tools/ide/completion/IdeCompleter.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/completion/IdeCompleter.java
@@ -15,6 +15,8 @@ import com.devonfw.tools.ide.context.AbstractIdeContext;
  */
 public class IdeCompleter implements Completer {
 
+  private static final String EXIT_COMMAND = "exit";
+
   private final AbstractIdeContext context;
 
   /**
@@ -30,6 +32,14 @@ public class IdeCompleter implements Completer {
 
   @Override
   public void complete(LineReader reader, ParsedLine commandLine, List<Candidate> candidates) {
+
+    String currentWord = commandLine.word();
+    int wordIndex = commandLine.wordIndex();
+
+    if (wordIndex == 0 && !currentWord.isEmpty() && EXIT_COMMAND.startsWith(currentWord)) {
+      candidates.add(new Candidate(EXIT_COMMAND));
+    }
+
     List<String> words = commandLine.words();
     CliArguments args = CliArguments.ofCompletion(words.toArray(String[]::new));
     List<CompletionCandidate> completion = this.context.complete(args, true);


### PR DESCRIPTION
### This PR fixes #836

### Implemented changes:

* fixed autocomplete behavior for exit command
* ensured exit is only suggested in valid context
---
### How to Test:

Run in Git Bash:

`mvn -pl cli exec:java -Dexec.mainClass=com.devonfw.tools.ide.cli.Ideasy -Dexec.args="shell"`

Then verify:

  * `e<TAB>` -> suggests `exit`
  * `<TAB>` with empty input -> no `exit`
  * `z<TAB>` -> no `exit`
  * after other commands (`intellij e<TAB>`) -> no `exit`

---
## Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
