### PR TITLE
#1981: fix ide update failing on windows arm64

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1135[#1135]: Fix PowerShell env variable initialization on Windows by sourcing functions from the PowerShell profile
 * https://github.com/devonfw/IDEasy/issues/741[#741]: Add a warning message for legacy devonfw-ide settings users
 * https://github.com/devonfw/IDEasy/issues/1933[#1933]: Added a console panel to the GUI
+* https://github.com/devonfw/IDEasy/issues/1981[#1981]: Fall back to windows-x64 when no windows-arm64 artifact is published
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/49?closed=1[milestone 2026.09.001].
 
@@ -48,7 +49,6 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/2131[#2131]: Improve `ide upgrade --mode=` auto-completion
 * https://github.com/devonfw/IDEasy/issues/1870[#1870]: Add generic get-version implementation for global tools under windows
 * https://github.com/devonfw/IDEasy/issues/1558[#1558]: Added installation log information to the "Select Project Folder" and exit dialogs and enhanced `windows-installer/README.adoc`.
-* https://github.com/devonfw/IDEasy/issues/1981[#1981]: ide update fails on windows@arm64
 * https://github.com/devonfw/IDEasy/issues/2187[#2187]: Start SoapUI commandlet in background
 * https://github.com/devonfw/IDEasy/issues/2189[#2189]: Integrate Ruff
 * https://github.com/devonfw/IDEasy/issues/2126[#2126]: Fix language selection dropdown

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/1981[#1981]: ide update fails on windows@arm64
 * https://github.com/devonfw/IDEasy/issues/2187[#2187]: Start SoapUI commandlet in background
 * https://github.com/devonfw/IDEasy/issues/2189[#2189]: Integrate Ruff
 * https://github.com/devonfw/IDEasy/issues/2126[#2126]: Fix language selection dropdown

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -48,6 +48,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/2131[#2131]: Improve `ide upgrade --mode=` auto-completion
 * https://github.com/devonfw/IDEasy/issues/1870[#1870]: Add generic get-version implementation for global tools under windows
 * https://github.com/devonfw/IDEasy/issues/1558[#1558]: Added installation log information to the "Select Project Folder" and exit dialogs and enhanced `windows-installer/README.adoc`.
+* https://github.com/devonfw/IDEasy/issues/1981[#1981]: ide update fails on windows@arm64
 * https://github.com/devonfw/IDEasy/issues/2187[#2187]: Start SoapUI commandlet in background
 * https://github.com/devonfw/IDEasy/issues/2189[#2189]: Integrate Ruff
 * https://github.com/devonfw/IDEasy/issues/2126[#2126]: Fix language selection dropdown

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnArtifact.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnArtifact.java
@@ -18,7 +18,7 @@ public class MvnArtifact extends SoftwareArtifact {
   public static final String ARTIFACT_ID_IDEASY_CLI = "ide-cli";
 
   /** {@link #getClassifier() Classifier} of source code. */
-  public static final String CLASSIFER_SOURCES = "sources";
+  public static final String CLASSIFIER_SOURCES = "sources";
 
   /** {@link #getType() Type} of JAR file. */
   public static final String TYPE_JAR = "jar";
@@ -28,6 +28,16 @@ public class MvnArtifact extends SoftwareArtifact {
 
   /** {@link #getFilename() Filename} for artifact metadata with version information. */
   public static final String MAVEN_METADATA_XML = "maven-metadata.xml";
+
+  public static final String XML_TAG_VERSIONING = "versioning";
+
+  public static final String XML_TAG_SNAPSHOT_VERSIONS = "snapshotVersions";
+
+  public static final String XML_TAG_SNAPSHOT_VERSION = "snapshotVersion";
+
+  public static final String XML_TAG_CLASSIFIER = "classifier";
+
+  public static final String XML_TAG_EXTENSION = "extension";
 
   private static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("-\\d{8}\\.\\d{6}-\\d+");
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnRepository.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnRepository.java
@@ -1,6 +1,7 @@
 package com.devonfw.tools.ide.tool.mvn;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -11,8 +12,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -63,24 +62,16 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
 
   private static final Duration METADATA_CACHE_DURATION_SNAPSHOT = Duration.ofMinutes(5);
 
-  private static final long XML_METADATA_CACHE_RETENTION =
-      Duration.ofMinutes(1).toMillis();
+  /**
+   * Short-lived in-memory cache used to avoid duplicate XML metadata fetches within one CLI run.
+   */
+  private static final Duration XML_METADATA_CACHE_DURATION = Duration.ofMinutes(1);
 
   private static final String CLASSIFIER_WINDOWS_ARM64 = "windows-arm64";
 
   private static final String CLASSIFIER_WINDOWS_X64 = "windows-x64";
 
-  /**
-   * Matches resolved timestamped Maven snapshot versions, for example:
-   * 2026.05.001-20260527.032443-21
-   * 2025.02.001-beta-20250204.023111-1
-   */
-  private static final Pattern PATTERN_TIMESTAMPED_SNAPSHOT =
-      Pattern.compile("^(.+)-\\d{8}\\.\\d{6}-\\d+$");
-
   private final Path localMavenRepository;
-
-  private final DocumentBuilder documentBuilder;
 
   private final Map<String, CachedValue<Document>> xmlMetadataCache;
 
@@ -99,12 +90,6 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
     super(context);
     this.localMavenRepository = IdeVariables.M2_REPO.get(this.context);
     this.xmlMetadataCache = new ConcurrentHashMap<>();
-    try {
-      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-      this.documentBuilder = factory.newDocumentBuilder();
-    } catch (Exception e) {
-      throw new IllegalStateException("Failed to create XML document builder", e);
-    }
   }
 
   @Override
@@ -162,10 +147,14 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
       }
 
       if (CLASSIFIER_WINDOWS_ARM64.equals(classifier)) {
-        classifier = resolveSnapshotClassifier(
+        classifier = resolveWindowsArm64Classifier(
             artifact,
             classifier,
             artifact.getType());
+
+        if (CLASSIFIER_WINDOWS_X64.equals(classifier)) {
+          arch = SystemArchitecture.X64;
+        }
       }
 
       artifact = artifact.withClassifier(classifier);
@@ -185,30 +174,25 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
    * @param artifact the artifact being resolved.
    * @param classifier the originally resolved classifier.
    * @param extension the artifact extension, such as {@code tar.gz}.
-   * @return the original classifier if it exists or no suitable fallback is
-   *         available; otherwise {@code windows-x64}.
+   * @return the original classifier if it exists or no suitable fallback is available; otherwise {@code windows-x64}.
    */
-  private String resolveSnapshotClassifier(
-      MvnArtifact artifact,
-      String classifier,
-      String extension) {
+  private String resolveWindowsArm64Classifier(MvnArtifact artifact, String classifier, String extension) {
 
-    String snapshotVersion = getSnapshotBaseVersion(artifact.getVersion());
-
-    // The classifier availability is listed in version-specific metadata only
-    // for Maven snapshots. Leave normal release handling unchanged.
-    if (snapshotVersion == null) {
-      return classifier;
+    if (!artifact.isSnapshot()) {
+      logWindowsArm64Fallback(artifact.getVersion());
+      return CLASSIFIER_WINDOWS_X64;
     }
 
-    MvnArtifact metadataArtifact = artifact
-        .withVersion(snapshotVersion)
-        .withMavenMetadata();
+    String metadataUrl = getMavenUrl(artifact.withMavenMetadata());
 
-    String metadataUrl = getMavenUrl(metadataArtifact);
-    Document metadata = fetchXmlMetadata(metadataUrl);
-
-    return resolveSnapshotClassifier(metadata, classifier, extension);
+    try {
+      Document metadata = fetchXmlMetadata(metadataUrl);
+      return resolveSnapshotClassifier(metadata, classifier, extension, artifact.getVersion());
+    } catch (RuntimeException e) {
+      LOG.debug("Failed to inspect snapshot metadata from {} - falling back to {}.",
+          metadataUrl, CLASSIFIER_WINDOWS_X64, e);
+      return CLASSIFIER_WINDOWS_X64;
+    }
   }
 
   /**
@@ -217,12 +201,10 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
    * @param metadata the version-specific Maven snapshot metadata.
    * @param classifier the requested artifact classifier.
    * @param extension the requested artifact extension.
+   * @param version the artifact version.
    * @return the resolved classifier.
    */
-  String resolveSnapshotClassifier(
-      Document metadata,
-      String classifier,
-      String extension) {
+  String resolveSnapshotClassifier(Document metadata, String classifier, String extension, String version) {
 
     if (hasSnapshotArtifact(metadata, classifier, extension)) {
       return classifier;
@@ -231,35 +213,13 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
     if (CLASSIFIER_WINDOWS_ARM64.equals(classifier)
         && hasSnapshotArtifact(metadata, CLASSIFIER_WINDOWS_X64, extension)) {
 
-      LOG.warn(
-          "No Windows ARM64 artifact is available. "
-              + "Falling back to the Windows x64 artifact.");
-
+      logWindowsArm64Fallback(version);
       return CLASSIFIER_WINDOWS_X64;
     }
 
     // Preserve the original classifier so the existing download error is
     // reported when neither the requested artifact nor a fallback exists.
     return classifier;
-  }
-
-  /**
-   * Converts a resolved timestamped snapshot version back to its Maven snapshot
-   * base version.
-   *
-   * @param version the resolved artifact version.
-   * @return the corresponding {@code -SNAPSHOT} version, or {@code null} if the
-   *         version is not a timestamped snapshot.
-   */
-  String getSnapshotBaseVersion(String version) {
-
-    Matcher matcher = PATTERN_TIMESTAMPED_SNAPSHOT.matcher(version);
-
-    if (!matcher.matches()) {
-      return null;
-    }
-
-    return matcher.group(1) + "-SNAPSHOT";
   }
 
   /**
@@ -270,27 +230,42 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
    * @param extension the artifact extension.
    * @return {@code true} if the artifact is present.
    */
-  private boolean hasSnapshotArtifact(
-      Document metadata,
-      String classifier,
-      String extension) {
+  private boolean hasSnapshotArtifact(Document metadata, String classifier, String extension) {
 
-    NodeList snapshotVersions =
-        metadata.getElementsByTagName("snapshotVersion");
+    Element root = metadata.getDocumentElement();
 
-    for (int i = 0; i < snapshotVersions.getLength(); i++) {
-      Node snapshotVersion = snapshotVersions.item(i);
+    Element versioning =
+        findFirstChildElement(root, MvnArtifact.XML_TAG_VERSIONING);
 
-      String currentClassifier =
-          getChildText(snapshotVersion, "classifier");
+    if (versioning == null) {
+      return false;
+    }
 
-      String currentExtension =
-          getChildText(snapshotVersion, "extension");
+    Element snapshotVersions =
+        findFirstChildElement(versioning, MvnArtifact.XML_TAG_SNAPSHOT_VERSIONS);
 
-      if (classifier.equals(currentClassifier)
-          && extension.equals(currentExtension)) {
+    if (snapshotVersions == null) {
+      return false;
+    }
 
-        return true;
+    NodeList children = snapshotVersions.getChildNodes();
+
+    for (int i = 0; i < children.getLength(); i++) {
+      Node node = children.item(i);
+
+      if (node instanceof Element snapshotVersion
+          && MvnArtifact.XML_TAG_SNAPSHOT_VERSION.equals(snapshotVersion.getTagName())) {
+
+        String currentClassifier =
+            getChildText(snapshotVersion, MvnArtifact.XML_TAG_CLASSIFIER);
+
+        String currentExtension =
+            getChildText(snapshotVersion, MvnArtifact.XML_TAG_EXTENSION);
+
+        if (classifier.equals(currentClassifier)
+            && extension.equals(currentExtension)) {
+          return true;
+        }
       }
     }
 
@@ -300,23 +275,17 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
   /**
    * Gets the text content of a direct child node.
    *
-   * @param parent the parent node.
-   * @param childName the child-node name.
+   * @param element the parent node.
+   * @param tag the child-node name.
    * @return the child text, or {@code null} if the child does not exist.
    */
-  private String getChildText(Node parent, String childName) {
+  private String getChildText(Element element, String tag) {
 
-    NodeList children = parent.getChildNodes();
-
-    for (int i = 0; i < children.getLength(); i++) {
-      Node child = children.item(i);
-
-      if (childName.equals(child.getNodeName())) {
-        return child.getTextContent().trim();
-      }
+    Element child = findFirstChildElement(element, tag);
+    if (child == null) {
+      return null;
     }
-
-    return null;
+    return child.getTextContent().trim();
   }
 
   /**
@@ -448,19 +417,26 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
     return getDownloadedArtifact(metadata.getMvnArtifact(), metadata.getChecksums());
   }
 
-  private Element getFirstChildElement(Element element, String tag, Object source) {
+  private Element findFirstChildElement(Element element, String tag) {
 
     NodeList children = element.getChildNodes();
-    int length = children.getLength();
-    for (int i = 0; i < length; i++) {
+    for (int i = 0; i < children.getLength(); i++) {
       Node node = children.item(i);
-      if (node instanceof Element child) {
-        if (child.getTagName().equals(tag)) {
-          return child;
-        }
+      if (node instanceof Element child && child.getTagName().equals(tag)) {
+        return child;
       }
     }
-    throw new IllegalStateException("Failed to resolve snapshot version - element " + tag + " not found in " + source);
+    return null;
+  }
+
+  private Element getFirstChildElement(Element element, String tag, Object source) {
+
+    Element child = findFirstChildElement(element, tag);
+    if (child != null) {
+      return child;
+    }
+    throw new IllegalStateException(
+        "Failed to resolve snapshot version - element " + tag + " not found in " + source);
   }
 
   private Document fetchXmlMetadata(String url) {
@@ -470,7 +446,7 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
             url,
             key -> new CachedValue<>(
                 () -> downloadXmlMetadata(key),
-                XML_METADATA_CACHE_RETENTION));
+                XML_METADATA_CACHE_DURATION.toMillis()));
 
     return cachedMetadata.get();
   }
@@ -479,18 +455,18 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
 
     try {
       return this.context.getNetworkStatus().invokeNetworkTask(() -> {
-        URL xmlUrl = new URL(url);
+        URL xmlUrl = URI.create(url).toURL();
 
         try (InputStream is = xmlUrl.openStream()) {
-          synchronized (this.documentBuilder) {
-            return this.documentBuilder.parse(is);
-          }
+          DocumentBuilder documentBuilder =
+              DocumentBuilderFactory.newInstance().newDocumentBuilder();
+          return documentBuilder.parse(is);
         }
       }, url);
 
     } catch (Exception e) {
       throw new CliException(
-          "Failed to determine the latest version from " + url, e);
+          "Failed to fetch XML metadata from " + url, e);
     }
   }
 
@@ -536,5 +512,11 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
       }
       return this.checksums.iterator();
     }
+  }
+
+  private void logWindowsArm64Fallback(String version) {
+    LOG.warn("No {} artifact is published for version {} - falling back to {} "
+            + "(see https://github.com/devonfw/IDEasy/issues/599).",
+        CLASSIFIER_WINDOWS_ARM64, version, CLASSIFIER_WINDOWS_X64);
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnRepository.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnRepository.java
@@ -67,9 +67,9 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
    */
   private static final Duration XML_METADATA_CACHE_DURATION = Duration.ofMinutes(1);
 
-  private static final String CLASSIFIER_WINDOWS_ARM64 = "windows-arm64";
+  private static final String ARCH_ARM64 = "arm64";
 
-  private static final String CLASSIFIER_WINDOWS_X64 = "windows-x64";
+  private static final String ARCH_X64 = "x64";
 
   private final Path localMavenRepository;
 
@@ -146,13 +146,15 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
         classifier = resolvedClassifier;
       }
 
-      if (CLASSIFIER_WINDOWS_ARM64.equals(classifier)) {
-        classifier = resolveWindowsArm64Classifier(
+      if (classifier.contains(ARCH_ARM64)) {
+        String originalClassifier = classifier;
+
+        classifier = resolveArm64Classifier(
             artifact,
             classifier,
             artifact.getType());
 
-        if (CLASSIFIER_WINDOWS_X64.equals(classifier)) {
+        if (!classifier.equals(originalClassifier)) {
           arch = SystemArchitecture.X64;
         }
       }
@@ -165,22 +167,21 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
   }
 
   /**
-   * Resolves the classifier for a timestamped Maven snapshot.
+   * Resolves the classifier for a Maven snapshot on ARM64.
    * <p>
-   * IDEasy currently does not publish a Windows ARM64 artifact. Windows on ARM
-   * can execute Windows x64 applications, so the x64 artifact is used as a
-   * fallback when the ARM64 artifact is unavailable.
+   * Snapshot metadata is inspected to determine whether the ARM64 artifact exists.
+   * If it is unavailable but a x64 artifact exists, the x64 artifact is used as fallback.
+   * Release artifacts are not changed here and are attempted as ARM64 first.
    *
    * @param artifact the artifact being resolved.
    * @param classifier the originally resolved classifier.
    * @param extension the artifact extension, such as {@code tar.gz}.
-   * @return the original classifier if it exists or no suitable fallback is available; otherwise {@code windows-x64}.
+   * @return the resolved classifier.
    */
-  private String resolveWindowsArm64Classifier(MvnArtifact artifact, String classifier, String extension) {
+  private String resolveArm64Classifier(MvnArtifact artifact, String classifier, String extension) {
 
     if (!artifact.isSnapshot()) {
-      logWindowsArm64Fallback(artifact.getVersion());
-      return CLASSIFIER_WINDOWS_X64;
+      return classifier;
     }
 
     String metadataUrl = getMavenUrl(artifact.withMavenMetadata());
@@ -189,9 +190,8 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
       Document metadata = fetchXmlMetadata(metadataUrl);
       return resolveSnapshotClassifier(metadata, classifier, extension, artifact.getVersion());
     } catch (RuntimeException e) {
-      LOG.debug("Failed to inspect snapshot metadata from {} - falling back to {}.",
-          metadataUrl, CLASSIFIER_WINDOWS_X64, e);
-      return CLASSIFIER_WINDOWS_X64;
+      LOG.debug("Failed to inspect snapshot metadata from {}.", metadataUrl, e);
+      return classifier;
     }
   }
 
@@ -206,15 +206,17 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
    */
   String resolveSnapshotClassifier(Document metadata, String classifier, String extension, String version) {
 
+    String fallbackClassifier = classifier.replace(ARCH_ARM64, ARCH_X64);
+
     if (hasSnapshotArtifact(metadata, classifier, extension)) {
       return classifier;
     }
 
-    if (CLASSIFIER_WINDOWS_ARM64.equals(classifier)
-        && hasSnapshotArtifact(metadata, CLASSIFIER_WINDOWS_X64, extension)) {
+    if (classifier.contains(ARCH_ARM64)
+        && hasSnapshotArtifact(metadata, fallbackClassifier, extension)) {
 
-      logWindowsArm64Fallback(version);
-      return CLASSIFIER_WINDOWS_X64;
+      logArm64Fallback(classifier, fallbackClassifier, version);
+      return fallbackClassifier;
     }
 
     // Preserve the original classifier so the existing download error is
@@ -314,10 +316,21 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
   private Path getDownloadedArtifact(MvnArtifact artifact, UrlChecksums checksums) {
 
     Path file = this.localMavenRepository.resolve(artifact.getPath());
+
     if (isNotUpToDateInLocalRepo(file)) {
       this.context.getFileAccess().mkdirs(file.getParent());
-      download(getMavenUrl(artifact), file, artifact.getVersion(), checksums);
+
+      try {
+        download(getMavenUrl(artifact), file, artifact.getVersion(), checksums);
+      } catch (RuntimeException e) {
+
+        if (shouldFallbackToX64(artifact, e)) {
+          return downloadX64Fallback(artifact);
+        }
+        throw e;
+      }
     }
+
     return file;
   }
 
@@ -420,7 +433,8 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
   private Element findFirstChildElement(Element element, String tag) {
 
     NodeList children = element.getChildNodes();
-    for (int i = 0; i < children.getLength(); i++) {
+    int length = children.getLength();
+    for (int i = 0; i < length; i++) {
       Node node = children.item(i);
       if (node instanceof Element child && child.getTagName().equals(tag)) {
         return child;
@@ -514,9 +528,79 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
     }
   }
 
-  private void logWindowsArm64Fallback(String version) {
-    LOG.warn("No {} artifact is published for version {} - falling back to {} "
-            + "(see https://github.com/devonfw/IDEasy/issues/599).",
-        CLASSIFIER_WINDOWS_ARM64, version, CLASSIFIER_WINDOWS_X64);
+  private void logArm64Fallback(String classifier, String fallbackClassifier, String version) {
+    LOG.warn("Artifact with classifier {} is unavailable for version {} - falling back to {}.",
+        classifier, version, fallbackClassifier);
+  }
+
+  /**
+   * Checks whether a failed ARM64 download should fall back to the corresponding x64 artifact.
+   *
+   * @param artifact the artifact whose download failed.
+   * @param error the download error.
+   * @return {@code true} if the x64 fallback should be attempted.
+   */
+  private boolean shouldFallbackToX64(MvnArtifact artifact, Throwable error) {
+
+    String classifier = artifact.getClassifier();
+
+    return classifier.contains(ARCH_ARM64)
+        && isNotFound(error);
+  }
+
+  /**
+   * Checks whether the given exception was caused by an HTTP 404 response.
+   *
+   * @param error the exception to inspect.
+   * @return {@code true} if the exception chain contains an HTTP 404 response.
+   */
+  private static boolean isNotFound(Throwable error) {
+
+    Throwable current = error;
+
+    while (current != null) {
+      String message = current.getMessage();
+      if ((message != null) && message.contains("status code 404")) {
+        return true;
+      }
+      current = current.getCause();
+    }
+
+    return false;
+  }
+
+  /**
+   * Downloads the  x64 artifact as fallback for an unavailable ARM64 release artifact.
+   *
+   * @param artifact the original ARM64 artifact.
+   * @return the downloaded x64 artifact.
+   */
+  private Path downloadX64Fallback(MvnArtifact artifact) {
+
+    String fallbackClassifier =
+        artifact.getClassifier().replace(ARCH_ARM64, ARCH_X64);
+
+    MvnArtifact fallbackArtifact =
+        artifact.withClassifier(fallbackClassifier);
+
+    Path fallbackFile =
+        this.localMavenRepository.resolve(fallbackArtifact.getPath());
+
+    logArm64Fallback(
+        artifact.getClassifier(),
+        fallbackClassifier,
+        artifact.getVersion());
+
+    if (isNotUpToDateInLocalRepo(fallbackFile)) {
+      this.context.getFileAccess().mkdirs(fallbackFile.getParent());
+
+      download(
+          getMavenUrl(fallbackArtifact),
+          fallbackFile,
+          fallbackArtifact.getVersion(),
+          getChecksums(fallbackArtifact));
+    }
+
+    return fallbackFile;
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnRepository.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnRepository.java
@@ -6,18 +6,24 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.devonfw.tools.ide.cache.CachedValue;
 import com.devonfw.tools.ide.cli.CliException;
 import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.os.OperatingSystem;
@@ -41,6 +47,8 @@ import com.devonfw.tools.ide.version.VersionIdentifier;
  */
 public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifactMetadata> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(MvnRepository.class);
+
   /** Base URL for Maven Central repository */
   public static final String MAVEN_CENTRAL = "https://repo1.maven.org/maven2";
 
@@ -54,9 +62,26 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
 
   private static final Duration METADATA_CACHE_DURATION_SNAPSHOT = Duration.ofMinutes(5);
 
+  private static final long XML_METADATA_CACHE_RETENTION =
+      Duration.ofMinutes(1).toMillis();
+
+  private static final String CLASSIFIER_WINDOWS_ARM64 = "windows-arm64";
+
+  private static final String CLASSIFIER_WINDOWS_X64 = "windows-x64";
+
+  /**
+   * Matches resolved timestamped Maven snapshot versions, for example:
+   * 2026.05.001-20260527.032443-21
+   * 2025.02.001-beta-20250204.023111-1
+   */
+  private static final Pattern PATTERN_TIMESTAMPED_SNAPSHOT =
+      Pattern.compile("^(.+)-\\d{8}\\.\\d{6}-\\d+$");
+
   private final Path localMavenRepository;
 
   private final DocumentBuilder documentBuilder;
+
+  private final Map<String, CachedValue<Document>> xmlMetadataCache;
 
   private static final Map<String, MvnArtifact> TOOL_MAP = Map.of(
       "ideasy", IdeasyCommandlet.ARTIFACT,
@@ -72,6 +97,7 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
 
     super(context);
     this.localMavenRepository = IdeVariables.M2_REPO.get(this.context);
+    this.xmlMetadataCache = new ConcurrentHashMap<>();
     try {
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       this.documentBuilder = factory.newDocumentBuilder();
@@ -112,24 +138,184 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
     OperatingSystem os = null;
     SystemArchitecture arch = null;
     String classifier = artifact.getClassifier();
+
     if (!classifier.isEmpty()) {
       String resolvedClassifier;
+
       os = this.context.getSystemInfo().getOs();
       resolvedClassifier = classifier.replace("${os}", os.toString());
+
       if (resolvedClassifier.equals(classifier)) {
         os = null;
       } else {
         classifier = resolvedClassifier;
       }
+
       arch = this.context.getSystemInfo().getArchitecture();
       resolvedClassifier = classifier.replace("${arch}", arch.toString());
+
       if (resolvedClassifier.equals(classifier)) {
         arch = null;
+      } else {
+        classifier = resolvedClassifier;
       }
-      artifact = artifact.withClassifier(resolvedClassifier);
+
+      if (CLASSIFIER_WINDOWS_ARM64.equals(classifier)) {
+        classifier = resolveSnapshotClassifier(
+            artifact,
+            classifier,
+            artifact.getType());
+      }
+
+      artifact = artifact.withClassifier(classifier);
     }
+
     UrlChecksums checksums = getChecksums(artifact);
     return new MvnArtifactMetadata(artifact, tool, edition, checksums, os, arch);
+  }
+
+  /**
+   * Resolves the classifier for a timestamped Maven snapshot.
+   * <p>
+   * IDEasy currently does not publish a Windows ARM64 artifact. Windows on ARM
+   * can execute Windows x64 applications, so the x64 artifact is used as a
+   * fallback when the ARM64 artifact is unavailable.
+   *
+   * @param artifact the artifact being resolved.
+   * @param classifier the originally resolved classifier.
+   * @param extension the artifact extension, such as {@code tar.gz}.
+   * @return the original classifier if it exists or no suitable fallback is
+   *         available; otherwise {@code windows-x64}.
+   */
+  private String resolveSnapshotClassifier(
+      MvnArtifact artifact,
+      String classifier,
+      String extension) {
+
+    String snapshotVersion = getSnapshotBaseVersion(artifact.getVersion());
+
+    // The classifier availability is listed in version-specific metadata only
+    // for Maven snapshots. Leave normal release handling unchanged.
+    if (snapshotVersion == null) {
+      return classifier;
+    }
+
+    MvnArtifact metadataArtifact = artifact
+        .withVersion(snapshotVersion)
+        .withMavenMetadata();
+
+    String metadataUrl = getMavenUrl(metadataArtifact);
+    Document metadata = fetchXmlMetadata(metadataUrl);
+
+    return resolveSnapshotClassifier(metadata, classifier, extension);
+  }
+
+  /**
+   * Resolves a snapshot classifier from Maven snapshot metadata.
+   *
+   * @param metadata the version-specific Maven snapshot metadata.
+   * @param classifier the requested artifact classifier.
+   * @param extension the requested artifact extension.
+   * @return the resolved classifier.
+   */
+  String resolveSnapshotClassifier(
+      Document metadata,
+      String classifier,
+      String extension) {
+
+    if (hasSnapshotArtifact(metadata, classifier, extension)) {
+      return classifier;
+    }
+
+    if (CLASSIFIER_WINDOWS_ARM64.equals(classifier)
+        && hasSnapshotArtifact(metadata, CLASSIFIER_WINDOWS_X64, extension)) {
+
+      LOG.warn(
+          "No Windows ARM64 artifact is available. "
+              + "Falling back to the Windows x64 artifact.");
+
+      return CLASSIFIER_WINDOWS_X64;
+    }
+
+    // Preserve the original classifier so the existing download error is
+    // reported when neither the requested artifact nor a fallback exists.
+    return classifier;
+  }
+
+  /**
+   * Converts a resolved timestamped snapshot version back to its Maven snapshot
+   * base version.
+   *
+   * @param version the resolved artifact version.
+   * @return the corresponding {@code -SNAPSHOT} version, or {@code null} if the
+   *         version is not a timestamped snapshot.
+   */
+  String getSnapshotBaseVersion(String version) {
+
+    Matcher matcher = PATTERN_TIMESTAMPED_SNAPSHOT.matcher(version);
+
+    if (!matcher.matches()) {
+      return null;
+    }
+
+    return matcher.group(1) + "-SNAPSHOT";
+  }
+
+  /**
+   * Checks whether the Maven snapshot metadata contains the requested artifact.
+   *
+   * @param metadata the Maven snapshot metadata.
+   * @param classifier the artifact classifier.
+   * @param extension the artifact extension.
+   * @return {@code true} if the artifact is present.
+   */
+  private boolean hasSnapshotArtifact(
+      Document metadata,
+      String classifier,
+      String extension) {
+
+    NodeList snapshotVersions =
+        metadata.getElementsByTagName("snapshotVersion");
+
+    for (int i = 0; i < snapshotVersions.getLength(); i++) {
+      Node snapshotVersion = snapshotVersions.item(i);
+
+      String currentClassifier =
+          getChildText(snapshotVersion, "classifier");
+
+      String currentExtension =
+          getChildText(snapshotVersion, "extension");
+
+      if (classifier.equals(currentClassifier)
+          && extension.equals(currentExtension)) {
+
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Gets the text content of a direct child node.
+   *
+   * @param parent the parent node.
+   * @param childName the child-node name.
+   * @return the child text, or {@code null} if the child does not exist.
+   */
+  private String getChildText(Node parent, String childName) {
+
+    NodeList children = parent.getChildNodes();
+
+    for (int i = 0; i < children.getLength(); i++) {
+      Node child = children.item(i);
+
+      if (childName.equals(child.getNodeName())) {
+        return child.getTextContent().trim();
+      }
+    }
+
+    return null;
   }
 
   /**
@@ -278,15 +464,32 @@ public class MvnRepository extends ArtifactToolRepository<MvnArtifact, MvnArtifa
 
   private Document fetchXmlMetadata(String url) {
 
+    CachedValue<Document> cachedMetadata =
+        this.xmlMetadataCache.computeIfAbsent(
+            url,
+            key -> new CachedValue<>(
+                () -> downloadXmlMetadata(key),
+                XML_METADATA_CACHE_RETENTION));
+
+    return cachedMetadata.get();
+  }
+
+  private Document downloadXmlMetadata(String url) {
+
     try {
       return this.context.getNetworkStatus().invokeNetworkTask(() -> {
         URL xmlUrl = new URL(url);
+
         try (InputStream is = xmlUrl.openStream()) {
-          return documentBuilder.parse(is);
+          synchronized (this.documentBuilder) {
+            return this.documentBuilder.parse(is);
+          }
         }
       }, url);
+
     } catch (Exception e) {
-      throw new CliException("Failed to determine the latest version from " + url, e);
+      throw new CliException(
+          "Failed to determine the latest version from " + url, e);
     }
   }
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnRepository.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/mvn/MvnRepository.java
@@ -6,13 +6,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 

--- a/cli/src/test/java/com/devonfw/tools/ide/os/SystemInfoMock.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/os/SystemInfoMock.java
@@ -11,6 +11,10 @@ public class SystemInfoMock {
   /** {@link OperatingSystem#WINDOWS} with {@link SystemArchitecture#X64}. */
   public static final SystemInfo WINDOWS_X64 = new SystemInfoImpl("Windows 10", "10.0", "amd64");
 
+  /** {@link OperatingSystem#WINDOWS} with {@link SystemArchitecture#ARM64}. */
+  public static final SystemInfo WINDOWS_ARM64 =
+      new SystemInfoImpl("Windows 11", "10.0", "aarch64");
+
   /** {@link OperatingSystem#MAC} with {@link SystemArchitecture#X64}. */
   public static final SystemInfo MAC_X64 = new SystemInfoImpl("Mac OS X", "12.6.9", "x86_64");
 
@@ -23,7 +27,7 @@ public class SystemInfoMock {
   /** {@link OperatingSystem#LINUX} with {@link SystemArchitecture#X64} running inside WSL. */
   public static final SystemInfo LINUX_WSL_X64 = new SystemInfoImpl("Linux", "5.15.153.1-microsoft-standard-WSL2", "x86_64", true);
 
-  private static final List<SystemInfo> MOCKS = List.of(WINDOWS_X64, MAC_X64, MAC_ARM64, LINUX_X64, LINUX_WSL_X64);
+  private static final List<SystemInfo> MOCKS = List.of(WINDOWS_X64, WINDOWS_ARM64, MAC_X64, MAC_ARM64, LINUX_X64, LINUX_WSL_X64);
 
   public static SystemInfo of(String osString) {
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnRepositoryTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnRepositoryTest.java
@@ -231,6 +231,74 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
     assertThat(version).hasToString("2025.02.001-beta-20250204.023111-1");
   }
 
+  @Test
+  void testResolveSnapshotClassifierFallsBackFromWindowsArm64ToX64() {
+
+    // arrange
+    IdeTestContext context = new IdeTestContext();
+    MvnRepository mvnRepository = context.getMvnRepository();
+    Document metadata = parseXml(XML_SNAPSNOT_METADATA);
+
+    // act
+    String classifier = mvnRepository.resolveSnapshotClassifier(
+        metadata,
+        "windows-arm64",
+        "tar.gz");
+
+    // assert
+    assertThat(classifier).isEqualTo("windows-x64");
+  }
+
+  @Test
+  void testResolveSnapshotClassifierKeepsWindowsArm64WhenAvailable() {
+
+    // arrange
+    IdeTestContext context = new IdeTestContext();
+    MvnRepository mvnRepository = context.getMvnRepository();
+
+    String arm64Artifact = """
+      <snapshotVersion>
+        <classifier>windows-arm64</classifier>
+        <extension>tar.gz</extension>
+        <value>2025.02.001-beta-20250204.023111-1</value>
+        <updated>20250204023111</updated>
+      </snapshotVersion>
+      """;
+
+    String xml = XML_SNAPSNOT_METADATA.replace(
+        "</snapshotVersions>",
+        arm64Artifact + "</snapshotVersions>");
+
+    Document metadata = parseXml(xml);
+
+    // act
+    String classifier = mvnRepository.resolveSnapshotClassifier(
+        metadata,
+        "windows-arm64",
+        "tar.gz");
+
+    // assert
+    assertThat(classifier).isEqualTo("windows-arm64");
+  }
+
+  @Test
+  void testResolveSnapshotClassifierDoesNotFallbackForLinuxArm64() {
+
+    // arrange
+    IdeTestContext context = new IdeTestContext();
+    MvnRepository mvnRepository = context.getMvnRepository();
+    Document metadata = parseXml(XML_SNAPSNOT_METADATA);
+
+    // act
+    String classifier = mvnRepository.resolveSnapshotClassifier(
+        metadata,
+        "linux-arm64",
+        "tar.gz");
+
+    // assert
+    assertThat(classifier).isEqualTo("linux-arm64");
+  }
+
   /** Test of {@link MvnRepository#fetchVersions(Document, String)}. */
   @Test
   void testResolveVersion() {
@@ -260,4 +328,24 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
     }
   }
 
+  @Test
+  void testGetSnapshotBaseVersion() {
+
+    // arrange
+    IdeTestContext context = new IdeTestContext();
+    MvnRepository mvnRepository = context.getMvnRepository();
+
+    // act/assert
+    assertThat(mvnRepository.getSnapshotBaseVersion(
+        "2026.05.001-20260527.032443-21"))
+        .isEqualTo("2026.05.001-SNAPSHOT");
+
+    assertThat(mvnRepository.getSnapshotBaseVersion(
+        "2025.02.001-beta-20250204.023111-1"))
+        .isEqualTo("2025.02.001-beta-SNAPSHOT");
+
+    assertThat(mvnRepository.getSnapshotBaseVersion(
+        "2026.05.001"))
+        .isNull();
+  }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnRepositoryTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnRepositoryTest.java
@@ -16,6 +16,7 @@ import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeTestContext;
 import com.devonfw.tools.ide.os.OperatingSystem;
 import com.devonfw.tools.ide.os.SystemArchitecture;
+import com.devonfw.tools.ide.os.SystemInfoMock;
 import com.devonfw.tools.ide.tool.ToolCommandlet;
 import com.devonfw.tools.ide.url.model.file.UrlChecksums;
 import com.devonfw.tools.ide.url.model.file.UrlDownloadFileMetadata;
@@ -141,6 +142,7 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
 
     // arrange
     IdeTestContext context = newContext(PROJECT_BASIC);
+    context.setSystemInfo(SystemInfoMock.WINDOWS_X64);
     MvnRepository mavenRepo = new MvnRepository(context);
     String tool = "ideasy";
     String edition = tool;
@@ -181,6 +183,7 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
 
     // arrange
     IdeTestContext context = newContext(PROJECT_BASIC);
+    context.setSystemInfo(SystemInfoMock.WINDOWS_X64);
     MvnRepository mavenRepo = new MvnRepository(context);
     String tool = "ideasy";
     String edition = tool;
@@ -233,6 +236,7 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
     assertThat(version).hasToString("2025.02.001-beta-20250204.023111-1");
   }
 
+  /** Test of {@link MvnRepository#resolveSnapshotClassifier(Document, String, String, String)}. */
   @Test
   void testResolveSnapshotClassifierFallsBackFromWindowsArm64ToX64() {
 
@@ -245,12 +249,14 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
     String classifier = mvnRepository.resolveSnapshotClassifier(
         metadata,
         "windows-arm64",
-        "tar.gz");
+        "tar.gz",
+        "2025.02.001-beta-20250204.023111-1");
 
     // assert
     assertThat(classifier).isEqualTo("windows-x64");
   }
 
+  /** Test of {@link MvnRepository#resolveSnapshotClassifier(Document, String, String, String)}. */
   @Test
   void testResolveSnapshotClassifierKeepsWindowsArm64WhenAvailable() {
 
@@ -277,12 +283,14 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
     String classifier = mvnRepository.resolveSnapshotClassifier(
         metadata,
         "windows-arm64",
-        "tar.gz");
+        "tar.gz",
+        "2025.02.001-beta-20250204.023111-1");
 
     // assert
     assertThat(classifier).isEqualTo("windows-arm64");
   }
 
+  /** Test of {@link MvnRepository#resolveSnapshotClassifier(Document, String, String, String)}. */
   @Test
   void testResolveSnapshotClassifierDoesNotFallbackForLinuxArm64() {
 
@@ -295,7 +303,8 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
     String classifier = mvnRepository.resolveSnapshotClassifier(
         metadata,
         "linux-arm64",
-        "tar.gz");
+        "tar.gz",
+        "2025.02.001-beta-20250204.023111-1");
 
     // assert
     assertThat(classifier).isEqualTo("linux-arm64");
@@ -320,6 +329,56 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
         "2024.07.003-alpha", "2024.07.002-alpha", "2024.06.001-alpha", "2024.05.001-alpha", "2024.04.001-alpha", "2024.03.001-alpha");
   }
 
+  /**
+   * Tests that a Windows ARM64 snapshot falls back to x64 when no ARM64 snapshot artifact is published.
+   */
+  @Test
+  void testGetMetadataFallsBackToWindowsX64ForSnapshotOnWindowsArm64() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    context.setSystemInfo(SystemInfoMock.WINDOWS_ARM64);
+    MvnRepository repository = context.getMvnRepository();
+    VersionIdentifier version = VersionIdentifier.of("2025.02.001-beta-20250204.023111-1");
+
+    // act
+    UrlDownloadFileMetadata metadata = repository.getMetadata(
+        "ideasy",
+        "ideasy",
+        version,
+        null);
+
+    // assert
+    assertThat(metadata.getUrls())
+        .anyMatch(url -> url.endsWith("-windows-x64.tar.gz"));
+    assertThat(metadata.getArch()).isSameAs(SystemArchitecture.X64);
+  }
+
+  /**
+   * Tests that a Windows ARM64 release falls back directly to x64.
+   */
+  @Test
+  void testGetMetadataFallsBackToWindowsX64ForReleaseOnWindowsArm64() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    context.setSystemInfo(SystemInfoMock.WINDOWS_ARM64);
+    MvnRepository repository = context.getMvnRepository();
+    VersionIdentifier version = VersionIdentifier.of("2025.01.001-beta");
+
+    // act
+    UrlDownloadFileMetadata metadata = repository.getMetadata(
+        "ideasy",
+        "ideasy",
+        version,
+        null);
+
+    // assert
+    assertThat(metadata.getUrls())
+        .anyMatch(url -> url.endsWith("-windows-x64.tar.gz"));
+    assertThat(metadata.getArch()).isSameAs(SystemArchitecture.X64);
+  }
+
   private static Document parseXml(String xml) {
 
     InputStream inputStream = new ByteArrayInputStream(xml.getBytes());
@@ -328,26 +387,5 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
     } catch (Exception e) {
       throw new RuntimeException("Failed to parse XML!", e);
     }
-  }
-
-  @Test
-  void testGetSnapshotBaseVersion() {
-
-    // arrange
-    IdeTestContext context = new IdeTestContext();
-    MvnRepository mvnRepository = context.getMvnRepository();
-
-    // act/assert
-    assertThat(mvnRepository.getSnapshotBaseVersion(
-        "2026.05.001-20260527.032443-21"))
-        .isEqualTo("2026.05.001-SNAPSHOT");
-
-    assertThat(mvnRepository.getSnapshotBaseVersion(
-        "2025.02.001-beta-20250204.023111-1"))
-        .isEqualTo("2025.02.001-beta-SNAPSHOT");
-
-    assertThat(mvnRepository.getSnapshotBaseVersion(
-        "2026.05.001"))
-        .isNull();
   }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnRepositoryTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnRepositoryTest.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -193,7 +194,8 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
 
     // assert
     assertThat(metadata.getUrls()).containsExactly(
-        "https://central.sonatype.com/repository/maven-snapshots/com/devonfw/tools/IDEasy/ide-cli/2025.01.001-beta-SNAPSHOT/ide-cli-2025.01.001-beta-20250121.023134-9-"
+        "https://central.sonatype.com/repository/maven-snapshots/com/devonfw/tools/IDEasy/ide-cli/"
+            + "2025.01.001-beta-SNAPSHOT/ide-cli-2025.01.001-beta-20250121.023134-9-"
             + os + "-" + arch + ".tar.gz");
     assertThat(metadata.getTool()).isEqualTo(tool);
     assertThat(metadata.getEdition()).isEqualTo(edition);

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnRepositoryTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/mvn/MvnRepositoryTest.java
@@ -2,6 +2,8 @@ package com.devonfw.tools.ide.tool.mvn;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -292,7 +294,7 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
 
   /** Test of {@link MvnRepository#resolveSnapshotClassifier(Document, String, String, String)}. */
   @Test
-  void testResolveSnapshotClassifierDoesNotFallbackForLinuxArm64() {
+  void testResolveSnapshotClassifierFallsBackForLinuxArm64() {
 
     // arrange
     IdeTestContext context = new IdeTestContext();
@@ -307,7 +309,7 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
         "2025.02.001-beta-20250204.023111-1");
 
     // assert
-    assertThat(classifier).isEqualTo("linux-arm64");
+    assertThat(classifier).isEqualTo("linux-x64");
   }
 
   /** Test of {@link MvnRepository#fetchVersions(Document, String)}. */
@@ -330,35 +332,10 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
   }
 
   /**
-   * Tests that a Windows ARM64 snapshot falls back to x64 when no ARM64 snapshot artifact is published.
-   */
-  @Test
-  void testGetMetadataFallsBackToWindowsX64ForSnapshotOnWindowsArm64() {
-
-    // arrange
-    IdeTestContext context = newContext(PROJECT_BASIC);
-    context.setSystemInfo(SystemInfoMock.WINDOWS_ARM64);
-    MvnRepository repository = context.getMvnRepository();
-    VersionIdentifier version = VersionIdentifier.of("2025.02.001-beta-20250204.023111-1");
-
-    // act
-    UrlDownloadFileMetadata metadata = repository.getMetadata(
-        "ideasy",
-        "ideasy",
-        version,
-        null);
-
-    // assert
-    assertThat(metadata.getUrls())
-        .anyMatch(url -> url.endsWith("-windows-x64.tar.gz"));
-    assertThat(metadata.getArch()).isSameAs(SystemArchitecture.X64);
-  }
-
-  /**
    * Tests that a Windows ARM64 release falls back directly to x64.
    */
   @Test
-  void testGetMetadataFallsBackToWindowsX64ForReleaseOnWindowsArm64() {
+  void testGetMetadataKeepsWindowsArm64ForReleaseOnWindowsArm64() {
 
     // arrange
     IdeTestContext context = newContext(PROJECT_BASIC);
@@ -375,8 +352,102 @@ class MvnRepositoryTest extends AbstractIdeContextTest {
 
     // assert
     assertThat(metadata.getUrls())
-        .anyMatch(url -> url.endsWith("-windows-x64.tar.gz"));
-    assertThat(metadata.getArch()).isSameAs(SystemArchitecture.X64);
+        .anyMatch(url -> url.endsWith("-windows-arm64.tar.gz"));
+    assertThat(metadata.getArch()).isSameAs(SystemArchitecture.ARM64);
+  }
+
+  /**
+   * Tests that an unavailable ARM64 release artifact falls back to the corresponding x64 artifact.
+   */
+  @Test
+  void testDownloadFallsBackFromArm64ToX64OnNotFound() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    List<String> requestedUrls = new ArrayList<>();
+
+    MvnRepository repository = new MvnRepository(context) {
+
+      @Override
+      protected UrlChecksums getChecksums(MvnArtifact artifact) {
+        return null;
+      }
+
+      @Override
+      protected Path download(String url, Path target, Object resolvedVersion, UrlChecksums expectedChecksums) {
+
+        requestedUrls.add(url);
+
+        if (url.contains("windows-arm64")) {
+          throw new IllegalStateException("Download failed with status code 404");
+        }
+
+        return target;
+      }
+    };
+
+    MvnArtifact artifact = new MvnArtifact(
+        "com.devonfw.tools.IDEasy",
+        "ide-cli",
+        "2025.01.001-beta")
+        .withType("tar.gz")
+        .withClassifier("windows-arm64");
+
+    MvnArtifactMetadata metadata =
+        repository.getMetadata(artifact, "ideasy", "ideasy");
+
+    // act
+    Path result = repository.download(metadata);
+
+    // assert
+    assertThat(requestedUrls).hasSize(2);
+    assertThat(requestedUrls.get(0)).endsWith("-windows-arm64.tar.gz");
+    assertThat(requestedUrls.get(1)).endsWith("-windows-x64.tar.gz");
+    assertThat(result.getFileName().toString()).endsWith("-windows-x64.tar.gz");
+  }
+
+  /**
+   * Tests that an ARM64 release artifact does not fall back to x64 for a non-404 download error.
+   */
+  @Test
+  void testDownloadDoesNotFallbackFromArm64ToX64OnOtherError() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    List<String> requestedUrls = new ArrayList<>();
+
+    MvnRepository repository = new MvnRepository(context) {
+
+      @Override
+      protected UrlChecksums getChecksums(MvnArtifact artifact) {
+        return null;
+      }
+
+      @Override
+      protected Path download(String url, Path target, Object resolvedVersion, UrlChecksums expectedChecksums) {
+
+        requestedUrls.add(url);
+        throw new IllegalStateException("Network connection failed");
+      }
+    };
+
+    MvnArtifact artifact = new MvnArtifact(
+        "com.devonfw.tools.IDEasy",
+        "ide-cli",
+        "2025.01.001-beta")
+        .withType("tar.gz")
+        .withClassifier("windows-arm64");
+
+    MvnArtifactMetadata metadata =
+        repository.getMetadata(artifact, "ideasy", "ideasy");
+
+    // act + assert
+    assertThatThrownBy(() -> repository.download(metadata))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Network connection failed");
+
+    assertThat(requestedUrls).hasSize(1);
+    assertThat(requestedUrls.get(0)).endsWith("-windows-arm64.tar.gz");
   }
 
   private static Document parseXml(String xml) {


### PR DESCRIPTION
### This PR fixes #1981 

### Implemented changes:

- Added a fallback from windows-arm64 to windows-x64 when no native Windows ARM64 snapshot artifact is available.
- Added snapshot metadata inspection to verify which platform classifiers are actually published.
- Added short-term caching for Maven metadata to avoid downloading and parsing the same maven-metadata.xml multiple times.
- Kept the fallback limited to Windows ARM64 so that Linux and macOS artifact resolution remain unchanged.
- Added tests covering the ARM64 fallback, existing ARM64 artifacts, unsupported classifiers, and snapshot-version resolution.

### Testing instructions

1. Run the focused Maven repository tests:
`mvn -pl cli -Dtest=MvnRepositoryTest test`

2. Run the complete test suite:
`mvn clean test`

3. Build and install the modified IDEasy version locally:
`./build-local-dev.sh`

4. Open a new PowerShell session and simulate Windows ARM64:
`$env:IDE_OPTIONS = "-Dos.arch=arm64"`

5. Verify the simulated architecture:
`ide status`

6. Run the previously failing snapshot upgrade:
`ide upgrade --mode=snapshot`

7. Verify that IDEasy falls back to the windows-x64 artifact instead of failing with a 404 for windows-arm64.

8. Remove the architecture override after testing:
`Remove-Item Env:IDE_OPTIONS -ErrorAction SilentlyContinue`

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue

