### PR TITLE
#1165: fix eclipse automatic project import

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,10 @@
 
 This file documents all notable changes to https://github.com/devonfw/IDEasy[IDEasy].
 
+== 2026.08.002
+
+* https://github.com/devonfw/IDEasy/issues/1165[#1165]: Fix automatic project import for Eclipse
+
 == 2026.08.001
 
 Release with new features and bugfixes:

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/eclipse/Eclipse.java
@@ -145,9 +145,11 @@ public class Eclipse extends IdeToolCommandlet {
       maven.getOrDownloadArtifact(groovyAnt);
       this.groovyInstalled = true;
     }
-    // -DdevonImportPath=\"${import_path}\" -DdevonImportWorkingSet=\"${importWorkingSets}\""
-    runTool(ProcessMode.DEFAULT, null, ProcessErrorHandling.THROW_CLI, List.of(VMARGS,
-        "-DrepositoryImportPath=\"" + repositoryPath + "\" -DrepositoryImportWorkingSet=\"" + "" + "\"", "-application", "org.eclipse.ant.core.antRunner",
-        "-buildfile", this.context.getIdeInstallationPath().resolve(IdeContext.FOLDER_INTERNAL).resolve("eclipse-import.xml").toString()));
+    Path buildFile = this.context.getIdeInstallationPath().resolve(IdeContext.FOLDER_INTERNAL).resolve("eclipse-import.xml");
+    // "-application" and "-buildfile" must come before "-vmargs" (added by super.configureToolArgs if ECLIPSE_VMARGS is set),
+    // as "-vmargs" and everything after it is passed to the JVM instead of being processed by eclipse itself.
+    runTool(ProcessMode.DEFAULT, null, ProcessErrorHandling.THROW_CLI,
+        List.of("-application", "org.eclipse.ant.core.antRunner", "-buildfile", buildFile.toString(), "-DrepositoryImportPath=" + repositoryPath,
+            "-DrepositoryImportWorkingSet="));
   }
 }

--- a/cli/src/main/package/internal/eclipse-import.groovy
+++ b/cli/src/main/package/internal/eclipse-import.groovy
@@ -105,7 +105,7 @@ class MyWorkbenchAdvisor extends org.eclipse.ui.application.WorkbenchAdvisor {
   public void preStartup() {
     try {
       // Get path from ant properties
-      String path = antProperties.get("devonImportPath");
+      String path = antProperties.get("repositoryImportPath");
       if (path == null || path.equals("")) {
         throw new IllegalStateException("Parameter repositoryImportPath must be set.");
       }

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/eclipse/EclipseTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/eclipse/EclipseTest.java
@@ -1,11 +1,15 @@
 package com.devonfw.tools.ide.tool.eclipse;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
+import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.context.IdeTestContext;
 import com.devonfw.tools.ide.log.IdeLogEntry;
 import com.devonfw.tools.ide.log.IdeLogLevel;
@@ -54,6 +58,37 @@ public class EclipseTest extends AbstractIdeContextTest {
     //if tool already installed
     eclipse.install();
     assertThat(context).logAtDebug().hasMessageContaining("Version 2024-09 of tool eclipse is already installed");
+  }
+
+  /**
+   * Tests that {@link Eclipse#importRepository(Path)} invokes eclipse headlessly with the ant runner application and does not misplace "-application" behind
+   * "-vmargs" (see https://github.com/devonfw/IDEasy/issues/1165).
+   */
+  @Test
+  void testImportRepository() throws Exception {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_ECLIPSE, "eclipseproject");
+    context.setSystemInfo(SystemInfoMock.of("linux"));
+    context.getStartContext().setForceMode(true); // #663
+    Eclipse eclipse = context.getCommandletManager().getCommandlet(Eclipse.class);
+    eclipse.install();
+    // avoid downloading groovy-ant via maven in this test as it is not the concern of this test
+    Field groovyInstalledField = Eclipse.class.getDeclaredField("groovyInstalled");
+    groovyInstalledField.setAccessible(true);
+    groovyInstalledField.set(eclipse, true);
+    Path repositoryPath = context.getWorkspacePath().resolve("my-repo");
+
+    // act
+    eclipse.importRepository(repositoryPath);
+
+    // assert
+    Path buildFile = context.getIdeInstallationPath().resolve(IdeContext.FOLDER_INTERNAL).resolve("eclipse-import.xml");
+    assertThat(eclipse.getToolBinPath().resolve("eclipsetest")).hasContent(
+        "eclipse linux -data " + context.getWorkspacePath() + " -keyring " + context.getUserHome().resolve(".eclipse").resolve(".keyring")
+            + " -configuration " + context.getPluginsPath().resolve("eclipse").resolve("configuration")
+            + " -consoleLog -nosplash -application org.eclipse.ant.core.antRunner -buildfile " + buildFile + " -DrepositoryImportPath=" + repositoryPath
+            + " -DrepositoryImportWorkingSet=");
   }
 
 }


### PR DESCRIPTION
### This PR fixes #1165

### Implemented changes:

* Reordered the arguments passed to eclipse for `importRepository` so `-application`/`-buildfile` come before `-vmargs`. Everything after `-vmargs` is forwarded to the JVM instead of being parsed by eclipse itself, so `-application org.eclipse.ant.core.antRunner` was never seen by eclipse and it silently fell back to launching the normal GUI instead of running the headless ant import.
* Fixed a property key mismatch: the Java side passed `-DrepositoryImportPath=...` but `eclipse-import.groovy` read it back via `antProperties.get("devonImportPath")` (leftover from an incomplete rename), so the import path was never picked up.

---

### Testing instructions

1. Configure a repository with `import=eclipse` in your settings repository (see [repository.adoc](https://github.com/devonfw/IDEasy/blob/main/documentation/repository.adoc)).
2. Run `ide create <project> <settings-git-url>` (or `ide repository` on an existing project).
3. Verify the project import into eclipse runs headlessly in the background without popping up the eclipse GUI and without requiring you to close anything manually.
4. Alternatively run `mvn -Dtest=EclipseTest test` in the `cli` module, which covers the fix with `EclipseTest#testImportRepository`.

---

### Checklist for this PR

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"
