### PR TITLE
#2386: dont wait until release is published, rename release to 2026.09.001

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--Drevision=2026.08.002-SNAPSHOT
+-Drevision=2026.09.001-SNAPSHOT

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,7 +2,7 @@
 
 This file documents all notable changes to https://github.com/devonfw/IDEasy[IDEasy].
 
-== 2026.08.002
+== 2026.09.001
 
 Release with new features and bugfixes:
 

--- a/pom.xml
+++ b/pom.xml
@@ -291,32 +291,6 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>deploy</id>
-      <build>
-        <plugins>
-          <plugin>
-            <!--
-              The plugin itself, its extension and publishingServerId/autoPublish are inherited from
-              the deploy profile of com.devonfw:maven-parent. Only the waiting behaviour is added
-              here: block until the deployment is actually published instead of returning as soon as
-              it is validated. Everything that follows the deployment - the GitHub release notes
-              linking to Maven Central and the Homebrew formula referencing the same artifacts -
-              would otherwise race the publication.
-            -->
-            <groupId>org.sonatype.central</groupId>
-            <artifactId>central-publishing-maven-plugin</artifactId>
-            <configuration>
-              <waitUntil>published</waitUntil>
-              <waitMaxTime>3600</waitMaxTime>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <developers>
     <developer>
       <id>hohwille</id>


### PR DESCRIPTION
### This PR fixes #2386

### Implemented changes:

* remove override of `central-publishing-maven-plugin` adding `waitUntil` and `waitMaxTime` properties.
* rename the release from 2026.08.002 to 2026.09.001 since already on Tuesday we have September

---

### Testing instructions

Please add conscise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. IMHO it is impossible to properly test this in advance - all we can do is merge this and hope that the next Release workflow run will succeed.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"