### PR TITLE
#2101: fix install.sh download URL to use Maven Central

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ main() {
   arch=$(detect_arch)
   version=$(fetch_latest_version)
   archive="ide-cli-${version}-${os}-${arch}.tar.gz"
-  download_url="https://github.com/${GITHUB_REPO}/releases/download/release/${version}/${archive}"
+  download_url="https://repo1.maven.org/maven2/com/devonfw/tools/IDEasy/ide-cli/${version}/${archive}"
 
   blue "Detected: ${os} ${arch}"
   blue "Latest version: ${version}"


### PR DESCRIPTION
### This PR fixes #2101

### Implemented changes:

* Replace the Github releases download url in `install.sh` with the Maven Central url

---

### Testing instructions
1. Run `bash -c "$(curl -fsSL https://raw.githubusercontent.com/devonfw/IDEasy/main/install.sh)"` on a clean environment.
2. Confirm the archive downloads from `repo1/maven2/com/devonfw/tools/IDEasy/ide-cli/...` without 404.
3. Confirm extraction and setup complete successfully.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"