### PR TITLE
#1216: run release tests before deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: ./cli/target/
-      - name: Create assemblies and publish to Apache Maven Central
+      - name: Prepare release version
         run: |
           sed -i "s/${SNAPSHOT_VERSION}/${RELEASE_VERSION}/" .mvn/maven.config
           git config --global user.email ${{ secrets.BUILD_USER_EMAIL }}
@@ -158,12 +158,23 @@ jobs:
           git add -f .mvn/maven.config
           git commit -m "set release version to ${RELEASE_VERSION}"
           git tag -a "release/${RELEASE_VERSION}" -m "tagged version ${RELEASE_VERSION}"
-          export GPG_TTY=$TTY
-          mkdir -p ./cli/target/
-          mvn --settings .mvn/settings.xml -B -ntp deploy -Passembly,msi,pkg,deploy -pl -:ide-macos-installer -Dgpg.pin.entry.mode=loopback -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
         env:
           RELEASE_VERSION: ${{ needs.resolve-version.outputs.release_version }}
           SNAPSHOT_VERSION: ${{ needs.resolve-version.outputs.snapshot_version }}
+      - name: Build and test release
+        run: |
+          mvn --settings .mvn/settings.xml -B -ntp install \
+            -pl -:ide-macos-installer
+      - name: Publish to Apache Maven Central
+        run: |
+          export GPG_TTY=$TTY
+          mvn --settings .mvn/settings.xml -B -ntp deploy \
+            -Passembly,msi,pkg,deploy \
+            -pl -:ide-macos-installer \
+            -DskipTests \
+            -Dgpg.pin.entry.mode=loopback \
+            -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+        env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/2142[#2142]: Move IDE-specific metadata (.idea, .vscode) out of workspace
 * https://github.com/devonfw/IDEasy/issues/989[#989]: Allow expressions in template variable definitions
 * https://github.com/devonfw/IDEasy/issues/1628[#1628]: Support for OS-specific CVEs
+* https://github.com/devonfw/IDEasy/issues/1216[#1216]: Improved the release workflow to run the full build and tests before deploying artifacts
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/50?closed=1[milestone 2026.09.002].
 


### PR DESCRIPTION
### This PR fixes #1216 

### Implemented changes:

* Split the release Maven execution into separate build/test and deploy steps.
* The release is now built and tested first using `mvn install`.
* Deployment to Maven Central only starts if the build and all tests succeed.
* The deploy step uses `-DskipTests` to avoid running the test suite a second time.
* Improved separation of release logs between build/test and deployment.

---

### Testing instructions

Please add concise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. Run the release build locally without deployment:
   `mvn --settings .mvn/settings.xml -B -ntp install -pl "-:ide-macos-installer"`

2. Verify that the full build and test suite completes successfully.

3. Verify that the release workflow contains two separate Maven steps:
   - `mvn install` for build and tests
   - `mvn deploy -DskipTests` for publishing

4. Verify that the deploy step is only reached if the previous build/test step succeeds.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue

