### PR TITLE
#2279: allow launching the GUI without an IDEasy project

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/2224[#2224]: Brew upgrade ideasy not working
 * https://github.com/devonfw/IDEasy/issues/1784[#1784]: GUI now supports displaying progress bars
 * https://github.com/devonfw/IDEasy/issues/1917[#1917]: Allow the creation of a desktop shortcut for the GUI
+* https://github.com/devonfw/IDEasy/issues/2279[#2279]: Fix desktop shortcut for the GUI not launching outside an IDEasy project
 * https://github.com/devonfw/IDEasy/issues/2134[#2134]: Add auto-completion for icd command
 * https://github.com/devonfw/IDEasy/issues/1953[#1953]: Implement base functionality of cleanup commandlet
 * https://github.com/devonfw/IDEAsy/issues/2181[#2181]: Merged the VsCode and VsCodium plugin folder and added excluded-editions as an option for plugins

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/gui/Gui.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/gui/Gui.java
@@ -50,6 +50,25 @@ public class Gui extends Commandlet {
     return false;
   }
 
+  /**
+   * Registers the {@link ToolInstallation#binDir() bin directory} of the given Maven installation in the {@link IdeContext#getPath() SystemPath} so that the
+   * Maven binary can be resolved.
+   * <p>
+   * This only applies without {@link IdeContext#getIdeHome() IDE_HOME}, where there is no project software folder to resolve Maven from. Inside a project the
+   * tool map is already filled from that folder, and since this commandlet installs the latest Maven rather than the configured one, registering it would
+   * override the version configured for the project.
+   *
+   * @param mvn the {@link Mvn} commandlet providing the tool name to register.
+   * @param mvnInstallation the {@link ToolInstallation} of Maven.
+   */
+  void registerMvnBinDir(Mvn mvn, ToolInstallation mvnInstallation) {
+
+    // The null check mirrors LocalToolCommandlet, since a null bin directory would end up in the tool map and break the next binary lookup.
+    if ((this.context.getIdeHome() == null) && (mvnInstallation.binDir() != null)) {
+      this.context.getPath().setPath(mvn.getName(), mvnInstallation.binDir());
+    }
+  }
+
   @Override
   protected void doRun() {
 
@@ -70,12 +89,7 @@ public class Gui extends Commandlet {
     ToolInstallation mvnInstallation = mvn.installTool(mavenToolInstallRequest);
     ToolInstallation javaInstallation = java.installTool(javaToolInstallRequest);
 
-    // Without IDE_HOME there is no project software folder, so SystemPath cannot resolve the mvn binary on its own.
-    // Registering the bin directory of the installation makes it findable, analogous to what LocalToolCommandlet does after a fresh installation.
-    // The null check mirrors LocalToolCommandlet, since a null bin directory would end up in the tool map and break the next binary lookup.
-    if (mvnInstallation.binDir() != null) {
-      this.context.getPath().setPath(mvn.getName(), mvnInstallation.binDir());
-    }
+    registerMvnBinDir(mvn, mvnInstallation);
 
     LOG.debug("Starting GUI via commandlet");
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/gui/Gui.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/gui/Gui.java
@@ -72,7 +72,10 @@ public class Gui extends Commandlet {
 
     // Without IDE_HOME there is no project software folder, so SystemPath cannot resolve the mvn binary on its own.
     // Registering the bin directory of the installation makes it findable, analogous to what LocalToolCommandlet does after a fresh installation.
-    this.context.getPath().setPath(mvn.getName(), mvnInstallation.binDir());
+    // The null check mirrors LocalToolCommandlet, since a null bin directory would end up in the tool map and break the next binary lookup.
+    if (mvnInstallation.binDir() != null) {
+      this.context.getPath().setPath(mvn.getName(), mvnInstallation.binDir());
+    }
 
     LOG.debug("Starting GUI via commandlet");
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/gui/Gui.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/gui/Gui.java
@@ -43,6 +43,14 @@ public class Gui extends Commandlet {
   }
 
   @Override
+  public boolean isIdeHomeRequired() {
+
+    // The GUI is typically launched from a desktop shortcut and therefore starts outside of any IDEasy project.
+    // Selecting the project is done within the GUI itself, which reads the available projects from IDE_ROOT.
+    return false;
+  }
+
+  @Override
   protected void doRun() {
 
     ProcessContext processContext = new ProcessContextImpl(this.context);
@@ -59,8 +67,12 @@ public class Gui extends Commandlet {
         new ToolEditionAndVersion(VersionIdentifier.of("25.*"))
     );
 
-    mvn.installTool(mavenToolInstallRequest);
+    ToolInstallation mvnInstallation = mvn.installTool(mavenToolInstallRequest);
     ToolInstallation javaInstallation = java.installTool(javaToolInstallRequest);
+
+    // Without IDE_HOME there is no project software folder, so SystemPath cannot resolve the mvn binary on its own.
+    // Registering the bin directory of the installation makes it findable, analogous to what LocalToolCommandlet does after a fresh installation.
+    this.context.getPath().setPath(mvn.getName(), mvnInstallation.binDir());
 
     LOG.debug("Starting GUI via commandlet");
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/gui/GuiTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/gui/GuiTest.java
@@ -1,14 +1,24 @@
 package com.devonfw.tools.ide.tool.gui;
 
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
 import com.devonfw.tools.ide.context.IdeTestContext;
+import com.devonfw.tools.ide.tool.ToolInstallation;
+import com.devonfw.tools.ide.tool.mvn.Mvn;
+import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
  * Test of {@link Gui}.
  */
 class GuiTest extends AbstractIdeContextTest {
+
+  private static ToolInstallation newMvnInstallation(Path binDir) {
+
+    return new ToolInstallation(binDir, binDir, binDir, VersionIdentifier.of("3.9.16"), false);
+  }
 
   /**
    * Test that {@link Gui} does not require {@code IDE_HOME}. The GUI is launched from a desktop shortcut, which always starts outside of any IDEasy project.
@@ -36,5 +46,64 @@ class GuiTest extends AbstractIdeContextTest {
     Gui gui = new Gui(context);
     // act & assert
     assertThat(gui.isIdeRootRequired()).isTrue();
+  }
+
+  /**
+   * Test that {@link Gui#registerMvnBinDir(Mvn, ToolInstallation)} registers the bin directory without {@code IDE_HOME}. Without a project there is no software
+   * folder to resolve Maven from, so the binary would not be found at all.
+   */
+  @Test
+  void testThatMvnBinDirIsRegisteredWithoutIdeHome() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    context.setIdeHome(null);
+    Gui gui = new Gui(context);
+    Mvn mvn = context.getCommandletManager().getCommandlet(Mvn.class);
+    Path binDir = context.getIdeRoot().resolve("software/mvn/bin");
+    assertThat(context.getPath().getPath(mvn.getName())).as("Maven is unknown without IDE_HOME").isNull();
+    // act
+    gui.registerMvnBinDir(mvn, newMvnInstallation(binDir));
+    // assert
+    assertThat(context.getPath().getPath(mvn.getName())).isEqualTo(binDir);
+  }
+
+  /**
+   * Test that {@link Gui#registerMvnBinDir(Mvn, ToolInstallation)} leaves the tool map untouched inside a project. The GUI installs the latest Maven, so
+   * registering it would override the version configured for the project.
+   */
+  @Test
+  void testThatMvnBinDirIsNotRegisteredInsideProject() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    Gui gui = new Gui(context);
+    Mvn mvn = context.getCommandletManager().getCommandlet(Mvn.class);
+    Path configuredMvn = context.getPath().getPath(mvn.getName());
+    assertThat(configuredMvn).as("Maven of the project is known inside a project").isNotNull();
+    // act
+    gui.registerMvnBinDir(mvn, newMvnInstallation(context.getIdeRoot().resolve("latest-mvn/bin")));
+    // assert
+    assertThat(context.getPath().getPath(mvn.getName())).isEqualTo(configuredMvn);
+  }
+
+  /**
+   * Test that {@link Gui#registerMvnBinDir(Mvn, ToolInstallation)} ignores a {@code null} bin directory. A {@code null} value in the tool map would break the
+   * next binary lookup, since {@code SystemPath} resolves against the stored path without a null check.
+   */
+  @Test
+  void testThatNullBinDirIsNotRegistered() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    context.setIdeHome(null);
+    Gui gui = new Gui(context);
+    Mvn mvn = context.getCommandletManager().getCommandlet(Mvn.class);
+    // act
+    gui.registerMvnBinDir(mvn, newMvnInstallation(null));
+    // assert
+    // asserting on getPath alone would not distinguish "not registered" from "registered as null", and asserting on the resolved path would depend on the
+    // machine running the test, so we verify the actual failure mode: a null value in the tool map makes the next lookup fail
+    assertThatCode(() -> context.getPath().findBinary(Path.of(mvn.getName()))).doesNotThrowAnyException();
   }
 }

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/gui/GuiTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/gui/GuiTest.java
@@ -1,0 +1,40 @@
+package com.devonfw.tools.ide.tool.gui;
+
+import org.junit.jupiter.api.Test;
+
+import com.devonfw.tools.ide.context.AbstractIdeContextTest;
+import com.devonfw.tools.ide.context.IdeTestContext;
+
+/**
+ * Test of {@link Gui}.
+ */
+class GuiTest extends AbstractIdeContextTest {
+
+  /**
+   * Test that {@link Gui} does not require {@code IDE_HOME}. The GUI is launched from a desktop shortcut, which always starts outside of any IDEasy project.
+   * Project selection happens inside the GUI, which reads the available projects from {@code IDE_ROOT}. See
+   * <a href="https://github.com/devonfw/IDEasy/issues/2279">#2279</a> for reference.
+   */
+  @Test
+  void testThatIdeHomeIsNotRequired() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    Gui gui = new Gui(context);
+    // act & assert
+    assertThat(gui.isIdeHomeRequired()).isFalse();
+  }
+
+  /**
+   * Test that {@link Gui} still requires {@code IDE_ROOT}, since the GUI resolves both the launcher {@code pom.xml} and the list of projects relative to it.
+   */
+  @Test
+  void testThatIdeRootIsRequired() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    Gui gui = new Gui(context);
+    // act & assert
+    assertThat(gui.isIdeRootRequired()).isTrue();
+  }
+}


