### PR TITLE
#2040: Fix workspace ComboBox reset on project switch

### DIFF
--- a/gui/src/main/java/com/devonfw/ide/gui/MainController.java
+++ b/gui/src/main/java/com/devonfw/ide/gui/MainController.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 import java.util.List;
+import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
@@ -62,6 +63,21 @@ public class MainController {
   private void initialize() {
 
     setProjectsComboBox();
+    selectedWorkspace.setOnAction(this::onWorkspaceSelected);
+  }
+
+  @FXML
+  private void onWorkspaceSelected(ActionEvent actionEvent) {
+
+    String workspaceName = selectedWorkspace.getValue();
+    if (workspaceName == null) {
+      return;
+    }
+    updateContext(selectedProject.getValue(), workspaceName);
+    androidStudioOpen.setDisable(false);
+    eclipseOpen.setDisable(false);
+    intellijOpen.setDisable(false);
+    vsCodeOpen.setDisable(false);
   }
 
   @FXML
@@ -116,15 +132,12 @@ public class MainController {
 
     selectedWorkspace.getItems().clear();
     selectedWorkspace.getItems().addAll(workspaces);
+    selectedWorkspace.setValue(null);
 
-    selectedWorkspace.setOnAction(actionEvent -> {
-      updateContext(selectedProject.getValue(), selectedWorkspace.getValue());
-
-      androidStudioOpen.setDisable(false);
-      eclipseOpen.setDisable(false);
-      intellijOpen.setDisable(false);
-      vsCodeOpen.setDisable(false);
-    });
+    androidStudioOpen.setDisable(true);
+    eclipseOpen.setDisable(true);
+    intellijOpen.setDisable(true);
+    vsCodeOpen.setDisable(true);
   }
 
   private void openIDE(String inIde) {


### PR DESCRIPTION
### This PR fixes #2040 

### Implemented changes:

- Workspace `onAction` was re-registered inside `setWorkspaceComboBox()`
  on every project selection. Clearing the items mid-setup fired the old
  handler with a stale/null workspace, causing a `FileNotFoundException`
  error dialog or a `NullPointerException` that aborted `addAll()`.
- Handler is now registered once in `initialize()` via `this::onWorkspaceSelected`.


---

### Testing instructions
- Open GUI by running `AppLauncher`
- Select a project → workspace dropdown populates, prompt text shown
- Switch to a different project → workspace resets to prompt text, buttons re-disabled
- Select a workspace in new project → no error dialog, correct context
  

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [ ] When running `mvn clean test` locally all tests pass and build is successful
- [ ] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [ ] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [ ] PR and issue(s) have suitable labels
- [ ] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [ ] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [ ] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [ ] You have formulated clear instructions on how to test your contribution under "Testing instructions"

 
