### PR TITLE
#2032: fixed processable logging

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -1350,7 +1350,7 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
       }
       try {
         if (cmd.isProcessableOutput()) {
-          if (!LOG.isDebugEnabled()) {
+          if (!isLogLevelEnabled(IdeLogLevel.DEBUG)) {
             // unless --debug or --trace was supplied, processable output commandlets will disable all log-levels except INFO to prevent other logs interfere
             previousLogLevel = this.startContext.setLogLevelConsole(IdeLogLevel.PROCESSABLE);
           }

--- a/cli/src/main/java/com/devonfw/tools/ide/context/IdeStartContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/IdeStartContext.java
@@ -31,6 +31,14 @@ public interface IdeStartContext extends ReadOfflineMode {
   IdeLogLevel getLogLevelLogger();
 
   /**
+   * @param level the {@link IdeLogLevel} to check.
+   * @return {@code true} if the given {@link IdeLogLevel} is actually enabled in the console, {@code }false} otherwise.
+   */
+  default boolean isLogLevelEnabled(IdeLogLevel level) {
+    return level.ordinal() >= getLogLevelConsole().ordinal();
+  }
+
+  /**
    * @return {@code true} in case of quiet mode (reduced output), {@code false} otherwise.
    */
   boolean isQuietMode();

--- a/cli/src/main/java/com/devonfw/tools/ide/log/IdeLogLevel.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/log/IdeLogLevel.java
@@ -159,7 +159,10 @@ public enum IdeLogLevel {
    */
   public void log(Logger logger, Throwable error, String message, Object... args) {
 
-    LoggingEventBuilder builder = logger.atLevel(this.slf4jLevel).setCause(error);
+    if (!isEnabled()) {
+      return;
+    }
+    LoggingEventBuilder builder = logger.makeLoggingEventBuilder(this.slf4jLevel).setCause(error);
     if (this.slf4jMarker != null) {
       builder = builder.addMarker(this.slf4jMarker);
     }
@@ -177,6 +180,9 @@ public enum IdeLogLevel {
   }
 
   /**
+   * <b>ATTENTION:</b> This method will only check if the log-level is globally enabled in SLF4J.<br>
+   * In most cases you want to use {@link com.devonfw.tools.ide.context.IdeContext#isLogLevelEnabled(IdeLogLevel)} instead.
+   *
    * @return {@code true} if this {@link IdeLogLevel} is enabled (globally), {@code false} otherwise.
    */
   public boolean isEnabled() {


### PR DESCRIPTION
### This PR fixes #2032 (processable logging)

### Implemented changes:

* added proper way to detect the enabled log-level
* fixed activation of proccessable logging by using the correct new method
* fixed logging to actually log on PROCESSABLE when threshold is set to PROCESSABLE

---

### Testing instructions

Please add conscise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. Locally hack GraalVM commandlet to reintroduce some runtime exception:
```
  public Path getToolPath() {

    if (true) {
      throw new IllegalStateException("test");
    }
    return this.context.getSoftwareExtraPath().resolve(getName());
  }
```
2. set breakpoint here:

3.  Run IDEasy in debug mode with args `env --bash` and see the exception is catched and logged but logger will suppress it
4. rerun with `--debug` to verify that then we see the error being logged.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [ ] When running `mvn clean test` locally all tests pass and build is successful
- [ ] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [ ] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [ ] PR and issue(s) have suitable labels
- [ ] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [ ] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [ ] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [ ] You have formulated clear instructions on how to test your contribution under "Testing instructions"
