### PR TITLE
#1041: disable Windows wildcard expansion in native image

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,12 @@
 
 This file documents all notable changes to https://github.com/devonfw/IDEasy[IDEasy].
 
+== 2026.07.002
+
+Release with new features and bugfixes:
+
+* https://github.com/devonfw/IDEasy/issues/1041[#1041]: native image has globbing active
+
 == 2026.07.001
 
 Release with new features and bugfixes:

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -266,6 +266,9 @@
                 <arg>--initialize-at-build-time=org.apache.commons</arg>
                 <arg>-H:IncludeResourceBundles=com.sun.org.apache.xml.internal.res.XMLErrorResources,com.sun.org.apache.xerces.internal.impl.msg.XMLMessages
                 </arg>
+                <!-- Disable Windows wildcard expansion so that arguments like "*" (e.g. "ide set-version gradle *")
+                     reach IDEasy verbatim instead of being expanded to file names by the C runtime. -->
+                <buildArg>-H:-EnableWildcardExpansion</buildArg>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
### This PR fixes #1041

On Windows, GraalVM native images link `setargv.obj` by default, which makes the C runtime
expand wildcards (`*`) in the command-line arguments **before** IDEasy's Java `main` receives
them. As a result `ide set-version gradle *` is turned into the list of files/directories in the
current working directory (e.g. `conf plugins settings software workspaces`), so the intended `*`
(VersionIdentifier for "latest stable") never reaches the version property and the command fails.
This affects cmd, PowerShell and git-bash alike, because the expansion is done by the binary
itself — it cannot be recovered in Java-side argument parsing.

### Implemented changes:

* `cli/pom.xml` (`native` profile): pass the GraalVM native-image option `-H:-EnableWildcardExpansion`
  so that `setargv.obj` is no longer linked and arguments reach IDEasy verbatim. Verified against the
  pinned GraalVM `25.0.3`, where `SubstrateOptions.EnableWildcardExpansion` (default `true`) is exactly
  the flag guarding the `setargv.obj` link step for executables.
* `CHANGELOG.adoc`: documented the fix under the next open release `2026.07.002`.

---

### Testing instructions

This is a Windows-native-build-only behavior; it cannot be reproduced in a JVM unit test (the C
runtime expands the arguments before Java runs). Verify with a native build:

1. Build the native image: `mvn -B -ntp -Pnative -DskipTests=true package` (repo root, on Windows with GraalVM + MSVC).
2. From any directory that contains sub-directories/files, run: `ide set-version gradle *`
3. The `*` is treated as "latest stable" and the version is set accordingly, instead of failing with
   `Invalid arguments: "set-version" "gradle" "conf" "plugins" ...` (the previously expanded directory names).

---

### Checklist for this PR

- [x] When running `mvn clean test` locally all tests pass and build is successful (no Java changed; only the `native` Maven profile and `CHANGELOG.adoc` are touched, so existing tests are unaffected)
- [x] PR title is of the form `#«issue-id»: «brief summary»`
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you
- [x] You followed all coding conventions
- [x] You have added the issue implemented by your PR in CHANGELOG.adoc
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

### Checklist for tool commandlets

Not applicable — this PR does not add a new tool commandlet.
