### PR TITLE
#2305: hotfix nightly build broken

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -159,4 +159,4 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           RELEASE_VERSION: ${{ needs.resolve-version.outputs.snapshot_version }}
-        run: mvn --settings .mvn/settings.xml -DskipTests=true -Darchetype.test.skip=true -Dgpg.skip=true -Dstyle.color=always -B -ntp -Passembly,msi,pkg,deploy deploy
+        run: mvn --settings .mvn/settings.xml -DskipTests=true -Darchetype.test.skip=true -Dgpg.skip=true -Dstyle.color=always -B -ntp -pl -:ide-macos-installer -Passembly,msi,pkg,deploy deploy

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -159,5 +159,4 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           RELEASE_VERSION: ${{ needs.resolve-version.outputs.snapshot_version }}
-        # -Drevision pins the deploy to the version resolved at the start of the workflow
-        run: mvn --settings .mvn/settings.xml -DskipTests=true -Darchetype.test.skip=true -Dgpg.skip=true -Dstyle.color=always -B -ntp -Passembly,msi,pkg,deploy -Drevision=${RELEASE_VERSION} deploy
+        run: mvn --settings .mvn/settings.xml -DskipTests=true -Darchetype.test.skip=true -Dgpg.skip=true -Dstyle.color=always -B -ntp -Passembly,msi,pkg,deploy deploy

--- a/macos-installer/pom.xml
+++ b/macos-installer/pom.xml
@@ -17,16 +17,6 @@
   </parent>
   <groupId>com.devonfw.tools.IDEasy</groupId>
 
-  <!-- This module only prepares the PKG installer build (filtered Distribution.xml). The PKG
-       artifacts themselves are attached to ide-cli via the pkg profile in cli/pom.xml, so this
-       module must never be published itself. skipPublishing covers the central-publishing-maven-plugin
-       (extension mode, inherited from the deploy profile of com.devonfw:maven-parent),
-       maven.deploy.skip covers a plain maven-deploy-plugin deploy. -->
-  <properties>
-    <skipPublishing>true</skipPublishing>
-    <maven.deploy.skip>true</maven.deploy.skip>
-  </properties>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
### This PR fixes #2305 

### Implemented changes:

* Removed skipDeploy flag from macos-installer/pom.xml
* Removed revision flag from deploy step in nightly_build (introduced by #2098 )

---

### Testing instructions

Please add conscise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. No message "Skipping Central SNAPSHOT Publishing at user's request." should be shown in Build and Deploy step in the nightly build
2. Revision variable should not be present any more during deploy

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

