### PR TITLE
#2032: fixed broken output of commandlet env bash

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/commandlet/EnvironmentCommandlet.java
@@ -152,7 +152,9 @@ public final class EnvironmentCommandlet extends Commandlet {
             tool.setEnvironment(environmentContext, toolInstallation, false);
           }
         } catch (Exception e) {
-          LOG.warn("An error occurred while setting the environment variables in local tools:", e);
+          if (LOG.isDebugEnabled()) {
+            IdeLogLevel.PROCESSABLE.log(LOG, e, "An error occurred while setting the environment variables in local tools:");
+          }
         }
       }
     }
@@ -176,7 +178,9 @@ public final class EnvironmentCommandlet extends Commandlet {
             }
           }
         } catch (Exception e) {
-          LOG.warn("An error occurred while collecting Bash completion for tool {}.", tool.getName(), e);
+          if (LOG.isDebugEnabled()) {
+            IdeLogLevel.PROCESSABLE.log(LOG, e, "An error occurred while collecting Bash completion for tool {}.", tool.getName());
+          }
         }
       }
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/graalvm/GraalVm.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/graalvm/GraalVm.java
@@ -24,7 +24,9 @@ public class GraalVm extends LocalToolCommandlet {
 
   @Override
   public Path getToolPath() {
-
+    if (this.context.getSoftwareExtraPath() == null) {
+      return null;
+    }
     return this.context.getSoftwareExtraPath().resolve(getName());
   }
 


### PR DESCRIPTION
### This PR fixes #2032 

### Implemented changes:

* Added null-check in `getToolPath()` in `GrallVm.java`
* Added log level checks to only log warnings, if user wants them with debug-mode

---

### Testing instructions

Please add conscise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

To test the fix for NullPointerException :
1. Checkout commit `#2032 Added null check to prevent NullPointerException in EnvironmentCommandlet.`
2. Modify IntelliJ Run configuration (working directory has to point to place outside of an IDEasy project):
<img width="997" height="687" alt="image" src="https://github.com/user-attachments/assets/b93d7a2f-b02a-4eb6-8c94-d61a35ba25a9" />
3. Run configuration
4. No warnings, or errors are printed

To test correct log-level:
1. Checkout commit '#2032 Added additional checks for logging level before logging warnings or errors in EnvironmentCommandlet.'
2. Comment out null check in `getToolPath()` in `GrallVm.java` to reintroduce bug
3. Run configuration mentioned above
5. No errors or exceptions will be logged
6. Modify commandline args to `--debug env --bash`
7. Run modified configuration
8. Error and exception will be logged

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [X] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [X] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [X] PR and issue(s) have suitable labels
- [X] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [X] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [X] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [X] You have formulated clear instructions on how to test your contribution under "Testing instructions"

