### PR TITLE
#1938: fixed GUI to allow usage outside of project

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -36,6 +36,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/2136[#2136]: Add Support for Ruby URL Updater for Linux and macOS
 * https://github.com/devonfw/IDEasy/issues/2292[#2292]: Questions appear twice
 * https://github.com/devonfw/IDEasy/issues/825[#825]: Add commandlet for GC Log Analyzer
+* https://github.com/devonfw/IDEasy/issues/1938[#1938]: GUI not launchable outside of project context
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/48?closed=1[milestone 2026.08.001].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/gui/Gui.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/gui/Gui.java
@@ -45,6 +45,12 @@ public class Gui extends Commandlet {
   }
 
   @Override
+  public boolean isIdeHomeRequired() {
+
+    return false;
+  }
+
+  @Override
   protected void doRun() {
 
     ProcessContext processContext = context.newProcess();


### PR DESCRIPTION
### This PR fixes #1938

### Implemented changes:

* override Gui.isIdeHomeRequired() to return false
* actual fix was already done by PR #2144

---

### Testing instructions

Please add conscise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. cd $IDE_ROOT
2. ide gui

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"
