### PR TITLE
#2127 split url updater build run

### DIFF
--- a/.github/workflows/update-urls.yml
+++ b/.github/workflows/update-urls.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Build url updater
         run: |
           mvn -B -ntp -Dstyle.color=always -pl url-updater -am install
-          mvn -B -ntp -Dstyle.color=always -pl url-updater exec:java -Dexec.mainClass="com.devonfw.tools.ide.url.UpdateInitiator" -Dexec.args="ide-urls PT5H30M"
         env:
           GHA_TOKEN: ${{ secrets.GHA_TOKEN }}
       - name: Run url updater

--- a/.github/workflows/update-urls.yml
+++ b/.github/workflows/update-urls.yml
@@ -23,9 +23,14 @@ jobs:
           java-version: 25
           distribution: 'temurin'
           cache: 'maven'
-      - name: Build and run url updater
+      - name: Build url updater
         run: |
           mvn -B -ntp -Dstyle.color=always -pl url-updater -am install
+          mvn -B -ntp -Dstyle.color=always -pl url-updater exec:java -Dexec.mainClass="com.devonfw.tools.ide.url.UpdateInitiator" -Dexec.args="ide-urls PT5H30M"
+        env:
+          GHA_TOKEN: ${{ secrets.GHA_TOKEN }}
+      - name: Run url updater
+        run: |
           mvn -B -ntp -Dstyle.color=always -pl url-updater exec:java -Dexec.mainClass="com.devonfw.tools.ide.url.UpdateInitiator" -Dexec.args="ide-urls PT5H30M"
         env:
           GHA_TOKEN: ${{ secrets.GHA_TOKEN }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/2127[2127]: Split build and run url updater step into separate build and run steps
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/47?closed=1[milestone 2026.07.002].
 
@@ -13,7 +14,6 @@ The full list of changes for this release can be found in https://github.com/dev
 
 Release with new features and bugfixes:
 
-* https://github.com/devonfw/IDEasy/issues/2127[2127]: Split build and run url updater step into separate build and run steps
 * https://github.com/devonfw/IDEasy/issues/1063[#1063]: Improve IDEasy user specific configuration documentation
 * https://github.com/devonfw/IDEasy/issues/1909[#1909]: add commandlet for Maven Daemon
 * https://github.com/devonfw/IDEasy/issues/2068[#2068]: Isolate Claude Code configuration per IDEasy project

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,7 +6,6 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
-* https://github.com/devonfw/IDEasy/issues/2127[2127]: Split build and run url updater step into separate build and run steps
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/47?closed=1[milestone 2026.07.002].
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,7 @@ The full list of changes for this release can be found in https://github.com/dev
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/2127[2127]: Split build and run url updater step into separate build and run steps
 * https://github.com/devonfw/IDEasy/issues/1063[#1063]: Improve IDEasy user specific configuration documentation
 * https://github.com/devonfw/IDEasy/issues/1909[#1909]: add commandlet for Maven Daemon
 * https://github.com/devonfw/IDEasy/issues/2068[#2068]: Isolate Claude Code configuration per IDEasy project


### PR DESCRIPTION
### This PR fixes #2127

### Implemented changes:

* `update-urls.yml`: Split the existing `Build and run url updater` workflow step into two separate steps

### Testing instructions

1. Trigger the workflow containing the url-updater job.
2. Verify that the workflow now contains two separate steps:
   * `Build url updater`
   * `Run url updater`
3. Confirm that the Maven build and test logs are shown in the `Build url updater` step.
4. Confirm that the url-updater execution logs are shown in the `Run url updater` step.
5. Verify that the workflow completes successfully and behaves the same as before.

### Notes

The workflow could not be fully executed in my fork because it requires
repository secrets that are not available in fork repositories.

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

### Checklist for tool commandlets

Not applicable — this PR does not add a new tool commandlet.

