### PR TITLE
#2048: Fix ide -v and --version handling

### DIFF
--- a/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/context/AbstractIdeContext.java
@@ -66,6 +66,7 @@ import com.devonfw.tools.ide.os.WindowsPathSyntax;
 import com.devonfw.tools.ide.process.ProcessContext;
 import com.devonfw.tools.ide.process.ProcessContextImpl;
 import com.devonfw.tools.ide.process.ProcessResult;
+import com.devonfw.tools.ide.property.KeywordProperty;
 import com.devonfw.tools.ide.property.Property;
 import com.devonfw.tools.ide.step.Step;
 import com.devonfw.tools.ide.step.StepImpl;
@@ -1628,7 +1629,8 @@ public abstract class AbstractIdeContext implements IdeContext, IdeLogArgFormatt
           currentProperty = option;
         } else {
           boolean allowDashedValue = (property != null && property.isValue() && property.isMultiValued());
-          if (!allowDashedValue && currentArgument.isOption()) {
+          boolean allowKeywordOption = (currentProperty instanceof KeywordProperty keywordProperty) && keywordProperty.matches(currentArgument.getKey());
+          if (!allowDashedValue && !allowKeywordOption && currentArgument.isOption()) {
             ValidationState state = new ValidationState(null);
             state.addInvalidOption(currentArgument.getKey());
             state.addErrorMessage("Invalid option \"" + currentArgument.getKey() + "\"");

--- a/cli/src/main/java/com/devonfw/tools/ide/property/KeywordProperty.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/property/KeywordProperty.java
@@ -67,7 +67,9 @@ public class KeywordProperty extends BooleanProperty {
   public boolean apply(CliArguments args, IdeContext context, Commandlet commandlet, CompletionCandidateCollector collector) {
 
     String normalizedName = this.name;
-    if (args.current().isOption()) {
+    if (args.current().getKey().equals(this.alias)) {
+      normalizedName = this.alias;
+    } else if (args.current().isOption()) {
       normalizedName = this.optionName;
     }
     return apply(normalizedName, args, context, commandlet, collector);

--- a/cli/src/test/java/com/devonfw/tools/ide/cli/IdeasyTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/cli/IdeasyTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeTestContext;
+import com.devonfw.tools.ide.version.IdeVersion;
 
 /**
  * Test of {@link Ideasy}.
@@ -31,6 +32,44 @@ class IdeasyTest extends AbstractIdeContextTest {
     // assert
     assertThat(context).logAtDebug().hasMessage("Step 'ide' ended with failure.");
     assertThat(context).log().hasNoEntryWithException();
+  }
+
+  /**
+   * Test of {@code ide --version}.
+   */
+  @Test
+  void testVersionLongOption() {
+
+    // arrange
+    IdeTestContext context = newContext(Path.of("/"));
+    Ideasy ideasy = new Ideasy(context);
+
+    // act
+    int exitCode = ideasy.run("--version");
+
+    // assert
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(context).logAtProcessable().hasMessage(IdeVersion.getVersionString());
+    assertThat(context).logAtError().hasNoMessageContaining("Unknown command");
+  }
+
+  /**
+   * Test of {@code ide -v}.
+   */
+  @Test
+  void testVersionShortOption() {
+
+    // arrange
+    IdeTestContext context = newContext(Path.of("/"));
+    Ideasy ideasy = new Ideasy(context);
+
+    // act
+    int exitCode = ideasy.run("-v");
+
+    // assert
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(context).logAtProcessable().hasMessage(IdeVersion.getVersionString());
+    assertThat(context).logAtError().hasNoMessageContaining("Unknown command");
   }
 
   /**


### PR DESCRIPTION
### This PR fixes #2048

### Implemented changes:

* Fixed CLI parsing for commandlet keyword options such as `-v` and  `--version`.
* Ensured that a keyword property used to resolve a commandlet is also consumed from the CLI arguments.
* Added tests for the commandlet option keywords.

---

### Testing instructions

Please add concise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. Build the CLI locally:

   ```bash
   mvn clean install
   ```

2. Edit the run configuration in IntelliJ and use the built CLI classpath.

   <img width="581" height="720" alt="image" src="https://github.com/user-attachments/assets/3c521c73-31ce-4458-ac0c-644510047b83" />
 Run the following commands:

   ```bash
   ide -v
   ide --version
   ```

4. Verify that:

   * `ide -v` and `ide --version` behave like `ide version`.

5. Run:

   ```bash
   mvn -pl cli -Dtest=IdeasyTest test
   ```


### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"


