### PR TITLE
add teams notifier for new external issues and prs

### DIFF
--- a/.github/workflows/issue-pr-observer.yml
+++ b/.github/workflows/issue-pr-observer.yml
@@ -25,7 +25,12 @@ jobs:
           WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
           REPO: ${{ github.repository }}
         run: |
-          SINCE=$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)
+          # Monday catches up the weekend (Fri–Sun); other weekdays look back 24h.
+          if [ "$(date -u +%u)" -eq 1 ]; then
+            SINCE=$(date -u -d '3 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          else
+            SINCE=$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)
+          fi
           echo "Scanning $REPO for items created since $SINCE"
 
           # Search returns both issues and PRs; keep only external authors (not on the team)
@@ -52,9 +57,8 @@ jobs:
           fi
           echo "$COUNT neue(r) externe(r) Eintrag/Eintraege gefunden."
 
-          # Build the bare Adaptive Card the Teams "Workflows" webhook expects
-          # (top-level type must be "AdaptiveCard"; no message/attachments envelope).
-          # Card text is in German; each item is its own container for comfortable reading.
+          # Teams' webhook wants a bare Adaptive Card: top-level type must be
+          # "AdaptiveCard", not wrapped in a message/attachments envelope.
           CARD=$(echo "$ITEMS_JSON" | jq --argjson count "$COUNT" '{
             type: "AdaptiveCard",
             "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",

--- a/.github/workflows/issue-pr-observer.yml
+++ b/.github/workflows/issue-pr-observer.yml
@@ -23,9 +23,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
-          REPO: devonfw/IDEasy
+          REPO: ${{ github.repository }}
         run: |
-          SINCE=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          SINCE=$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "Scanning $REPO for items created since $SINCE"
 
           # Search returns both issues and PRs; keep only external authors (not on the team)

--- a/.github/workflows/issue-pr-observer.yml
+++ b/.github/workflows/issue-pr-observer.yml
@@ -52,10 +52,10 @@ jobs:
 
           COUNT=$(echo "$ITEMS_JSON" | jq 'length')
           if [ "$COUNT" -eq 0 ]; then
-            echo "Keine neuen externen Issues oder PRs. Teams-Benachrichtigung wird uebersprungen."
+            echo "No new external issues or PRs. Skipping Teams-notification."
             exit 0
           fi
-          echo "$COUNT neue(r) externe(r) Eintrag/Eintraege gefunden."
+          echo "$COUNT new external issue(s)/PR(s) found."
 
           # Teams' webhook wants a bare Adaptive Card: top-level type must be
           # "AdaptiveCard", not wrapped in a message/attachments envelope.
@@ -68,7 +68,7 @@ jobs:
                 { type: "TextBlock", size: "Large", weight: "Bolder", wrap: true,
                   text: "🆕 Neue externe Issues & Pull Requests" },
                 { type: "TextBlock", spacing: "None", isSubtle: true, wrap: true,
-                  text: ("Letzte 24 Stunden · " + (if $count == 1 then "1 neuer Eintrag" else "\($count) neue Einträge" end)) }
+                  text: ("Letzter Zeitraum · " + (if $count == 1 then "1 neuer Eintrag" else "\($count) neue Einträge" end)) }
               ]
               + [ .[] | {
                     type: "Container",

--- a/.github/workflows/issue-pr-observer.yml
+++ b/.github/workflows/issue-pr-observer.yml
@@ -1,0 +1,83 @@
+name: External Issue & PR Observer
+
+# Posts a weekday-morning digest of new EXTERNAL issues/PRs (last 24h) to a Teams
+# channel so incoming reports from outside the team are noticed quickly and don't slip.
+# "External" = author_association is not MEMBER, OWNER or COLLABORATOR.
+# Requires the repository secret TEAMS_WEBHOOK_URL (a Teams "Workflows" incoming webhook).
+
+on:
+  workflow_dispatch:          
+  schedule:
+    - cron: '0 7 * * 1-5'     # 07:00 UTC, Mon-Fri (= 09:00 CEST summer / 08:00 CET winter)
+
+permissions:
+  issues: read
+  pull-requests: read
+  contents: read
+
+jobs:
+  observe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan for new external issues & PRs and notify Teams
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+        run: |
+          SINCE=$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)
+          echo "Scanning $REPO for items created since $SINCE"
+
+          # Search returns both issues and PRs; keep only external authors (not on the team)
+          # and emit a structured object per item so the card can lay them out nicely.
+          ITEMS_JSON=$(gh api -X GET search/issues \
+            -f q="repo:$REPO created:>=$SINCE" \
+            --jq '[.items[]
+              | select(.author_association != "MEMBER"
+                   and .author_association != "OWNER"
+                   and .author_association != "COLLABORATOR")
+              | {
+                  kind:   (if .pull_request then "Pull Request" else "Issue" end),
+                  icon:   (if .pull_request then "🔵" else "🟢" end),
+                  number: .number,
+                  title:  .title,
+                  url:    .html_url,
+                  user:   .user.login
+                }]')
+
+          COUNT=$(echo "$ITEMS_JSON" | jq 'length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Keine neuen externen Issues oder PRs. Teams-Benachrichtigung wird uebersprungen."
+            exit 0
+          fi
+          echo "$COUNT neue(r) externe(r) Eintrag/Eintraege gefunden."
+
+          # Build the bare Adaptive Card the Teams "Workflows" webhook expects
+          # (top-level type must be "AdaptiveCard"; no message/attachments envelope).
+          # Card text is in German; each item is its own container for comfortable reading.
+          CARD=$(echo "$ITEMS_JSON" | jq --argjson count "$COUNT" '{
+            type: "AdaptiveCard",
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            version: "1.4",
+            body: (
+              [
+                { type: "TextBlock", size: "Large", weight: "Bolder", wrap: true,
+                  text: "🆕 Neue externe Issues & Pull Requests" },
+                { type: "TextBlock", spacing: "None", isSubtle: true, wrap: true,
+                  text: ("Letzte 24 Stunden · " + (if $count == 1 then "1 neuer Eintrag" else "\($count) neue Einträge" end)) }
+              ]
+              + [ .[] | {
+                    type: "Container",
+                    separator: true,
+                    spacing: "Medium",
+                    items: [
+                      { type: "TextBlock", weight: "Bolder", wrap: true,
+                        text: "\(.icon) #\(.number) · \(.title)" },
+                      { type: "TextBlock", spacing: "None", isSubtle: true, size: "Small", wrap: true,
+                        text: "\(.kind) · von @\(.user) · [Öffnen](\(.url))" }
+                    ]
+                  } ]
+            )
+          }')
+
+          curl -sS --fail -X POST -H "Content-Type: application/json" -d "$CARD" "$WEBHOOK"

--- a/.github/workflows/issue-pr-observer.yml
+++ b/.github/workflows/issue-pr-observer.yml
@@ -23,9 +23,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WEBHOOK: ${{ secrets.TEAMS_WEBHOOK_URL }}
-          REPO: ${{ github.repository }}
+          REPO: devonfw/IDEasy
         run: |
-          SINCE=$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)
+          SINCE=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)
           echo "Scanning $REPO for items created since $SINCE"
 
           # Search returns both issues and PRs; keep only external authors (not on the team)


### PR DESCRIPTION
### This PR adds a Teams notifier

### Implemented changes:

* new scheduled github actions 
* runs every weekday , mondays looks back over the weekend
* posts only when there is something new

---

### Testing instructions

1. add a repo secret 'TEAMS_WEBHOOK_URL' 
2. go to actions-> external issues & pr observer -> run workflow
3. if there are external issues/prs in the last day, card will be posted to the teams channel.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"
