### PR TITLE
#2025: improve JavaDoc of IdeContext

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,7 +33,6 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1719[#1719]: Add Rust and MSVC support
 * https://github.com/devonfw/IDEasy/issues/1991[#1991]: Improve WindowsHelperMock
 * https://github.com/devonfw/IDEasy/issues/1457[#1457]: Improve CLI error messages on invalid args or commandlets not available in current context
-* https://github.com/devonfw/IDEasy/issues/2025[#2025]: Improve JavaDoc of IdeContext
 * https://github.com/devonfw/IDEasy/issues/2030[#2030]: Fix Plugin install error in Intellij
 * https://github.com/devonfw/IDEasy/issues/2032[#2032]: commandlet env bash leads to broken output
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1719[#1719]: Add Rust and MSVC support
 * https://github.com/devonfw/IDEasy/issues/1991[#1991]: Improve WindowsHelperMock
 * https://github.com/devonfw/IDEasy/issues/1457[#1457]: Improve CLI error messages on invalid args or commandlets not available in current context
+* https://github.com/devonfw/IDEasy/issues/2025[#2025]: Improve JavaDoc of IdeContext
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/45?closed=1[milestone 2026.06.001].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
@@ -54,7 +54,7 @@ import com.devonfw.tools.ide.version.VersionIdentifier;
  * <li>{@link #question(Object[], String, Object...) question} (for interaction to let the end-user decide)</li>
  * <li>{@link #getUrls() url metadata} (access ide-urls to find versions, download URLs, dependency and security metadata)</li>
  * <li>{@link #getDefaultToolRepository() tool repository} (for abstraction of version resolution and download of tools)</li>
- * <li>{@link #getSystem() ide system} (to abstract system environment variables)</li>
+ * <li>{@link #getSystem() ide system} (abstraction of {@link java.lang.System} for system environment variables)</li>
  * </ul>
  */
 public interface IdeContext extends IdeStartContext {

--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
@@ -49,7 +49,8 @@ import com.devonfw.tools.ide.version.VersionIdentifier;
  * <li>{@link #newProgressBar(String, long, String, long) progress bar} (to display long-running progress for UX)</li>
  * <li>{@link #getGitContext() git context} (for git operations like clone, fetch, pull, etc.)</li>
  * <li>{@link #getSystemInfo() system info} (for information about OS and CPU architecture)</li>
- * <li>{@link #getVariables() environment varialbes} (to access and modify environment variables according to our configuration layout)</li>
+ * <li>{@link #getVariables() environment variables} (to access and modify IDEasy variables according to our configuration layout)</li>
+ * 
  * <li>{@link #question(Object[], String, Object...) question} (for interaction to let the end-user decide)</li>
  * <li>{@link #getUrls() url metadata} (access ide-urls to find versions, download URLs, dependency and security metadata)</li>
  * <li>{@link #getDefaultToolRepository() tool repository} (for abstraction of version resolution and download of tools)</li>

--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeContext.java
@@ -37,7 +37,24 @@ import com.devonfw.tools.ide.version.IdeVersion;
 import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
- * Interface for interaction with the user allowing to input and output information.
+ * Interface for the context of IDEasy and the potential current project. Central constants for names of files and folders are defined here and should be
+ * referenced instead of duplicating such string literals across the code-base. All central components can be accessed from here such as:
+ * <ul>
+ * <li>{@link #getPath() system path} (abstraction of PATH environment variable)</li>
+ * <li>{@link #getCommandletManager() commandlet manager} (access {@link com.devonfw.tools.ide.commandlet.Commandlet}s)</li>
+ * <li>{@link #getFileAccess() file access} (file and I/O operations on a higher level of abstraction)</li>
+ * <li>{@link #getNetworkStatus() network status} (determine if we are online or offline)</li>
+ * <li>{@link #newProcess() process context} (start external programs as process including logging, error handling, background and output processing)</li>
+ * <li>{@link #newStep(String) step} creation (a sub-task that may fail without stopping the overall process)</li>
+ * <li>{@link #newProgressBar(String, long, String, long) progress bar} (to display long-running progress for UX)</li>
+ * <li>{@link #getGitContext() git context} (for git operations like clone, fetch, pull, etc.)</li>
+ * <li>{@link #getSystemInfo() system info} (for information about OS and CPU architecture)</li>
+ * <li>{@link #getVariables() environment varialbes} (to access and modify environment variables according to our configuration layout)</li>
+ * <li>{@link #question(Object[], String, Object...) question} (for interaction to let the end-user decide)</li>
+ * <li>{@link #getUrls() url metadata} (access ide-urls to find versions, download URLs, dependency and security metadata)</li>
+ * <li>{@link #getDefaultToolRepository() tool repository} (for abstraction of version resolution and download of tools)</li>
+ * <li>{@link #getSystem() ide system} (to abstract system environment variables)</li>
+ * </ul>
  */
 public interface IdeContext extends IdeStartContext {
 


### PR DESCRIPTION
### This PR fixes #2025 

### Implemented changes:

* Expanded the interface-level JavaDoc of `IdeContext`
* Documented the convention that central file/folder name constants are defined in `IdeContext` and should be referenced instead of duplicating string literals across the code-base. 

---

### Testing instructions

Please add conscise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. Hover over `IdeContext` in the IDE (or open Quick Documentation) and confirm the expanded JavaDoc is shown.
2. Run `mvn javadoc:javadoc` through the maven goals and confirm that it builds with success.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

