### PR TITLE
#950: avoid non-interactive GPG handling for Rancher Desktop on SUSE

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/2178[#2178]: Make ReleaseCommandlet independent of specific build commandlet and fix `ide build` using npm instead of yarn
 * https://github.com/devonfw/IDEasy/issues/2142[#2142]: Move IDE-specific metadata (.idea, .vscode) out of workspace
 * https://github.com/devonfw/IDEasy/issues/989[#989]: Allow expressions in template variable definitions
+* https://github.com/devonfw/IDEasy/issues/950[#950]: Avoid non-interactive GPG handling for Rancher Desktop on SUSE
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/50?closed=1[milestone 2026.09.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/NativePackage.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/NativePackage.java
@@ -13,6 +13,7 @@ public class NativePackage {
   private final List<String> extraInstallOptions;
   private final List<String> setupCommands;
   private final List<String> cleanupCommands;
+  private final boolean interactiveInstall;
 
   /**
    * Creates a new {@link NativePackage} with optional fields defaulting to empty lists.
@@ -25,11 +26,29 @@ public class NativePackage {
    */
   public NativePackage(NativePackageManager pm, List<String> packages,
       List<String> extraInstallOptions, List<String> setupCommands, List<String> cleanupCommands) {
+    this(pm, packages, extraInstallOptions, setupCommands, cleanupCommands, false);
+  }
+
+  /**
+   * Creates a new {@link NativePackage}.
+   *
+   * @param pm the specific {@link NativePackageManager}
+   * @param packages the packages that need to be handled.
+   * @param extraInstallOptions extra install options (optional)
+   * @param setupCommands commands to run before install (optional)
+   * @param cleanupCommands commands to run after uninstall (optional)
+   * @param interactiveInstall {@code true} to allow interactive user input during installation, {@code false} otherwise.
+   */
+  public NativePackage(NativePackageManager pm, List<String> packages,
+      List<String> extraInstallOptions, List<String> setupCommands, List<String> cleanupCommands,
+      boolean interactiveInstall) {
+
     this.packageManager = Objects.requireNonNull(pm, "package manager must not be null");
     this.packages = List.copyOf(Objects.requireNonNull(packages, "packages must not be null"));
     this.extraInstallOptions = extraInstallOptions != null ? List.copyOf(extraInstallOptions) : List.of();
     this.setupCommands = setupCommands != null ? List.copyOf(setupCommands) : List.of();
     this.cleanupCommands = cleanupCommands != null ? List.copyOf(cleanupCommands) : List.of();
+    this.interactiveInstall = interactiveInstall;
   }
 
   /**
@@ -108,5 +127,12 @@ public class NativePackage {
    */
   public List<String> getVersionQueryCommand() {
     return this.packageManager.getVersionQueryCommand(this.packages.getFirst());
+  }
+
+  /**
+   * @return {@code true} if this package should be installed interactively, {@code false} otherwise.
+   */
+  public boolean isInteractiveInstall() {
+    return this.interactiveInstall;
   }
 }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/NativePackageManager.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/NativePackageManager.java
@@ -8,27 +8,29 @@ import java.util.List;
  */
 public enum NativePackageManager {
   /** Advanced Package Tool (APT) is the package manager of Debian based Linux distributions. */
-  APT("install -y", "-y autoremove --purge", "=", "*"),
+  APT("install -y", null, "-y autoremove --purge", "=", "*"),
 
   /** Zypper is the package manager of SUSE based Linux distributions. */
-  ZYPPER("--non-interactive install", "remove", "=", ""),
+  ZYPPER("--non-interactive install", "install", "remove", "=", ""),
 
   /** Yellowdog Updater Modified (YUM) is the package manager of RPM package based Linux distributions like Fedora, Red Hat, or CentOS. */
-  YUM("install -y", "remove -y", "-", "*"),
+  YUM("install -y", null, "remove -y", "-", "*"),
 
   /** DaNdiFied yum (DNF) is the package manager of RPM package based Linux distributions like Fedora. It is the successor of {@link #YUM}. */
-  DNF("install -y", "remove -y", "-", "*");
+  DNF("install -y", null, "remove -y", "-", "*");
 
   private static final String DPKG_STATUS_INSTALLED = "installed";
   private static final String SUDO = "sudo";
 
   private final String installCommand;
+  private final String interactiveInstallCommand;
   private final String uninstallCommand;
   private final String versionSeparator;
   private final String versionWildCard;
 
-  NativePackageManager(String installCommand, String uninstallCommand, String versionSeparator, String versionWildCard) {
+  NativePackageManager(String installCommand, String interactiveInstallCommand, String uninstallCommand, String versionSeparator, String versionWildCard) {
     this.installCommand = installCommand;
+    this.interactiveInstallCommand = interactiveInstallCommand;
     this.uninstallCommand = uninstallCommand;
     this.versionSeparator = versionSeparator;
     this.versionWildCard = versionWildCard;
@@ -127,7 +129,13 @@ public enum NativePackageManager {
     for (String option : nativePackage.getExtraInstallOptions()) {
       command.append(' ').append(option);
     }
-    command.append(' ').append(this.installCommand);
+
+    String installCommand = this.installCommand;
+    if (nativePackage.isInteractiveInstall() && this.interactiveInstallCommand != null) {
+      installCommand = this.interactiveInstallCommand;
+    }
+    command.append(' ').append(installCommand);
+
     for (String pkg : nativePackage.getPackages()) {
       command.append(' ').append(getPackageSpec(pkg, version));
     }

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/docker/Docker.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/docker/Docker.java
@@ -72,9 +72,10 @@ public class Docker extends GlobalToolCommandlet {
         new NativePackage(
             NativePackageManager.ZYPPER,
             List.of("rancher-desktop"),
-            List.of("--no-gpg-checks"),
+            List.of(),
             List.of("sudo zypper addrepo https://download.opensuse.org/repositories/isv:/Rancher:/stable/rpm/isv:Rancher:stable.repo"),
-            null
+            null,
+            true
         ),
         new NativePackage(
             NativePackageManager.APT,
@@ -91,7 +92,8 @@ public class Docker extends GlobalToolCommandlet {
             List.of(
                 "sudo rm -f /etc/apt/sources.list.d/isv-rancher-stable.list",
                 "sudo rm -f /usr/share/keyrings/isv-rancher-stable-archive-keyring.gpg"
-            )
+            ),
+            false
         )
     );
   }


### PR DESCRIPTION
### This PR fixes #950 

### Implemented changes:

* Removed --no-gpg-checks from the Rancher Desktop installation on SUSE Linux.
* Added support for interactive native package installation.
* Configured Rancher Desktop to use interactive zypper install so users can explicitly reject, temporarily trust, or permanently trust the repository signing key.
* Kept the existing non-interactive Zypper behavior unchanged for other native packages.

### Testing instructions

Please add concise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. Start a SUSE Linux environment where the Rancher repository signing key is not already trusted.

2. Run: ide install docker

3. Verify that the generated Rancher Desktop installation command does not contain: `--no-gpg-checks` or `--non-interactive`

4. Verify that Zypper asks how the repository signing key should be handled and allows the user to choose between rejecting, temporarily trusting, or permanently trusting the key.

5. Verify that other Zypper-based native package installations remain non-interactive.

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue

