### PR TITLE
#2236: preserve working directory when launching VS Code

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ Release with new features and bugfixes:
 * https://github.com/devonfw/IDEasy/issues/2142[#2142]: Move IDE-specific metadata (.idea, .vscode) out of workspace
 * https://github.com/devonfw/IDEasy/issues/989[#989]: Allow expressions in template variable definitions
 * https://github.com/devonfw/IDEasy/issues/1628[#1628]: Support for OS-specific CVEs
+* https://github.com/devonfw/IDEasy/issues/2236[#2236]: Preserve the current working directory when launching VS Code via `ide vscode`
 
 The full list of changes for this release can be found in https://github.com/devonfw/IDEasy/milestone/50?closed=1[milestone 2026.09.002].
 

--- a/cli/src/main/java/com/devonfw/tools/ide/tool/vscode/Vscode.java
+++ b/cli/src/main/java/com/devonfw/tools/ide/tool/vscode/Vscode.java
@@ -89,9 +89,14 @@ public class Vscode extends IdeToolCommandlet {
     Path vsCodeConf = getIdeMetadataPath().resolve("config");
     pc.addArg("--new-window");
     pc.addArg("--user-data-dir=" + vsCodeConf);
+
     Path vsCodeExtensionFolder = this.context.getIdeHome().resolve("plugins/vscode");
     pc.addArg("--extensions-dir=" + vsCodeExtensionFolder);
-    pc.addArg(this.context.getWorkspacePath());
+
+    Path workspacePath = this.context.getWorkspacePath();
+    Path cwd = this.context.getCwd();
+    pc.addArg(cwd.startsWith(workspacePath) ? cwd : workspacePath);
+
     super.configureToolArgs(pc, processMode, args);
   }
 

--- a/cli/src/test/java/com/devonfw/tools/ide/tool/vscode/VscodeTest.java
+++ b/cli/src/test/java/com/devonfw/tools/ide/tool/vscode/VscodeTest.java
@@ -269,6 +269,46 @@ class VscodeTest extends AbstractIdeContextTest {
   }
 
   /**
+   * Tests that VS Code is launched with the current working directory when it is located inside the workspace.
+   */
+  @Test
+  void testConfigureToolArgsUsesCwdInsideWorkspace() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_VSCODE);
+    Path cwd = context.getWorkspacePath().resolve("IDEasy").resolve("cli");
+    context.setCwd(cwd, context.getWorkspaceName(), context.getIdeHome());
+    Vscode commandlet = new Vscode(context);
+    ArgCapturingProcessContext pc = new ArgCapturingProcessContext(context);
+
+    // act
+    commandlet.configureToolArgs(pc, ProcessMode.DEFAULT, List.of());
+
+    // assert
+    assertThat(pc.capturedArgs).contains(cwd.toString());
+  }
+
+  /**
+   * Tests that VS Code falls back to the workspace path when launched from outside the workspace.
+   */
+  @Test
+  void testConfigureToolArgsFallsBackToWorkspaceOutsideWorkspace() {
+
+    // arrange
+    IdeTestContext context = newContext(PROJECT_VSCODE);
+    Path cwd = context.getIdeHome().getParent().resolve("outside-workspace");
+    context.setCwd(cwd, context.getWorkspaceName(), context.getIdeHome());
+    Vscode commandlet = new Vscode(context);
+    ArgCapturingProcessContext pc = new ArgCapturingProcessContext(context);
+
+    // act
+    commandlet.configureToolArgs(pc, ProcessMode.DEFAULT, List.of());
+
+    // assert
+    assertThat(pc.capturedArgs).contains(context.getWorkspacePath().toString());
+  }
+
+  /**
    * Test double for {@link Vscode} that captures CLI arguments passed to {@link #runTool(ProcessContext, ProcessMode, List)} so tests can assert command
    * construction without spawning an external process.
    */


### PR DESCRIPTION
### This PR fixes #2236 

### Implemented changes:

* Changed the VS Code launch path to use the current working directory instead of the IDEasy workspace root.
* This preserves the directory from which `ide vscode` was invoked.
* Newly opened VS Code integrated terminals now start in the same directory.
* Existing workspace configuration and VS Code metadata handling remain unchanged.

---

### Testing instructions

Please add conscise, understandable instructions on how a reviewer can test/verify the functionality of your contribution here:

1. Build the native CLI:  `mvn -B -ntp -pl cli -am -Pnative package -DskipTests`

2. From Git Bash, navigate to a subdirectory, e.g.: `cd ~/Projects/IDEasy/workspaces/main/IDEasy/cli`

3. Launch the freshly built IDEasy executable: `./target/ideasy.exe vscode`

4. Verify that VS Code opens the current directory.

5. Open a new integrated terminal in VS Code and run: `pwd`

6. Verify that the terminal starts in the same directory from which `ide vscode` was launched.

---

### Checklist for this PR

Make sure everything is checked before merging this PR. For further info please also see
our [DoD](https://github.com/devonfw/IDEasy/blob/main/documentation/contributing/DoD.adoc).

- [x] When running `mvn clean test` locally all tests pass and build is successful
- [x] PR title is of the form `#«issue-id»: «brief summary»` (e.g. `#921: fixed setup.bat` and not `feature/921 fixed setup.bat`). If no issue ID exists, title only.
- [x] PR top-level comment summaries what has been done and contains link to addressed issue(s)
- [x] PR and issue(s) have suitable labels
- [x] Issue is set to `In Progress` and assigned to you *or* there is no issue (might happen for very small PRs)
- [x] You followed all [coding conventions](https://github.com/devonfw/IDEasy/blob/main/documentation/coding-conventions.adoc)
- [x] You have added the issue implemented by your PR in [CHANGELOG.adoc](https://github.com/devonfw/IDEasy/blob/main/CHANGELOG.adoc) unless issue is labelled
  with `internal`
- [x] You have not changed any dependency in `pom.xml` files or otherwise if runtime dependencies changed, you have updated our [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [x] You have formulated clear instructions on how to test your contribution under "Testing instructions"

### Checklist for tool commandlets

Have you added a new `«tool»` as commandlet? There are the following additional checks:

- [ ] The tool can be installed automatically (during setup via settings) or via the commandlet call
- [ ] The tool is isolated in its IDEasy project, see [Sandbox Principle](https://github.com/devonfw/IDEasy/blob/main/documentation/sandbox.adoc)
- [ ] The new tool is added to the table of tools in [LICENSE.asciidoc](https://github.com/devonfw/IDEasy/blob/main/documentation/LICENSE.adoc)
- [ ] The new commandlet is a [command-wrapper](https://github.com/devonfw/IDEasy/blob/main/documentation/cli.adoc#command-wrapper) for `«tool»`
- [ ] Proper help texts for all supported languages are added [here](https://github.com/devonfw/IDEasy/tree/main/cli/src/main/resources/nls)
- [ ] The new commandlet installs potential dependencies automatically
- [ ] The variables `«TOOL»_VERSION` and `«TOOL»_EDITION` are honored by your commandlet
- [ ] The new commandlet is tested on all platforms it is available for or tested on all platforms that are in scope of the linked issue

