### PR TITLE
#2271: fix pgadmin installation on linux

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/1135[#1135]: Fix PowerShell env variable initialization on Windows by sourcing functions from the PowerShell profile
 * https://github.com/devonfw/IDEasy/issues/741[#741]: Add a warning message for legacy devonfw-ide settings users
 * https://github.com/devonfw/IDEasy/issues/1933[#1933]: Added a console panel to the GUI
+* https://github.com/devonfw/IDEasy/issues/2271[#2271]: Fix `ide install pgadmin` on Linux
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/49?closed=1[milestone 2026.09.001].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/GlobalToolCommandlet.java
@@ -23,6 +23,7 @@ import com.devonfw.tools.ide.process.ProcessMode;
 import com.devonfw.tools.ide.process.ProcessResult;
 import com.devonfw.tools.ide.step.Step;
 import com.devonfw.tools.ide.tool.repository.ToolRepository;
+import com.devonfw.tools.ide.version.GenericVersionRange;
 import com.devonfw.tools.ide.version.VersionIdentifier;
 
 /**
@@ -134,12 +135,16 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
     VersionIdentifier resolvedVersion = request.getRequested().getResolvedVersion();
     if (this.context.getSystemInfo().isLinux()) {
       // on Linux global tools are typically installed via the package manager of the OS
-      // if a global tool implements getNativePackages() to returns at least one NativePackage, then we will install this way.
+      // if a global tool implements getNativePackages() to return at least one NativePackage, then we will install this way.
       List<PackageManagerCommand> commands = getInstallPackageManagerCommands(resolvedVersion);
       if (!commands.isEmpty()) {
         boolean newInstallation = runWithPackageManager(request.isSilent(), commands, NativePackageAction.INSTALL);
-        Path rootDir = getInstallationPath(getConfiguredEdition(), resolvedVersion);
-        return createToolInstallation(rootDir, resolvedVersion, newInstallation, request.getProcessContext(), request.isAdditionalInstallation());
+
+        VersionIdentifier installedVersion = getInstalledVersion();
+        Path rootDir = getInstallationPath(getConfiguredEdition(), installedVersion);
+
+        return createToolInstallation(rootDir, installedVersion, newInstallation, request.getProcessContext(),
+            request.isAdditionalInstallation());
       }
     }
 
@@ -183,6 +188,20 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
       return new ToolInstallation(null, null, null, resolvedVersion, true, true);
     }
     return createToolInstallation(installationPath, resolvedVersion, true, pc, false);
+  }
+
+  @Override
+  protected VersionIdentifier resolveVersionForInstall(String edition, GenericVersionRange version) {
+
+    if (this.context.getSystemInfo().isLinux() && !getNativePackages().isEmpty()) {
+      if (version instanceof VersionIdentifier versionIdentifier && !versionIdentifier.isPattern()) {
+        return versionIdentifier;
+      }
+
+      return null;
+    }
+
+    return super.resolveVersionForInstall(edition, version);
   }
 
   /**
@@ -308,7 +327,7 @@ public abstract class GlobalToolCommandlet extends ToolCommandlet {
   public void uninstall() {
     if (this.context.getSystemInfo().isWindows()) {
       WindowsHelper.get(this.context).uninstallApplication(getWindowsRegistryAppName());
-    } else if (this.context.getSystemInfo().isLinux()) {
+    } else if (this.context.getSystemInfo().isLinux() && !getNativePackages().isEmpty()) {
       runWithPackageManager(false, getUninstallPackageManagerCommands(), NativePackageAction.UNINSTALL);
     } else {
       LOG.error("Couldn't uninstall {} on this OS. Please uninstall manually.", this.getName());

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/ToolCommandlet.java
@@ -461,6 +461,7 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
       version = request.isIgnoreProject() ? VersionIdentifier.LATEST : getConfiguredVersion();
       requested.setVersion(version);
     }
+
     VersionIdentifier resolvedVersion = requested.getResolvedVersion();
     if (resolvedVersion == null) {
       if (this.context.isSkipUpdatesMode()) {
@@ -473,17 +474,32 @@ public abstract class ToolCommandlet extends Commandlet implements Tags {
         }
       }
       if (resolvedVersion == null) {
-        resolvedVersion = getToolRepository().resolveVersion(this.tool, edition.edition(), version, this);
+        resolvedVersion = resolveVersionForInstall(edition.edition(), version);
       }
-      requested.setResolvedVersion(resolvedVersion);
+
+      if (resolvedVersion != null) {
+        requested.setResolvedVersion(resolvedVersion);
+      }
     }
+  }
+
+  /**
+   * Resolves the requested version for installation.
+   *
+   * @param edition the requested tool edition.
+   * @param version the requested version or version range.
+   * @return the resolved {@link VersionIdentifier} or {@code null} if version resolution is delegated to another installation mechanism.
+   */
+  protected VersionIdentifier resolveVersionForInstall(String edition, GenericVersionRange version) {
+
+    return getToolRepository().resolveVersion(this.tool, edition, version, this);
   }
 
   /**
    * Hook for subclasses to adjust the requested tool edition before the version is finalized.
    *
    * @param requested the requested {@link ToolEditionAndVersion}
-   * @return the given or trgansformed {@link ToolEditionAndVersion}
+   * @return the given or transformed {@link ToolEditionAndVersion}
    */
   protected ToolEditionAndVersion adjustRequestedEdition(ToolEditionAndVersion requested) {
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/GlobalToolCommandletTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/GlobalToolCommandletTest.java
@@ -199,4 +199,43 @@ class GlobalToolCommandletTest extends AbstractIdeContextTest {
         "sudo apt -y autoremove --purge mytool",
         "sudo rm -f /etc/apt/sources.list.d/mytool.list");
   }
+
+  /**
+   * Verifies that an explicitly requested exact version is preserved for a Linux tool installed via a native package manager.
+   */
+  @Test
+  void testResolveVersionForInstallKeepsExactVersionForLinuxNativePackage() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    context.setSystemInfo(SystemInfoMock.LINUX_X64);
+    PackageManagedToolCommandlet commandlet = new PackageManagedToolCommandlet(context);
+    VersionIdentifier version = VersionIdentifier.of("1.2.3");
+
+    // act
+    VersionIdentifier resolvedVersion = commandlet.resolveVersionForInstall("default", version);
+
+    // assert
+    assertThat(resolvedVersion).isEqualTo(version);
+  }
+
+  /**
+   * Verifies that a version pattern is not resolved by IDEasy for a Linux tool installed via a native package manager, so the package manager can determine the
+   * concrete version.
+   */
+  @Test
+  void testResolveVersionForInstallReturnsNullForPatternOnLinuxNativePackage() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_BASIC);
+    context.setSystemInfo(SystemInfoMock.LINUX_X64);
+    PackageManagedToolCommandlet commandlet = new PackageManagedToolCommandlet(context);
+    VersionIdentifier version = VersionIdentifier.of("1.2.*");
+
+    // act
+    VersionIdentifier resolvedVersion = commandlet.resolveVersionForInstall("default", version);
+
+    // assert
+    assertThat(resolvedVersion).isNull();
+  }
 }


### PR DESCRIPTION
### This PR fixes #2271 

### Implemented changes:

* Fixed `ide install pgadmin` on Linux when pgAdmin is installed via native packages.
* Adjusted version resolution so Linux package managers can determine the installed version when no exact version is requested.
* Preserved explicitly requested exact versions.
* Detects and uses the actually installed version after native package installation.
* Native uninstall handling is only used for tools that actually define native packages.

### Testing instructions

Please add concise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. On Linux (e.g. Ubuntu or WSL), make sure pgAdmin is not installed.
2. Build IDEasy locally over ` ./build-local-dev.sh`
3. Run:  `ide install pgadmin`

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"