### PR DESCRIPTION
### This PR fixes #2279

The desktop shortcut added by #1917 is created correctly but never starts the GUI, because it launches `ideasy gui` from outside any IDEasy project.

### Implemented changes:

* `Gui` no longer requires `IDE_HOME`. `IDE_ROOT` is still required, since the launcher pom and the project list resolve relative to it. Project selection happens inside the GUI, which reads the projects from `IDE_ROOT` via `ProjectManager`.
* The bin directory of the resolved Maven installation is registered in the `SystemPath`. Without `IDE_HOME` there is no project software folder, so `mvn` was not resolvable and the launch failed with `CreateProcess error=2`.
* New `GuiTest` covering both the relaxed `IDE_HOME` requirement and that `IDE_ROOT` stays required.

---

### Testing instructions

1. Build the branch: `mvn -o package -DskipTests` in `cli`.
2. Open a shell that has no `IDE_HOME` set and change into a directory outside any IDEasy project, for example your home directory.
3. Run the `gui` commandlet from that directory.
4. Expected: the GUI window opens. Before this change the run aborted with `The gui commandlet requires an IDEasy project to work`.

Note that `ide-gui` must be resolvable from `USER_HOME/.m2` or a remote repository, since without `IDE_HOME` the Maven configuration folder falls back to `USER_HOME/.m2` (`Mvn.java:282-283`). On a SNAPSHOT developer installation you may need to run `mvn -pl gui -am install` first.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labeled
  with `internal`
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"
