### PR TITLE
#2030: fix plugin install in intellij

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1719[#1719]: Add Rust and MSVC support
 * https://github.com/devonfw/IDEasy/issues/1991[#1991]: Improve WindowsHelperMock
 * https://github.com/devonfw/IDEasy/issues/1457[#1457]: Improve CLI error messages on invalid args or commandlets not available in current context
+* https://github.com/devonfw/IDEasy/issues/2030[#2030]: Fix Plugin install error in Intellij
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/45?closed=1[milestone 2026.06.001].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -55,7 +55,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     if (customRepo) {
       args.add(plugin.url());
     }
-    ProcessResult result = super.runTool(pc, ProcessMode.DEFAULT, args);
+    ProcessResult result = runTool(pc, ProcessMode.DEFAULT, args);
     if (result.isSuccessful()) {
       IdeLogLevel.SUCCESS.log(LOG, "Successfully installed plugin: {}", plugin.name());
       step.success();
@@ -82,7 +82,9 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
 
   @Override
   public ProcessResult runTool(ProcessContext pc, ProcessMode processMode, List<String> args) {
-    args.add(this.context.getWorkspacePath().toString());
+    if (!args.contains("installPlugins")) {
+      args.add(this.context.getWorkspacePath().toString());
+    }
 
     String variableName = getName().toUpperCase(Locale.ROOT).replace("-", "_") + VM_ARGS_ENV_SUFFIX;
     String userVmArgsContent = this.context.getVariables().get(variableName);

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -55,7 +55,7 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
     if (customRepo) {
       args.add(plugin.url());
     }
-    ProcessResult result = runTool(pc, ProcessMode.DEFAULT, args);
+    ProcessResult result = super.runTool(pc, ProcessMode.DEFAULT, args);
     if (result.isSuccessful()) {
       IdeLogLevel.SUCCESS.log(LOG, "Successfully installed plugin: {}", plugin.name());
       step.success();


### PR DESCRIPTION
### This PR fixes  [#2030](https://github.com/devonfw/IDEasy/issues/2030)

### Implemented changes:

* Avoid appending workspace path to IntelliJ plugin installs

---

### Testing instructions

1. You can test the change using Graalvm (https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/graalvm-build-guide.adoc)
2. after compelting the steps there close you intellij and call `"C:\Users\projects\IDEasy\workspaces\main\IDEasy\cli\target\ideasy.exe" intellij` in the workspace (you can choose main)
3. Make sure that at least one plugin is active
4. No error code should be present

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"