### PR TITLE
#2114: fix false 'Cygwin is not supported' warning in Git Bash

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,6 +8,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Run shell function tests
+        shell: bash
+        run: bash cli/src/test/functions-test.sh
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Run shell function tests
+        shell: bash
+        run: bash cli/src/test/functions-test.sh
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/822[#822] : Added Cwd path limit in shell
 * https://github.com/devonfw/IDEasy/issues/1517[#1517]: Fix IDEasy MSI does not configure Windows Terminal for git-bash
 * https://github.com/devonfw/IDEasy/issues/1227[#1227]: Added Setup instrcutions to the Windows installer
+* https://github.com/devonfw/IDEasy/issues/2114[#2114]: Fix false "Cygwin is not supported" warning in Git Bash
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/46?closed=1[milestone 2026.07.001].
 

--- a/cli/src/main/package/functions
+++ b/cli/src/main/package/functions
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 # this script should be sourced, shebang above only for syntax highlighting in editors
+
+# Detects a genuine Cygwin environment (as opposed to MSYS2/Git Bash).
+# Since 2025-02 MSYS2 (and thus Git Bash) reports OSTYPE=cygwin, so OSTYPE can no longer
+# distinguish the two. "uname -s" still reports CYGWIN_NT for Cygwin and MINGW*/MSYS* for
+# Git Bash, hence we rely on it here.
+_ide_is_cygwin() {
+  case "$(uname -s 2>/dev/null)" in
+    CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Detects an MSYS2/Git Bash environment ("uname -s" reports MINGW* or MSYS*, unlike Cygwin's CYGWIN*).
+_ide_is_msys() {
+  case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 function ide() {
   local return_code
   local ide_env
@@ -25,7 +45,7 @@ function ide() {
       echo "IDE environment variables have been set for ${IDE_HOME} in workspace ${WORKSPACE}"
     fi
   fi
-  if [ "${OSTYPE}" = "cygwin" ] && [ "$#" != 0 ]; then
+  if _ide_is_cygwin && [ "$#" != 0 ]; then
     echo -e "\033[93m--- WARNING: CYGWIN IS NOT SUPPORTED ---\nCygwin console is not supported by IDEasy.\nConsider using the git terminal instead.\nIf you want to use Cygwin with IDEasy, you will have to configure it yourself.\nA few suggestions and caveats can be found here:\nhttps://github.com/devonfw/IDEasy/blob/main/documentation/cygwin.adoc\n\033[39m"
   fi
 }
@@ -176,7 +196,7 @@ if [ "${0/*\//}" = "zsh" ]; then
   bashcompinit
 fi
 
-if [ "${OSTYPE}" = "msys" ]; then
+if _ide_is_msys; then
   IDE_ROOT="$(cygpath "${IDE_ROOT}")"
 fi
 if ! command -v ideasy &> /dev/null; then

--- a/cli/src/test/functions-test.sh
+++ b/cli/src/test/functions-test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Unit tests for the shell integration in cli/src/main/package/functions.
+#
+# These tests focus on the OS-detection behavior that decides whether the
+# "CYGWIN IS NOT SUPPORTED" warning is shown. Since 2025-02 MSYS2 (and thus
+# Git Bash) reports OSTYPE=cygwin, so OSTYPE alone can no longer distinguish
+# Cygwin from Git Bash - the detection has to rely on "uname -s" instead.
+#
+# Run standalone: bash cli/src/test/functions-test.sh
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+FUNCTIONS_FILE="${SCRIPT_DIR}/../main/package/functions"
+
+# reuse the assertThat helper of the integration tests
+# shellcheck source=all-tests-functions.sh
+source "${SCRIPT_DIR}/all-tests-functions.sh"
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+# minimal fake "ideasy" binary so sourcing the functions file has no side effects
+cat > "${STUB_DIR}/ideasy" <<'EOS'
+#!/usr/bin/env bash
+exit 0
+EOS
+chmod +x "${STUB_DIR}/ideasy"
+mkdir -p "${STUB_DIR}/root"
+
+total=0
+failed=0
+
+# runIde <OSTYPE> <uname -s value> : sources the functions file in a fresh shell that
+# simulates the given environment and prints the output of "ide <arg>".
+runIde() {
+  FAKE_OSTYPE="$1" FAKE_UNAME_S="$2" FUNCTIONS_FILE="${FUNCTIONS_FILE}" STUB_DIR="${STUB_DIR}" \
+    bash --noprofile --norc -c '
+      export PATH="${STUB_DIR}:${PATH}"
+      export IDE_ROOT="${STUB_DIR}/root"
+      uname() { if [ "$1" = "-s" ]; then echo "${FAKE_UNAME_S}"; else command uname "$@"; fi; }
+      cygpath() { echo "${@: -1}"; }
+      OSTYPE="${FAKE_OSTYPE}"
+      source "${FUNCTIONS_FILE}" >/dev/null 2>&1
+      ide dummyarg 2>&1
+    '
+}
+
+# check <description> <expected: shown|hidden> <OSTYPE> <uname -s value>
+check() {
+  local description="$1" expected="$2" ostype="$3" uname_s="$4"
+  total=$((total + 1))
+  local output
+  output="$(runIde "${ostype}" "${uname_s}")"
+  if echo "${output}" | grep -q "CYGWIN IS NOT SUPPORTED"; then
+    local actual="shown"
+  else
+    local actual="hidden"
+  fi
+  if [ "${actual}" = "${expected}" ]; then
+    doSuccess "PASSED: ${description} (warning ${actual})"
+  else
+    doError "FAILED: ${description} - expected warning ${expected} but was ${actual}"
+    failed=$((failed + 1))
+  fi
+}
+
+echo "Testing Cygwin warning detection in ${FUNCTIONS_FILE}"
+
+# genuine Cygwin -> warning is intended
+check "genuine Cygwin console shows the warning" shown cygwin "CYGWIN_NT-10.0-26200"
+# modern Git Bash: MSYS2 relabeled OSTYPE to cygwin -> must NOT warn (the regression)
+check "modern Git Bash (OSTYPE=cygwin, uname=MINGW) shows no warning" hidden cygwin "MINGW64_NT-10.0-26200"
+# legacy Git Bash: OSTYPE still msys -> no warning
+check "legacy Git Bash (OSTYPE=msys, uname=MINGW) shows no warning" hidden msys "MINGW64_NT-10.0-26200"
+# MSYS environment -> no warning
+check "MSYS environment shows no warning" hidden cygwin "MSYS_NT-10.0-26200"
+
+echo
+if [ "${failed}" = 0 ]; then
+  doSuccess "All ${total} tests passed."
+  exit 0
+else
+  doError "${failed} of ${total} tests failed."
+  exit 1
+fi


### PR DESCRIPTION
### This PR fixes #2114

### Implemented changes:

* `ide <command>` no longer prints a false `--- WARNING: CYGWIN IS NOT SUPPORTED ---` warning when run in **Git Bash**.
* Root cause: on 2025-02-14 MSYS2 (the runtime behind Git for Windows) relabeled `bash` to report `$OSTYPE=cygwin` instead of `msys` (see the [MSYS2 news entry](https://www.msys2.org/news/)). Since then the exact-match `[ "${OSTYPE}" = "cygwin" ]` check can no longer distinguish genuine Cygwin from Git Bash, so recent Git for Windows installs (bash >= 5.3) wrongly trigger the warning.
* Detection now keys off `uname -s`, which still differs (`CYGWIN_NT*` for Cygwin vs `MINGW*`/`MSYS*` for Git Bash), via two small helpers `_ide_is_cygwin` / `_ide_is_msys` in `cli/src/main/package/functions`.
* The same relabel also silently disabled the `cygpath "${IDE_ROOT}"` conversion that was guarded by `[ "${OSTYPE}" = "msys" ]`; this guard now uses `_ide_is_msys`, restoring the intended behavior on modern Git Bash while leaving genuine Cygwin behavior unchanged.
* Added `cli/src/test/functions-test.sh`, a standalone regression test covering genuine Cygwin, modern Git Bash (OSTYPE=cygwin + uname=MINGW), legacy Git Bash (OSTYPE=msys) and MSYS.
* Wired that test into CI (`build.yml` on push to `main` and `build-pr.yml` on every PR) so the shell integration is covered automatically - previously the shell tests (`all-tests.sh`) only ran via manual `workflow_dispatch`.

---

### Testing instructions

1. On a machine with a recent Git for Windows (bash >= 5.3, where `echo $OSTYPE` prints `cygwin`), open **Git Bash**, set up IDEasy and run any `ide` command with an argument, e.g. `ide help`. The `CYGWIN IS NOT SUPPORTED` warning must **not** appear.
2. Automated: run `bash cli/src/test/functions-test.sh` - all 4 scenarios must pass. (The test fails on the previous `OSTYPE`-based implementation.) This now also runs in the PR CI build.

---

### Checklist for this PR

- [x] When running `mvn clean test` locally all tests pass and build is successful (change is shell/CI-only, no Java sources touched; the dedicated shell regression test `cli/src/test/functions-test.sh` passes)
- [x] PR title is of the form `#«issue-id»: «brief summary»`
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue
- [x] You followed all coding conventions
- [x] You have added the issue implemented by your PR in CHANGELOG.adoc unless issue is labeled with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"
