### PR TITLE
#2286: Fix SystemPath.findBinary to search extraPathEntries

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,8 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/2286[#2286]: Fix SystemPath.findBinary to search extraPathEntries
+
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/49?closed=1[milestone 2026.08.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/common/SystemPath.java
@@ -284,6 +284,12 @@ public class SystemPath {
     String fileName = toolPath.getFileName().toString();
 
     if (parent == null) {
+      for (Path path : this.extraPathEntries) {
+        Path binaryPath = findBinaryInOrder(path, fileName);
+        if (binaryPath != null && filter.test(binaryPath)) {
+          return binaryPath;
+        }
+      }
       for (Path path : this.tool2pathMap.values()) {
         Path binaryPath = findBinaryInOrder(path, fileName);
         if (binaryPath != null && filter.test(binaryPath)) {

--- a/cli/src/test/java/com/devonfw/tools/ide/common/SystemPathTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/common/SystemPathTest.java
@@ -1,5 +1,7 @@
 package com.devonfw.tools.ide.common;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -144,14 +146,14 @@ class SystemPathTest extends AbstractIdeContextTest {
   }
 
   @Test
-  void testFindBinaryFindsBinaryInExtraPathEntries() throws java.io.IOException {
+  void testFindBinaryFindsBinaryInExtraPathEntries() throws IOException {
     // arrange
     IdeTestContext context = newContext(PROJECT_BASIC);
     Path binDir = context.getIdeHome().resolve("scratch-bin");
-    java.nio.file.Files.createDirectories(binDir);
+    Files.createDirectories(binDir);
     // create a plain binary name (no extension) so it works on both Linux and Windows
     Path fakeToolFile = binDir.resolve("faketool");
-    java.nio.file.Files.writeString(fakeToolFile, "@echo hi");
+    Files.writeString(fakeToolFile, "@echo hi");
 
     // empty PATH and no software folder, so tool2pathMap and paths stay empty
     SystemPath base = new SystemPath(context, "", null, null, ';', List.of());
@@ -162,6 +164,28 @@ class SystemPathTest extends AbstractIdeContextTest {
     Path resolved = merged.findBinary(Path.of("faketool"));
     assertThat(resolved).isNotEqualTo(Path.of("faketool"));
     assertThat(resolved).isEqualTo(fakeToolFile);
+  }
+
+  @Test
+  void testFindBinaryExtraPathEntriesWinsOverTool2pathMap() throws IOException {
+    // arrange - create two directories, both with a binary named "mytool"
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    Path toolDir = context.getIdeHome().resolve("software-tool");
+    Files.createDirectories(toolDir);
+    Files.writeString(toolDir.resolve("mytool"), "tool-version");
+
+    Path extraDir = context.getIdeHome().resolve("extra-path");
+    Files.createDirectories(extraDir);
+    Files.writeString(extraDir.resolve("mytool"), "extra-version");
+
+    // tool2pathMap has "toolDir", extraPathEntries has "extraDir"
+    SystemPath base = new SystemPath(context, "", null, toolDir, ';', List.of());
+    SystemPath merged = base.withPath(null, List.of(extraDir));
+
+    // assert - findBinary should return the one from extraPathEntries, NOT from tool2pathMap
+    Path resolved = merged.findBinary(Path.of("mytool"));
+    assertThat(resolved).isEqualTo(extraDir.resolve("mytool"));
+    assertThat(resolved).isNotEqualTo(toolDir.resolve("mytool"));
   }
 
   @Test

--- a/cli/src/test/java/com/devonfw/tools/ide/common/SystemPathTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/common/SystemPathTest.java
@@ -169,23 +169,26 @@ class SystemPathTest extends AbstractIdeContextTest {
   @Test
   void testFindBinaryExtraPathEntriesWinsOverTool2pathMap() throws IOException {
     // arrange - create two directories, both with a binary named "mytool"
+    // tool2pathMap collects subdirectories of softwarePath, so mytool must be a subdirectory
     IdeTestContext context = newContext(PROJECT_BASIC);
     Path toolDir = context.getIdeHome().resolve("software-tool");
     Files.createDirectories(toolDir);
-    Files.writeString(toolDir.resolve("mytool"), "tool-version");
+    Path mytoolInToolDir = toolDir.resolve("mytool");
+    Files.createDirectories(mytoolInToolDir);
+    Files.writeString(mytoolInToolDir.resolve("mytool"), "tool-version");
 
     Path extraDir = context.getIdeHome().resolve("extra-path");
     Files.createDirectories(extraDir);
     Files.writeString(extraDir.resolve("mytool"), "extra-version");
 
-    // tool2pathMap has "toolDir", extraPathEntries has "extraDir"
+    // tool2pathMap has "software-tool" (mytool is a subdirectory → registered), extraPathEntries has "extraDir"
     SystemPath base = new SystemPath(context, "", null, toolDir, ';', List.of());
     SystemPath merged = base.withPath(null, List.of(extraDir));
 
     // assert - findBinary should return the one from extraPathEntries, NOT from tool2pathMap
     Path resolved = merged.findBinary(Path.of("mytool"));
     assertThat(resolved).isEqualTo(extraDir.resolve("mytool"));
-    assertThat(resolved).isNotEqualTo(toolDir.resolve("mytool"));
+    assertThat(resolved).isNotEqualTo(mytoolInToolDir.resolve("mytool"));
   }
 
   @Test

--- a/cli/src/test/java/com/devonfw/tools/ide/common/SystemPathTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/common/SystemPathTest.java
@@ -144,6 +144,25 @@ class SystemPathTest extends AbstractIdeContextTest {
   }
 
   @Test
+  void testFindBinaryFindsBinaryInExtraPathEntries() throws java.io.IOException {
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    Path binDir = context.getIdeHome().resolve("scratch-bin");
+    java.nio.file.Files.createDirectories(binDir);
+    java.nio.file.Files.writeString(binDir.resolve("faketool.cmd"), "@echo hi");
+
+    // empty PATH and no software folder, so tool2pathMap and paths stay empty
+    SystemPath base = new SystemPath(context, "", null, null, ';', List.of());
+    SystemPath merged = base.withPath(null, List.of(binDir));
+
+    // assert
+    assertThat(merged.toString()).contains(binDir.toString());
+    Path resolved = merged.findBinary(Path.of("faketool"));
+    assertThat(resolved).isNotEqualTo(Path.of("faketool"));
+    assertThat(resolved).isEqualTo(binDir.resolve("faketool.cmd"));
+  }
+
+  @Test
   void testConstructorNormalizesPathEntryWithControlCharactersAndKeepsIt() {
     // arrange
     IdeTestContext context = newContext("find-binary", "project/workspaces", false);

--- a/cli/src/test/java/com/devonfw/tools/ide/common/SystemPathTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/common/SystemPathTest.java
@@ -149,7 +149,9 @@ class SystemPathTest extends AbstractIdeContextTest {
     IdeTestContext context = newContext(PROJECT_BASIC);
     Path binDir = context.getIdeHome().resolve("scratch-bin");
     java.nio.file.Files.createDirectories(binDir);
-    java.nio.file.Files.writeString(binDir.resolve("faketool.cmd"), "@echo hi");
+    // create a plain binary name (no extension) so it works on both Linux and Windows
+    Path fakeToolFile = binDir.resolve("faketool");
+    java.nio.file.Files.writeString(fakeToolFile, "@echo hi");
 
     // empty PATH and no software folder, so tool2pathMap and paths stay empty
     SystemPath base = new SystemPath(context, "", null, null, ';', List.of());
@@ -159,7 +161,7 @@ class SystemPathTest extends AbstractIdeContextTest {
     assertThat(merged.toString()).contains(binDir.toString());
     Path resolved = merged.findBinary(Path.of("faketool"));
     assertThat(resolved).isNotEqualTo(Path.of("faketool"));
-    assertThat(resolved).isEqualTo(binDir.resolve("faketool.cmd"));
+    assertThat(resolved).isEqualTo(fakeToolFile);
   }
 
   @Test


### PR DESCRIPTION
### This PR fixes https://github.com/devonfw/IDEasy/issues/2286

  ### Implemented changes:

  `withPathEntry()` adds directories to the PATH exported to child processes, but `SystemPath.findBinary()` never searched `extraPathEntries`. This caused binaries added this way to
  fail with `CreateProcess error=2`.

  - Added `extraPathEntries` as the first search location in `findBinary()` — matching the PATH precedence order used by `toString()` (`extraPathEntries` → `tool2pathMap` → `paths`)
  - Added `testFindBinaryFindsBinaryInExtraPathEntries()` to verify the fix

  ---

  ### Testing instructions

  1. Run `mvn clean test` — all tests (CLI: 848, GUI: 56, URL-Updater: 72) pass with BUILD SUCCESS
  2. The new test creates a directory with a fake binary, adds it via `withPath()`, and verifies `findBinary()` resolves it correctly

  ---

  ### Checklist for this PR

  - [x] When running `mvn clean test` locally all tests pass and build is successful
  - [x] PR title is of the form `#«issue-id»: «brief summary»`
  - [x] PR top-level comment summarizes what has been done and contains link to addressed issue(s)
  - [x] PR and issue(s) have suitable labels
  - [x] Issue is set to `In Progress` and assigned to you
  - [x] You followed all coding conventions
  - [x] You have not changed any dependency in `pom.xml` files
  - [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"
