### PR TITLE
#492: Use Maven dependency cache in CI workflows

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '25'
+          cache: 'maven'
       - name: Check formatting (Spotless, changed files only)
         # Ratchets to origin/main, so only files changed by this PR are checked.
         # Fix locally with: mvn spotless:apply

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '25'
+          cache: 'maven'
       - name: Build project with Maven
         run: mvn -B -ntp -Dstyle.color=always install
       - name: Coveralls GitHub Action

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '25'
+          cache: 'maven'
       - name: Run pitest coverage
         run: |
           cd cli

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -136,6 +136,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '25'
+          cache: 'maven'
       - name: Download natives and build project
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
### This PR fixes #492 

### Implemented changes:

Added cache: 'maven' to the setup-java@v5 step in build.yml, build-pr.yml, mutation-test.yml, and the deploy job of nightly-build.yml, so these jobs restore a shared ~/.m2/repository dependency cache instead of re-downloading all Maven dependencies on every run. This matches the convention already used in release.yml, update-cve.yml, and update-urls.yml.
The cache is keyed on the hash of the pom.xml files (handled automatically by setup-java), so it  is reused while dependencies are unchanged and only re-created when they change

---

### Testing instructions

1. Open this PR, expand the CI Build PR run -> Set up JDK step. Look for the cache line. It should be a hit ("Cache restored successfully…") because main's CI has already cached this dependency set (the pom.xml files are unchanged from main). A miss only occurs the first time a new dependency set is ever cached.
2. On Checks , then hover CI Build PR, then Re-run jobs. The re-run (same commit, same pom.xml) should log a hit again, with a minimal Maven download.
3. Confirm the Set up JDK step / total run is noticeably faster than a cold run, most artifacts restored, not re-downloaded.


---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [ ] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [ ] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"
