### PR TITLE
avoid pointless error with stacktrace in logs

### DIFF
--- a/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnFinalChecksumTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnFinalChecksumTest.java
@@ -12,8 +12,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 
 /**
- * Integration test verifying that the deterministic archives produced by our mock repositories
- * match our hardcoded "Gold Standard" values.
+ * Integration test verifying that the deterministic archives produced by our mock repositories match our hardcoded "Gold Standard" values.
  */
 @WireMockTest
 class MvnFinalChecksumTest extends AbstractIdeContextTest {
@@ -21,10 +20,8 @@ class MvnFinalChecksumTest extends AbstractIdeContextTest {
   private static final String PROJECT_MVN = "mvn";
 
 
-
   /**
-   * Integration test verifying that the tool installation correctly performs and validates 
-   * the checksum from the URL repository (urls.sha256).
+   * Integration test verifying that the tool installation correctly performs and validates the checksum from the URL repository (urls.sha256).
    */
   @Test
   void testVerifyUrlChecksum(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
@@ -32,6 +29,7 @@ class MvnFinalChecksumTest extends AbstractIdeContextTest {
     // 1. Arrange: Use the "mvn" project context with WireMock
     IdeTestContext context = newContext(PROJECT_MVN, wmRuntimeInfo);
     Mvn mvn = context.getCommandletManager().getCommandlet(Mvn.class);
+    context.setAnswers("login", "password");
 
     // Read the expected hash from the URL repository file in the test resources
     Path urlsSha256Path = context.getIdePath().resolve("urls/mvn/mvn/3.9.7/urls.sha256");


### PR DESCRIPTION
### This PR prevents a pointless exception caused by some test

### Implemented changes:

* read the logs when this test runs
* understood the problem
* fixed it

Should actually be done by developers before they push such tests.

---

### Testing instructions

Please add conscise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. check the log when this test runs. Should not contain error with stacktrace saying that end of answers is reached.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"
