### PR TITLE
#2329: workspace main should be auto selected when selecting a project in the gui

### DIFF
--- a/gui/src/main/java/com/devonfw/ide/gui/MainController.java
+++ b/gui/src/main/java/com/devonfw/ide/gui/MainController.java
@@ -235,6 +235,15 @@ public class MainController {
     selectedWorkspace.getItems().clear();
     selectedWorkspace.getItems().addAll(workspaces);
 
+    if (workspaces.contains("main")) {
+      selectedWorkspace.setValue("main");
+      updateContext(selectedProject.getValue(), selectedWorkspace.getValue());
+      androidStudioOpen.setDisable(false);
+      eclipseOpen.setDisable(false);
+      intellijOpen.setDisable(false);
+      vsCodeOpen.setDisable(false);
+    }
+
     selectedWorkspace.setOnAction(actionEvent -> {
       updateContext(selectedProject.getValue(), selectedWorkspace.getValue());
 


### PR DESCRIPTION
### This PR fixes #2329

### Implemented changes:

* Added auto-selection logic of the workspace "main" to `setWorkspaceComboBox` in `MainController.java`
* Changed tests to fit the auto-selection logic

---

### Testing instructions

Please add conscise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. Run `./build-local-dev.sh` (when #2352 is merged)
2. Open a shell and run `ide gui`
3. Select a project in the gui and observe the workspace combobox, it should contain "main" and the IDE-buttons should be clickable.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [ ] When running `mvn clean test` locally all tests pass and build is successful
- [ ] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [ ] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [ ] PR and issue(s) have suitable labels
- [ ] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [ ] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [ ] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [ ] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] You have formulated clear instructions on how to test your contribution under "Testing instructions"
