### PR TITLE
#871: add progress bar to DMG extraction

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@ This file documents all notable changes to https://github.com/devonfw/IDEasy[IDE
 
 Release with new features and bugfixes:
 
+* https://github.com/devonfw/IDEasy/issues/871[#871]: Add a progress bar when copying applications from DMG files
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/50?closed=1[milestone 2026.09.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/io/FileAccessImpl.java
@@ -213,6 +213,18 @@ public class FileAccessImpl extends HttpDownloader implements FileAccess {
     }
   }
 
+  private void copyTreeWithProgressBar(Path source, Path target, FileCopyMode mode) {
+
+    long size = getPathSize(source);
+    try (IdeProgressBar progressBar = this.context.newProgressbarForCopying(size)) {
+      copy(source, target, mode, (copiedSource, copiedTarget, directory) -> {
+        if (!directory) {
+          progressBar.stepBy(getFileSize(copiedSource));
+        }
+      });
+    }
+  }
+
   @Override
   public String download(String url) {
 
@@ -1009,7 +1021,7 @@ public class FileAccessImpl extends HttpDownloader implements FileAccess {
       throw new IllegalStateException("Failed to unpack DMG as no MacOS *.app was found in file " + file);
     }
 
-    copy(appPath, targetDir, FileCopyMode.COPY_TREE_OVERRIDE_TREE);
+    copyTreeWithProgressBar(appPath, targetDir, FileCopyMode.COPY_TREE_OVERRIDE_TREE);
     pc.addArgs("detach", "-force", mountPath);
     pc.run();
   }
@@ -1423,6 +1435,18 @@ public class FileAccessImpl extends HttpDownloader implements FileAccess {
       LOG.warn("Failed to determine size of file {}: {}", file, e.toString(), e);
       return 0;
     }
+  }
+
+  private long getPathSize(Path path) {
+
+    if (!Files.isDirectory(path)) {
+      return getFileSize(path);
+    }
+    long size = 0;
+    for (Path child : listChildren(path, file -> true)) {
+      size += getPathSize(child);
+    }
+    return size;
   }
 
 

--- a/cli/src/test/java/com/devonfw/tools/ide/io/FileAccessImplTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/io/FileAccessImplTest.java
@@ -24,10 +24,13 @@ import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 import com.devonfw.tools.ide.context.AbstractIdeContextTest;
+import com.devonfw.tools.ide.context.IdeContext;
 import com.devonfw.tools.ide.context.IdeTestContext;
 import com.devonfw.tools.ide.os.SystemInfoMock;
+import com.devonfw.tools.ide.process.ProcessContext;
 
 /**
  * Test of {@link FileAccessImpl}.
@@ -797,6 +800,36 @@ class FileAccessImplTest extends AbstractIdeContextTest {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Test of {@link FileAccessImpl#extractDmg(Path, Path)} with a progress bar for copying the mounted app.
+   */
+  @Test
+  void testExtractDmgWithProgressBar(@TempDir Path tempDir) throws IOException {
+
+    // arrange
+    IdeTestContext context = newContext(tempDir);
+    context.setIdeHome(tempDir);
+    context.setSystemInfo(SystemInfoMock.MAC_X64);
+    ProcessContext processContext = Mockito.mock(ProcessContext.class);
+    context.setProcessContext(processContext);
+    Path appPath = context.getIdeHome().resolve(IdeContext.FOLDER_UPDATES).resolve(IdeContext.FOLDER_VOLUME).resolve("MyApp.app");
+    Path sourceFile = appPath.resolve("Contents/Resources/resource.txt");
+    Files.createDirectories(sourceFile.getParent());
+    Files.writeString(sourceFile, "x".repeat(1024));
+    long appSize = Files.size(sourceFile);
+    Path target = tempDir.resolve("target");
+
+    // act
+    context.getFileAccess().extractDmg(tempDir.resolve("MyApp.dmg"), target);
+
+    // assert
+    assertThat(target.resolve(appPath.getFileName()).resolve(appPath.relativize(sourceFile))).hasSameTextualContentAs(sourceFile);
+    IdeProgressBarTestImpl progressBar = context.getProgressBarMap().get(IdeProgressBar.TITLE_COPYING);
+    assertThat(progressBar).isNotNull();
+    assertThat(progressBar.getMaxSize()).isEqualTo(appSize);
+    assertThat(progressBar.getEventList()).extracting(IdeProgressBarTestImpl.ProgressEvent::getStepSize).containsExactly(appSize);
   }
 
   /**


### PR DESCRIPTION
### This PR fixes #871

### Implemented changes:

* added a `Copying` progress bar while IDEasy copies an application from a mounted DMG.
* reused the existing recursive copy logic and update the progress after each copied file. 
* added a focused test for the progress bar and updated the changelog.

---

### Testing instructions

1. On macOS, check out this PR:

   ```shell
   gh pr checkout 2408
2. Run the focused test:
   ```shell
   cd cli
   mvn -Dtest=FileAccessImplTest#testExtractDmgWithProgressBar test
   ```
4. Verify that the test finishes with BUILD SUCCESS.
5. Optionally, run a real DMG installation:
  ```shell
mvn exec:exec -Dexec.executable=java -Dexec.args="-cp %classpath com.devonfw.tools.ide.cli.Ideasy --force install pycharm"
  ```
6. Verify that the Copying progress reaches 100%, the DMG is detached, and the installation completes.

---

### Checklist for this PR

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

