### PR TITLE
#1548: avoid Windows plugin locks during IDE updates

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1135[#1135]: Fix PowerShell env variable initialization on Windows by sourcing functions from the PowerShell profile
 * https://github.com/devonfw/IDEasy/issues/741[#741]: Add a warning message for legacy devonfw-ide settings users
 * https://github.com/devonfw/IDEasy/issues/1933[#1933]: Added a console panel to the GUI
+* https://github.com/devonfw/IDEasy/issues/1548[#1548]: Use version-specific plugin directories to avoid Windows file-lock failures during IDE updates
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/49?closed=1[milestone 2026.09.001].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaBasedIdeToolCommandlet.java
@@ -47,15 +47,18 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
   @Override
   public boolean installPlugin(ToolPluginDescriptor plugin, final Step step, ProcessContext pc) {
 
-    // In case of plugins with a custom repo url
     boolean customRepo = plugin.url() != null;
+
     List<String> args = new ArrayList<>();
     args.add("installPlugins");
     args.add(plugin.id().replace("+", " "));
+
     if (customRepo) {
       args.add(plugin.url());
     }
+
     ProcessResult result = runTool(pc, ProcessMode.DEFAULT, args);
+
     if (result.isSuccessful()) {
       IdeLogLevel.SUCCESS.log(LOG, "Successfully installed plugin: {}", plugin.name());
       step.success();
@@ -88,23 +91,35 @@ public class IdeaBasedIdeToolCommandlet extends IdeToolCommandlet {
 
     String variableName = getName().toUpperCase(Locale.ROOT).replace("-", "_") + VM_ARGS_ENV_SUFFIX;
     String userVmArgsContent = this.context.getVariables().get(variableName);
-    if (userVmArgsContent == null || userVmArgsContent.isEmpty()) {
-      return super.runTool(pc, processMode, args);
+
+    String[] userVmArgs = new String[0];
+    if ((userVmArgsContent != null) && !userVmArgsContent.isEmpty()) {
+      userVmArgs = userVmArgsContent.trim().split("\\s+");
     }
-    String[] userVmArgs = userVmArgsContent.trim().split("\\s+");
 
     String prefix = getIdeProductPrefix();
     Path defaultVmOptionsPath = resolveDefaultVmOptionsPath(this.getToolPath(), prefix);
+    if ((prefix == null) || (defaultVmOptionsPath == null)) {
+      return super.runTool(pc, processMode, args);
+    }
+
     String defaultVmArgsContent = this.context.getFileAccess().readFileContent(defaultVmOptionsPath);
     if (defaultVmArgsContent == null || defaultVmArgsContent.isEmpty()) {
       LOG.debug("Default {} jvm options not found at: {}", getName(), defaultVmOptionsPath);
       return super.runTool(pc, processMode, args);
     }
+
     String[] defaultVmArgs = defaultVmArgsContent.trim().split("\\s+");
+    String pluginsPathArg = "-Didea.plugins.path="
+        + getPluginsInstallationPath().toAbsolutePath();
+    String[] additionalVmArgs = new String[userVmArgs.length + 1];
+    System.arraycopy(userVmArgs, 0, additionalVmArgs, 0, userVmArgs.length);
+    additionalVmArgs[userVmArgs.length] = pluginsPathArg;
 
     String userOptionsFileName = "." + prefix + VM_OPTIONS_FILE_EXTENSION;
     Path confPath = this.context.getWorkspacePath().resolve(userOptionsFileName);
-    this.context.getFileAccess().writeFileContent(mergeVmArgs(defaultVmArgs, userVmArgs), confPath, true);
+
+    this.context.getFileAccess().writeFileContent(mergeVmArgs(defaultVmArgs, additionalVmArgs), confPath, true);
 
     pc.withEnvVar(prefix.toUpperCase() + VM_OPTIONS_ENV_SUFFIX, confPath.toAbsolutePath().toString());
     return super.runTool(pc, processMode, args);

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaPluginDownloader.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ide/IdeaPluginDownloader.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -25,18 +26,20 @@ import com.devonfw.tools.ide.step.Step;
 import com.devonfw.tools.ide.tool.plugin.ToolPluginDescriptor;
 
 /**
- * Used for a direct download and installation of idea plugins
+ * Used for a direct download and installation of idea plugins.
  */
 public class IdeaPluginDownloader {
 
   private static final Logger LOG = LoggerFactory.getLogger(IdeaPluginDownloader.class);
 
   private static final String BUILD_FILE = "build.txt";
+
   private final IdeContext context;
+
   private final IdeaBasedIdeToolCommandlet commandlet;
 
   /**
-   * the constructor
+   * The constructor.
    *
    * @param context the {@link IdeContext}.
    * @param commandlet the {@link IdeaBasedIdeToolCommandlet} to use.
@@ -50,11 +53,11 @@ public class IdeaPluginDownloader {
    * @param plugin the {@link ToolPluginDescriptor} to install.
    * @param step the {@link Step} for the plugin installation.
    * @param pc the {@link ProcessContext} to use.
-   * @return boolean {@code true} if successful installed, {@code false} if not.
+   * @return boolean {@code true} if successfully installed, {@code false} otherwise.
    */
   public boolean installPlugin(ToolPluginDescriptor plugin, Step step, ProcessContext pc) {
-    String downloadUrl = getDownloadUrl(plugin);
 
+    String downloadUrl = getDownloadUrl(plugin);
     String pluginId = plugin.id();
 
     Path tmpDir = null;
@@ -63,111 +66,219 @@ public class IdeaPluginDownloader {
       Path installationPath = this.commandlet.getPluginsInstallationPath();
       ensureInstallationPathExists(installationPath);
 
-      FileAccess fileAccess = context.getFileAccess();
+      FileAccess fileAccess = this.context.getFileAccess();
       tmpDir = fileAccess.createTempDir(pluginId);
 
       Path downloadedFile = downloadPlugin(fileAccess, downloadUrl, tmpDir, pluginId);
-      extractDownloadedPlugin(fileAccess, downloadedFile, pluginId);
+      extractDownloadedPlugin(fileAccess, downloadedFile, pluginId, installationPath);
 
       step.success();
       return true;
+
     } catch (IOException e) {
+
       step.error(e);
       throw new IllegalStateException("Failed to process installation of plugin: " + pluginId, e);
+
     } finally {
+
       if (tmpDir != null) {
-        context.getFileAccess().delete(tmpDir);
+        this.context.getFileAccess().delete(tmpDir);
       }
     }
   }
 
   /**
-   * @param plugin the {@link ToolPluginDescriptor} to be installer
+   * @param plugin the {@link ToolPluginDescriptor} to be installed.
    * @return a {@link String} representing the download URL.
    */
   private String getDownloadUrl(ToolPluginDescriptor plugin) {
+
     String downloadUrl = plugin.url();
-    String pluginId = URLEncoder.encode(plugin.id(), StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+
+    String pluginId = URLEncoder.encode(plugin.id(), StandardCharsets.UTF_8)
+        .replaceAll("\\+", "%20");
 
     String buildVersion = readBuildVersion();
 
-    if (downloadUrl == null || downloadUrl.isEmpty()) {
-      downloadUrl = String.format("https://plugins.jetbrains.com/pluginManager?action=download&id=%s&build=%s", pluginId, buildVersion);
+    if ((downloadUrl == null) || downloadUrl.isEmpty()) {
+      downloadUrl = String.format(
+          "https://plugins.jetbrains.com/pluginManager?action=download&id=%s&build=%s",
+          pluginId,
+          buildVersion);
     }
+
     return downloadUrl;
   }
 
   private String readBuildVersion() {
+
     Path buildFile = this.commandlet.getToolPath().resolve(BUILD_FILE);
-    if (context.getSystemInfo().isMac()) {
-      MacOsHelper macOsHelper = new MacOsHelper(context);
-      Path appPath = macOsHelper.findAppDir(macOsHelper.findRootToolPath(this.commandlet, context));
+
+    if (this.context.getSystemInfo().isMac()) {
+      MacOsHelper macOsHelper = new MacOsHelper(this.context);
+      Path appPath = macOsHelper.findAppDir(
+          macOsHelper.findRootToolPath(this.commandlet, this.context));
+
       buildFile = appPath.resolve("Contents/Resources").resolve(BUILD_FILE);
     }
+
     try {
       return Files.readString(buildFile);
     } catch (IOException e) {
-      throw new IllegalStateException("Failed to read " + this.commandlet.getName() + " build version: " + buildFile, e);
+      throw new IllegalStateException(
+          "Failed to read " + this.commandlet.getName() + " build version: " + buildFile,
+          e);
     }
   }
 
   private void ensureInstallationPathExists(Path installationPath) throws IOException {
+
     if (!Files.exists(installationPath)) {
       try {
         Files.createDirectories(installationPath);
       } catch (IOException e) {
-        throw new IllegalStateException("Failed to create directory " + installationPath, e);
+        throw new IllegalStateException(
+            "Failed to create directory " + installationPath,
+            e);
       }
     }
   }
 
-  private Path downloadPlugin(FileAccess fileAccess, String downloadUrl, Path tmpDir, String pluginId) throws IOException {
+  private Path downloadPlugin(FileAccess fileAccess, String downloadUrl, Path tmpDir,
+      String pluginId) throws IOException {
+
     String extension = getFileExtensionFromUrl(downloadUrl);
+
     if (extension.isEmpty()) {
       throw new IllegalStateException("Unknown file type for URL: " + downloadUrl);
     }
-    String fileName = String.format("%s-plugin-%s%s", this.commandlet.getName(), pluginId, extension);
+
+    String fileName = String.format(
+        "%s-plugin-%s%s",
+        this.commandlet.getName(),
+        pluginId,
+        extension);
+
     Path downloadedFile = tmpDir.resolve(fileName);
+
     fileAccess.download(downloadUrl, downloadedFile);
+
     return downloadedFile;
   }
 
-  private void extractDownloadedPlugin(FileAccess fileAccess, Path downloadedFile, String pluginId) throws IOException {
-    Path targetDir = this.commandlet.getPluginsInstallationPath().resolve(pluginId);
+  public void extractDownloadedPlugin(FileAccess fileAccess, Path downloadedFile,
+      String pluginId, Path installationPath) throws IOException {
+
+    String fileName = downloadedFile.getFileName().toString();
+    Path targetDir = installationPath.resolve(pluginId);
+
     if (Files.exists(targetDir)) {
       LOG.info("Plugin already installed, target directory already existing: {}", targetDir);
+      return;
+    }
+
+    if (fileName.endsWith(".zip")) {
+
+      Path extractionDir = downloadedFile.getParent().resolve(pluginId + "-extracted");
+      fileAccess.mkdirs(extractionDir);
+
+      try {
+        fileAccess.extractZip(downloadedFile, extractionDir);
+
+        List<Path> extractedDirectories = fileAccess.listChildren(extractionDir, Files::isDirectory);
+
+        if (extractedDirectories.size() != 1) {
+          throw new IllegalStateException(
+              "Expected exactly one plugin root directory in archive " + downloadedFile);
+        }
+
+        Path pluginRoot = extractedDirectories.getFirst();
+        Files.move(pluginRoot, targetDir);
+
+      } finally {
+        fileAccess.delete(extractionDir);
+      }
+
+    } else if (fileName.endsWith(".jar")) {
+
+      fileAccess.extractJar(downloadedFile, targetDir);
+
     } else {
-      fileAccess.extract(downloadedFile, targetDir);
+      throw new IllegalStateException(
+          "Unsupported plugin archive: " + downloadedFile);
     }
   }
 
   private String getFileExtensionFromUrl(String urlString) throws RuntimeException {
 
     URI uri = null;
-    HttpRequest request;
+
     try (HttpClient client = HttpClientFactory.create()) {
+
       uri = URI.create(urlString);
-      request = HttpRequest.newBuilder().uri(uri)
-          .method("HEAD", HttpRequest.BodyPublishers.noBody()).timeout(Duration.ofSeconds(5)).build();
 
-      HttpResponse<?> res = client.send(request, HttpResponse.BodyHandlers.ofString());
+      HttpRequest request = HttpRequest.newBuilder()
+          .uri(uri)
+          .method("HEAD", HttpRequest.BodyPublishers.noBody())
+          .timeout(Duration.ofSeconds(5))
+          .build();
 
-      int responseCode = res.statusCode();
+      HttpResponse<?> response = client.send(
+          request,
+          HttpResponse.BodyHandlers.ofString());
+
+      int responseCode = response.statusCode();
+
       if (responseCode != HttpURLConnection.HTTP_OK) {
-        throw new RuntimeException("Failed to fetch file headers: HTTP " + responseCode);
+        throw new RuntimeException(
+            "Failed to fetch file headers: HTTP " + responseCode);
       }
 
-      Optional<String> contentType = res.headers().firstValue("content-type");
-      if (contentType.isEmpty()) {
-        return "";
+      Optional<String> contentType = response.headers().firstValue("content-type");
+
+      if (contentType.isPresent()) {
+        String type = contentType.get().toLowerCase();
+
+        if (type.startsWith("application/zip")) {
+          return ".zip";
+        }
+
+        if (type.startsWith("application/java-archive")) {
+          return ".jar";
+        }
       }
-      return switch (contentType.get()) {
-        case "application/zip" -> ".zip";
-        case "application/java-archive" -> ".jar";
-        default -> "";
-      };
+
+      Optional<String> contentDisposition = response.headers().firstValue("content-disposition");
+
+      if (contentDisposition.isPresent()) {
+        String disposition = contentDisposition.get().toLowerCase();
+
+        if (disposition.contains(".zip")) {
+          return ".zip";
+        }
+
+        if (disposition.contains(".jar")) {
+          return ".jar";
+        }
+      }
+
+      String path = uri.getPath().toLowerCase();
+
+      if (path.endsWith(".zip")) {
+        return ".zip";
+      }
+
+      if (path.endsWith(".jar")) {
+        return ".jar";
+      }
+
+      return "";
+
     } catch (Exception e) {
-      throw new RuntimeException("Failed to perform HEAD request of URL " + uri, e);
+      throw new RuntimeException(
+          "Failed to perform HEAD request of URL " + uri,
+          e);
     }
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/plugin/PluginBasedCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/plugin/PluginBasedCommandlet.java
@@ -24,6 +24,7 @@ import com.devonfw.tools.ide.step.Step;
 import com.devonfw.tools.ide.tool.LocalToolCommandlet;
 import com.devonfw.tools.ide.tool.ToolInstallRequest;
 import com.devonfw.tools.ide.tool.ide.IdeToolCommandlet;
+import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
  * Base class for {@link LocalToolCommandlet}s that support plugins. It can automatically install configured plugins for the tool managed by this commandlet.
@@ -114,21 +115,50 @@ public abstract class PluginBasedCommandlet extends LocalToolCommandlet {
    */
   public Path getPluginsInstallationPath() {
 
-    return this.context.getPluginsPath().resolve(this.tool);
+    VersionIdentifier version = getInstalledVersion();
+    if (version == null) {
+      return this.context.getPluginsPath().resolve(this.tool);
+    }
+    return getPluginsInstallationPath(version);
+  }
+
+  public Path getPluginsInstallationPath(VersionIdentifier version) {
+
+    if (version == null) {
+      return this.context.getPluginsPath().resolve(this.tool);
+    }
+
+    return this.context.getPluginsPath()
+        .resolve(this.tool)
+        .resolve(version.toString());
   }
 
   @Override
   protected void postInstall(ToolInstallRequest request) {
 
     super.postInstall(request);
-    Path pluginsInstallationPath = getPluginsInstallationPath();
+
+    VersionIdentifier version = null;
+    if (request.getRequested() != null) {
+      version = request.getRequested().getResolvedVersion();
+    }
+    if (version == null) {
+      version = getInstalledVersion();
+    }
+
+    Path pluginsInstallationPath = getPluginsInstallationPath(version);
 
     if (!request.isAlreadyInstalled() || this.forcePluginReinstall.isTrue()) {
-      LOG.info("Resetting all installed plugins...");
-      deleteAllPlugins(pluginsInstallationPath);
+      LOG.info("Resetting installed plugins for the current IDE version...");
+      deleteAllPlugins(pluginsInstallationPath, version);
     }
+
     this.context.getFileAccess().mkdirs(pluginsInstallationPath);
     installPlugins(request.getProcessContext());
+
+    if (version != null) {
+      cleanupOldPluginVersions(version);
+    }
   }
 
   /**
@@ -136,17 +166,12 @@ public abstract class PluginBasedCommandlet extends LocalToolCommandlet {
    *
    * @param pluginsInstallationPath the {@link Path} to the plugins installation folder.
    */
-  private void deleteAllPlugins(Path pluginsInstallationPath) {
+  private void deleteAllPlugins(Path pluginsInstallationPath, VersionIdentifier version) {
 
     FileAccess fileAccess = this.context.getFileAccess();
     fileAccess.delete(pluginsInstallationPath);
-    List<Path> markerFiles = fileAccess.listChildren(this.context.getIdeHome().resolve(IdeContext.FOLDER_DOT_IDE), Files::isRegularFile);
-    for (Path path : markerFiles) {
-      if (path.getFileName().toString().startsWith("plugin." + getName())) {
-        fileAccess.delete(path);
-        LOG.debug("Plugin marker file {} got deleted.", path);
-      }
-    }
+
+    deletePluginMarkerFiles(version == null ? null : version.toString());
   }
 
   private void installPlugins(ProcessContext pc) {
@@ -242,7 +267,17 @@ public abstract class PluginBasedCommandlet extends LocalToolCommandlet {
    */
   public Path retrievePluginMarkerFilePath(ToolPluginDescriptor plugin) {
     if (this.context.getIdeHome() != null) {
-      String markerFileName = "plugin" + "." + getName() + "." + getInstalledEdition() + "." + plugin.name();
+      String markerFileName = "plugin"
+          + "." + getName()
+          + "." + getInstalledEdition();
+
+      String ideVersion = getPluginMarkerVersionSegment();
+      if (ideVersion != null) {
+        markerFileName = markerFileName + "." + ideVersion;
+      }
+
+      markerFileName = markerFileName + "." + plugin.name();
+
       String version = plugin.version();
       if ((version != null) && !version.isBlank()) {
         markerFileName = markerFileName + ".version-" + normalizeMarkerFileSegment(version);
@@ -274,12 +309,24 @@ public abstract class PluginBasedCommandlet extends LocalToolCommandlet {
 
   private void deleteExistingPluginMarkerFiles(FileAccess fileAccess, ToolPluginDescriptor plugin, Path currentMarkerFilePath) {
 
-    String markerFilePrefix = "plugin" + "." + getName() + "." + getInstalledEdition() + "." + plugin.name();
+    String markerFilePrefix = "plugin"
+        + "." + getName()
+        + "." + getInstalledEdition();
+
+    String ideVersion = getPluginMarkerVersionSegment();
+    if (ideVersion != null) {
+      markerFilePrefix = markerFilePrefix + "." + ideVersion;
+    }
+
+    markerFilePrefix = markerFilePrefix + "." + plugin.name();
+    String finalMarkerFilePrefix = markerFilePrefix;
+
     List<Path> markerFiles = fileAccess.listChildren(currentMarkerFilePath.getParent(),
         p -> {
           String fileName = p.getFileName().toString();
-          return Files.isRegularFile(p) && (fileName.equals(markerFilePrefix) || fileName.startsWith(markerFilePrefix + ".version-"));
+          return Files.isRegularFile(p) && (fileName.equals(finalMarkerFilePrefix) || fileName.startsWith(finalMarkerFilePrefix + ".version-"));
         });
+
     for (Path markerFile : markerFiles) {
       if (!markerFile.equals(currentMarkerFilePath)) {
         fileAccess.delete(markerFile);
@@ -363,5 +410,79 @@ public abstract class PluginBasedCommandlet extends LocalToolCommandlet {
   protected void handleInstallForInactivePlugin(ToolPluginDescriptor plugin) {
 
     LOG.debug("Omitting installation of inactive plugin {} ({}).", plugin.name(), plugin.id());
+  }
+
+  private void cleanupOldPluginVersions(VersionIdentifier currentVersion) {
+
+    Path toolPluginsPath = this.context.getPluginsPath().resolve(this.tool);
+    FileAccess fileAccess = this.context.getFileAccess();
+
+    if (!Files.isDirectory(toolPluginsPath)) {
+      return;
+    }
+
+    List<Path> versionDirectories = fileAccess.listChildren(toolPluginsPath, Files::isDirectory);
+
+    for (Path versionDirectory : versionDirectories) {
+      String version = versionDirectory.getFileName().toString();
+
+      if (version.equals(currentVersion.toString())) {
+        continue;
+      }
+
+      try {
+        fileAccess.delete(versionDirectory);
+        deletePluginMarkerFiles(version);
+        LOG.debug("Deleted obsolete plugin directory {}.", versionDirectory);
+      } catch (RuntimeException _) {
+        LOG.warn("Could not delete obsolete plugin directory {}. It may still be in use and will be cleaned up later.",
+            versionDirectory);
+      }
+    }
+  }
+
+  private String getPluginMarkerVersionSegment() {
+
+    VersionIdentifier ideVersion = getInstalledVersion();
+    if (ideVersion == null) {
+      return null;
+    }
+    return normalizeMarkerFileSegment(ideVersion.toString());
+  }
+
+  /**
+   * Deletes plugin marker files belonging to the specified IDE version.
+   *
+   * @param version the IDE version whose plugin marker files shall be deleted, or {@code null} to delete all plugin marker files for this tool.
+   */
+  private void deletePluginMarkerFiles(String version) {
+
+    FileAccess fileAccess = this.context.getFileAccess();
+
+    List<Path> markerFiles = fileAccess.listChildren(
+        this.context.getIdeHome().resolve(IdeContext.FOLDER_DOT_IDE),
+        Files::isRegularFile);
+
+    String markerPrefix = "plugin." + getName() + ".";
+    String versionSegment = null;
+
+    if (version != null) {
+      versionSegment = "." + normalizeMarkerFileSegment(version) + ".";
+    }
+
+    for (Path markerFile : markerFiles) {
+      String fileName = markerFile.getFileName().toString();
+
+      boolean matches = fileName.startsWith(markerPrefix);
+
+      if (versionSegment != null) {
+        matches = matches && fileName.contains(versionSegment);
+      }
+
+      if (matches) {
+        fileAccess.delete(markerFile);
+        LOG.debug("Plugin marker file {} got deleted.", markerFile);
+      }
+    }
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/vscode/Vscode.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/vscode/Vscode.java
@@ -89,8 +89,10 @@ public class Vscode extends IdeToolCommandlet {
     Path vsCodeConf = this.context.getWorkspacePath().resolve(".vscode/.userdata");
     pc.addArg("--new-window");
     pc.addArg("--user-data-dir=" + vsCodeConf);
-    Path vsCodeExtensionFolder = this.context.getIdeHome().resolve("plugins/vscode");
+
+    Path vsCodeExtensionFolder = getPluginsInstallationPath();
     pc.addArg("--extensions-dir=" + vsCodeExtensionFolder);
+
     pc.addArg(this.context.getWorkspacePath());
     super.configureToolArgs(pc, processMode, args);
   }

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/androidstudio/AndroidStudioTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/androidstudio/AndroidStudioTest.java
@@ -100,24 +100,39 @@ class AndroidStudioTest extends AbstractIdeContextTest {
     androidStudio.run();
 
     // assert
+    String expectedPluginsPath = androidStudio.getPluginsInstallationPath()
+        .toAbsolutePath()
+        .toString();
+
     assertThat(context.getWorkspacePath().resolve(".studio.vmoptions"))
         .exists()
         .hasContent("""
-            -Xms256m
-            -Xmx4096m
-            -XX:ReservedCodeCacheSize=256m
-            -ea
-            -Dsun.io.useCanonCaches=true
-            """);
+          -Xms256m
+          -Xmx4096m
+          -XX:ReservedCodeCacheSize=256m
+          -ea
+          -Dsun.io.useCanonCaches=true
+          """ + "-Didea.plugins.path=" + expectedPluginsPath + System.lineSeparator());
   }
 
   private void checkInstallation(IdeTestContext context) {
     // commandlet - android-studio
     AndroidStudio commandlet = context.getCommandletManager().getCommandlet(AndroidStudio.class);
     assertThat(commandlet.getInstalledVersion().toString()).isEqualTo("2024.1.1.1");
-    assertThat(context).log().hasEntries(new IdeLogEntry(IdeLogLevel.SUCCESS, "Successfully ended step 'Install plugin MockedPlugin (1/1)'.", true), //
-        new IdeLogEntry(IdeLogLevel.SUCCESS, "Successfully installed android-studio in version 2024.1.1.1", true));
-    assertThat(context.getPluginsPath().resolve("android-studio").resolve("mockedPlugin").resolve("dev").resolve("MockedClass.class")).exists();
+    assertThat(context).log().hasEntries(
+        new IdeLogEntry(
+            IdeLogLevel.SUCCESS,
+            "Successfully ended step 'Install plugin MockedPlugin (1/1)'.",
+            true),
+        new IdeLogEntry(
+            IdeLogLevel.SUCCESS,
+            "Successfully installed android-studio in version 2024.1.1.1",
+            true));
+    assertThat(commandlet.getPluginsInstallationPath()
+        .resolve("mockedPlugin")
+        .resolve("dev")
+        .resolve("MockedClass.class"))
+        .exists();
   }
 
   private void setupMockedPlugin(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/eclipse/EclipseTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/eclipse/EclipseTest.java
@@ -45,6 +45,9 @@ public class EclipseTest extends AbstractIdeContextTest {
     eclipse.run();
 
     // assert
+    Path configurationPath = eclipse.getPluginsInstallationPath()
+        .resolve("configuration");
+
     assertThat(eclipse.getInstalledVersion().toString()).isEqualTo("2024-09");
     assertThat(context).log().hasEntries(
         new IdeLogEntry(IdeLogLevel.SUCCESS, "Successfully installed java in version 17.0.10_7", true),
@@ -52,8 +55,10 @@ public class EclipseTest extends AbstractIdeContextTest {
     assertThat(context).logAtSuccess().hasMessage("Successfully ended step 'Install plugin anyedit (1/1)'.");
     assertThat(context.getPluginsPath().resolve("eclipse")).isDirectory();
     assertThat(eclipse.getToolBinPath().resolve("eclipsetest")).hasContent(
-        "eclipse " + os + " -data " + context.getWorkspacePath() + " -keyring " + context.getUserHome().resolve(".eclipse").resolve(".keyring")
-            + " -configuration " + context.getPluginsPath().resolve("eclipse").resolve("configuration")
+        "eclipse " + os
+            + " -data " + context.getWorkspacePath()
+            + " -keyring " + context.getUserHome().resolve(".eclipse").resolve(".keyring")
+            + " -configuration " + configurationPath
             + " gui -showlocation eclipseproject -nosplash");
 
     //if tool already installed
@@ -87,7 +92,7 @@ public class EclipseTest extends AbstractIdeContextTest {
     Path buildFile = context.getIdeInstallationPath().resolve(IdeContext.FOLDER_INTERNAL).resolve("eclipse-import.xml");
     assertThat(eclipse.getToolBinPath().resolve("eclipsetest")).hasContent(
         "eclipse linux -data " + context.getWorkspacePath() + " -keyring " + context.getUserHome().resolve(".eclipse").resolve(".keyring")
-            + " -configuration " + context.getPluginsPath().resolve("eclipse").resolve("configuration")
+            + " -configuration " + eclipse.getPluginsInstallationPath().resolve("configuration")
             + " -consoleLog -nosplash -application org.eclipse.ant.core.antRunner -buildfile " + buildFile + " -DrepositoryImportPath=" + repositoryPath
             + " -DrepositoryImportWorkingSet=");
   }

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IdeaPluginDownloaderTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IdeaPluginDownloaderTest.java
@@ -1,0 +1,83 @@
+package com.devonfw.tools.ide.tool.intellij;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.devonfw.tools.ide.context.AbstractIdeContextTest;
+import com.devonfw.tools.ide.context.IdeTestContext;
+import com.devonfw.tools.ide.io.FileAccess;
+import com.devonfw.tools.ide.tool.ide.IdeaPluginDownloader;
+import com.devonfw.tools.ide.tool.plugin.ToolPluginDescriptor;
+
+/**
+ * Test of {@link IdeaPluginDownloader}.
+ */
+class IdeaPluginDownloaderTest extends AbstractIdeContextTest {
+
+  /**
+   * Verifies that a ZIP plugin whose archive root folder differs from its plugin ID is installed under the plugin ID and can therefore be uninstalled.
+   *
+   * @param tempDir temporary directory used to create the plugin archive.
+   * @throws IOException if creating or extracting the test archive fails.
+   */
+  @Test
+  void testZipPluginWithDifferentArchiveRootCanBeUninstalled(@TempDir Path tempDir) throws IOException {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    Intellij commandlet = new Intellij(context);
+    IdeaPluginDownloader downloader = new IdeaPluginDownloader(context, commandlet);
+    FileAccess fileAccess = context.getFileAccess();
+
+    String pluginId = "test.plugin.id";
+    String archiveRoot = "different-folder-name";
+
+    ToolPluginDescriptor plugin = new ToolPluginDescriptor(
+        pluginId,
+        "test-plugin",
+        null,
+        null,
+        true,
+        Set.of(),
+        Set.of());
+
+    Path pluginArchive = tempDir.resolve("plugin.zip");
+
+    try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(pluginArchive))) {
+      zip.putNextEntry(new ZipEntry(archiveRoot + "/"));
+      zip.closeEntry();
+
+      zip.putNextEntry(new ZipEntry(archiveRoot + "/lib/"));
+      zip.closeEntry();
+
+      zip.putNextEntry(new ZipEntry(archiveRoot + "/lib/plugin.jar"));
+      zip.write(new byte[] { 0 });
+      zip.closeEntry();
+    }
+
+    Path installationPath = commandlet.getPluginsInstallationPath();
+    fileAccess.mkdirs(installationPath);
+
+    // act
+    downloader.extractDownloadedPlugin(fileAccess, pluginArchive, pluginId, installationPath);
+
+    // assert
+    Path installedPluginPath = installationPath.resolve(pluginId);
+    assertThat(installedPluginPath).isDirectory();
+    assertThat(installedPluginPath.resolve("lib").resolve("plugin.jar")).exists();
+    assertThat(installationPath.resolve(archiveRoot)).doesNotExist();
+
+    // act
+    commandlet.uninstallPlugin(plugin);
+
+    // assert
+    assertThat(installedPluginPath).doesNotExist();
+  }
+}

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/intellij/IntellijTest.java
@@ -148,7 +148,8 @@ class IntellijTest extends AbstractIdeContextTest {
     commandlet.run();
 
     // assert
-    assertThat(commandlet.retrievePluginMarkerFilePath(commandlet.getPlugin("ActivePlugin"))).exists();
+    Path oldMarkerFile = commandlet.retrievePluginMarkerFilePath(commandlet.getPlugin("ActivePlugin"));
+    assertThat(oldMarkerFile).exists();
 
     // act
     commandlet.setEdition("ultimate");
@@ -156,7 +157,7 @@ class IntellijTest extends AbstractIdeContextTest {
 
     // assert
     assertThat(context).logAtDebug()
-        .hasEntries("Plugin marker file " + context.getIdeHome().resolve(".ide").resolve("plugin.intellij.intellij.ActivePlugin") + " got deleted.");
+        .hasEntries("Plugin marker file " + oldMarkerFile  + " got deleted.");
     assertThat(commandlet.retrievePluginMarkerFilePath(commandlet.getPlugin("ActivePlugin"))).exists();
   }
 
@@ -272,15 +273,21 @@ class IntellijTest extends AbstractIdeContextTest {
     intellij.run();
 
     // assert
+    String expectedPluginsPath = context.getPluginsPath()
+        .resolve("intellij")
+        .resolve("2023.3.3")
+        .toAbsolutePath()
+        .toString();
+
     assertThat(context.getWorkspacePath().resolve(".idea.vmoptions"))
         .exists()
         .hasContent("""
-            -Xms256m
-            -Xmx4096m
-            -XX:ReservedCodeCacheSize=256m
-            -ea
-            -Dsun.io.useCanonCaches=true
-            """);
+        -Xms256m
+        -Xmx4096m
+        -XX:ReservedCodeCacheSize=256m
+        -ea
+        -Dsun.io.useCanonCaches=true
+        """ + "-Didea.plugins.path=" + expectedPluginsPath + System.lineSeparator());
   }
 
   /**

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/pycharm/PycharmTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/pycharm/PycharmTest.java
@@ -1,5 +1,7 @@
 package com.devonfw.tools.ide.tool.pycharm;
 
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -140,7 +142,8 @@ class PycharmTest extends AbstractIdeContextTest {
     commandlet.run();
 
     // assert
-    assertThat(commandlet.retrievePluginMarkerFilePath(commandlet.getPlugin("ActivePlugin"))).exists();
+    Path oldMarkerFile = commandlet.retrievePluginMarkerFilePath(commandlet.getPlugin("ActivePlugin"));
+    assertThat(oldMarkerFile).exists();
 
     // act
     commandlet.setEdition("professional");
@@ -148,7 +151,7 @@ class PycharmTest extends AbstractIdeContextTest {
 
     // assert
     assertThat(context).logAtDebug()
-        .hasEntries("Plugin marker file " + context.getIdeHome().resolve(".ide").resolve("plugin.pycharm.pycharm.ActivePlugin") + " got deleted.");
+        .hasEntries("Plugin marker file " + oldMarkerFile + " got deleted.");
     assertThat(commandlet.retrievePluginMarkerFilePath(commandlet.getPlugin("ActivePlugin"))).exists();
   }
 
@@ -167,15 +170,19 @@ class PycharmTest extends AbstractIdeContextTest {
     pycharm.run();
 
     // assert
+    String expectedPluginsPath = pycharm.getPluginsInstallationPath()
+        .toAbsolutePath()
+        .toString();
+
     assertThat(context.getWorkspacePath().resolve(".pycharm.vmoptions"))
         .exists()
         .hasContent("""
-            -Xms256m
-            -Xmx4096m
-            -XX:ReservedCodeCacheSize=256m
-            -ea
-            -Dsun.io.useCanonCaches=true
-            """);
+          -Xms256m
+          -Xmx4096m
+          -XX:ReservedCodeCacheSize=256m
+          -ea
+          -Dsun.io.useCanonCaches=true
+          """ + "-Didea.plugins.path=" + expectedPluginsPath + System.lineSeparator());
   }
 
   private void checkInstallation(IdeTestContext context) {


### PR DESCRIPTION
### This PR fixes #1548 

### Implemented changes:

This PR changes plugin handling so that IDE updates on Windows no longer fail when the currently running IDE keeps files from an old plugin installation locked.

Previously, plugins were installed into one shared directory per IDE, for example:
`plugins/intellij/`

During an IntelliJ update, IDEasy reset this directory before installing plugins for the new IDE version. On Windows, this could fail when the currently running IntelliJ instance still had plugin files open, for example native files belonging to plugins such as GitHub Copilot.

Plugins are now stored per IDE version:
```
plugins/intellij/
├── 2026.1.4/
└── 2026.2/
```

This allows the new IDE version and its plugins to be installed independently from the plugin directory still used by the running old IDE.

#### Plugin directory handling

`PluginBasedCommandlet ` now resolves the plugin installation path using the installed IDE version: `plugins/<tool>/<version>`

For example:
```
plugins/intellij/2026.2
plugins/pycharm/2026.2
plugins/android-studio/2024.1.1.1
plugins/eclipse/2024-09
```

Plugin marker files also contain the IDE version so plugin state is tracked independently for each installed IDE version. After plugins for the new IDE version have been installed, IDEasy tries to remove obsolete version directories (this cleanup is best-effort only).

If Windows prevents deletion because the old IDE still holds files open, IDEasy logs a warning such as:
```
Could not delete obsolete plugin directory ...\plugins\intellij\2026.1.4.
It may still be in use and will be cleaned up later.
```
The IDE update itself continues successfully. Once the old IDE is closed, a later `install/update` can remove the obsolete plugin directory.

#### JetBrains IDE plugin loading:

IntelliJ-based IDEs are configured to use the version-specific plugin path through:
`-Didea.plugins.path=<IDE_HOME>/plugins/<tool>/<version>`

The generated VM options therefore point each IDE version to its corresponding plugin directory. Example:
`-Didea.plugins.path=C:\Users\...\IDEasy\plugins\intellij\2026.2`

This applies to IntelliJ IDEA, PyCharm and Android Studio.

#### JetBrains Marketplace plugin installation:

Marketplace plugins are now downloaded directly instead of invoking the IDE's installPlugins command.

This is important because invoking IntelliJ while another IntelliJ instance is already running can fail with the single-instance restriction and therefore still prevent plugin installation during an IDE update.

Plugin archives are installed according to their archive type:

ZIP plugins are extracted directly into the version-specific plugin directory so their own directory structure is preserved. For example a Marketplace archive containing:
```
plantuml4idea/
└── lib/
    └── ...
```
becomes:
```
plugins/intellij/2026.2/
└── plantuml4idea/
    └── lib/
        └── ...
```

JAR plugins are extracted into a directory named after the plugin ID. This distinction is necessary because standalone plugin JARs do not necessarily contain their own surrounding plugin directory. Custom plugin repository URLs continue to use the existing IDE command-based installation mechanism.

#### Other IDEs:

VS Code now also uses the version-specific plugin directory through its `--extensions-dir` argument.

Eclipse configuration paths are based on the version-specific plugin installation directory, for example:
`plugins/eclipse/2024-09/configuration`

Tests were updated accordingly.

---

### Testing instructions

Please add concise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

The issue was reproduced using IntelliJ IDEA on Windows.

1. Configure an older IntelliJ version, for example: `INTELLIJ_VERSION=2026.1.4`

2. Install IntelliJ: `ide install intellij`

3. Verify that the configured plugin is installed under the version-specific directory: `ls -la "$IDE_HOME/plugins/intellij"`

Expected: `2026.1.4`

4. Start IntelliJ: `ide intellij`

5. Keep the old IntelliJ instance running.

6. Change the configured IntelliJ version to a newer supported version, for example: `INTELLIJ_VERSION=2026.2`

7. While the old IntelliJ instance is still running, execute: `ide update`

8. Verify that:
> IntelliJ 2026.2 is installed successfully.
> Plugins for 2026.2 are installed into: `plugins/intellij/2026.2`
> the running IntelliJ instance may keep the old plugin directory locked;
> IDEasy only logs a warning when deletion of the old directory fails;
> the overall ide update still completes successfully.

Example warning:
```
Could not delete obsolete plugin directory ...\plugins\intellij\2026.1.4.
It may still be in use and will be cleaned up later.
```

9. Close the old IntelliJ instance and start the new one: `ide intellij`

10. Verify:
> `Help -> About` shows the new IntelliJ version.
> the configured plugin is available under `Settings -> Plugins -> Installed.`
> the generated VM options contain the new version-specific plugin path.

Example:
`-Didea.plugins.path=...\plugins\intellij\2026.2`

11. Close IntelliJ and run another update: `ide update`

12. Verify that the obsolete plugin directory can now be removed and only the current plugin directory remains: `ls -la "$IDE_HOME/plugins/intellij"`

Expected: `2026.2`

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue

